### PR TITLE
Add giftcard to PaymentMethod enum

### DIFF
--- a/Mollie.Api/Models/Payment/PaymentMethod.cs
+++ b/Mollie.Api/Models/Payment/PaymentMethod.cs
@@ -16,6 +16,7 @@ namespace Mollie.Api.Models.Payment {
         [EnumMember(Value = "podiumcadeaukaart")] PodiumCadeaukaart,
         [EnumMember(Value = "paypal")] PayPal,
         [EnumMember(Value = "paysafecard")] PaySafeCard,
-        [EnumMember(Value = "kbc")] Kbc
+        [EnumMember(Value = "kbc")] Kbc,
+        [EnumMember(Value = "giftcard")] GiftCard
     }
 }


### PR DESCRIPTION
See issue logged, we are missing 'giftcard' as payment means.