### PR TITLE
Issuers added

### DIFF
--- a/Mollie.Api/Client/Abstract/IPaymentMethodClient.cs
+++ b/Mollie.Api/Client/Abstract/IPaymentMethodClient.cs
@@ -9,7 +9,8 @@ using Mollie.Api.Models.Url;
 namespace Mollie.Api.Client.Abstract {
     public interface IPaymentMethodClient {
         Task<PaymentMethodResponse> GetPaymentMethodAsync(PaymentMethod paymentMethod, string locale = null);
-        Task<ListResponse<PaymentMethodListData>> GetPaymentMethodListAsync(SequenceType? sequenceType = null, string locale = null, Amount amount = null);
+		Task<PaymentMethodResponse> GetPaymentMethodAsync(PaymentMethod paymentMethod, bool Issuers, string locale = null);
+		Task<ListResponse<PaymentMethodListData>> GetPaymentMethodListAsync(SequenceType? sequenceType = null, string locale = null, Amount amount = null);
         Task<PaymentMethodResponse> GetPaymentMethodAsync(UrlObjectLink<PaymentMethodResponse> url);
     }
 }

--- a/Mollie.Api/Client/PaymentMethodClient.cs
+++ b/Mollie.Api/Client/PaymentMethodClient.cs
@@ -38,5 +38,18 @@ namespace Mollie.Api.Client {
 
             return await this.GetAsync<PaymentMethodResponse>($"methods/{paymentMethod.ToString().ToLower()}{queryString}").ConfigureAwait(false);
         }
-    }
+
+		public async Task<PaymentMethodResponse> GetPaymentMethodAsync(PaymentMethod paymentMethod, bool Issuers, string locale = null)
+		{
+			var parameters = new Dictionary<string, string>();
+			if(Issuers)
+				parameters.Add("include", "issuers");
+			if(locale != null)
+				parameters.Add(nameof(locale), locale);
+			string queryString = parameters.ToQueryString();
+
+			return await this.GetAsync<PaymentMethodResponse>($"methods/{paymentMethod.ToString().ToLower()}{queryString}").ConfigureAwait(false);
+		}
+
+	}
 }

--- a/Mollie.Api/Models/Issuer/IssuerResponse.cs
+++ b/Mollie.Api/Models/Issuer/IssuerResponse.cs
@@ -1,20 +1,25 @@
 ﻿namespace Mollie.Api.Models.Issuer {
-    public class IssuerResponse {
-        /// <summary>
-        ///     The issuer's unique identifier, for example ideal_ABNANL2A. When creating a payment, specify this ID as the issuer
-        ///     parameter to forward
-        ///     the consumer to their banking environment directly.
-        /// </summary>
-        public string Id { get; set; }
+	public class IssuerResponse {
+		/// <summary>
+		/// Contains "issuer"
+		/// </summary>
+		public string Resource { get; set; }
 
-        /// <summary>
-        ///     The issuer's full name, for example 'ABN AMRO'.
-        /// </summary>
-        public string Name { get; set; }
+		/// <summary>
+		///     The issuer's unique identifier, for example ideal_ABNANL2A. When creating a payment, specify this ID as the issuer
+		///     parameter to forward
+		///     the consumer to their banking environment directly.
+		/// </summary>
+		public string Id { get; set; }
 
-        /// <summary>
-        ///     The payment method this issuer belongs to. The Issuers API currently only supports iDEAL.
-        /// </summary>
-        public string Method { get; set; }
-    }
+		/// <summary>
+		///     The issuer's full name, for example 'ABN AMRO'.
+		/// </summary>
+		public string Name { get; set; }
+
+		/// <summary>
+		///     Different Issuer Image icons (iDEAL).
+		/// </summary>
+		public IssuerResponseImage Image { get; set; }
+	}
 }

--- a/Mollie.Api/Models/Issuer/IssuerResponseImage.cs
+++ b/Mollie.Api/Models/Issuer/IssuerResponseImage.cs
@@ -1,0 +1,16 @@
+﻿namespace Mollie.Api.Models.Issuer {
+	/// <summary>
+	/// URLs of images representing the issuer.
+	/// </summary>
+	public class IssuerResponseImage {
+		public string Size1x { get; set; }
+		public string Size2x { get; set; }
+		public string Svg { get; set; }
+
+		public override string ToString()
+		{
+			return this.Size1x;
+		}
+	}
+
+}

--- a/Mollie.Api/Models/PaymentMethod/PaymentMethodResponse.cs
+++ b/Mollie.Api/Models/PaymentMethod/PaymentMethodResponse.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Mollie.Api.Models.PaymentMethod {
     public class PaymentMethodResponse {
@@ -22,10 +23,15 @@ namespace Mollie.Api.Models.PaymentMethod {
         /// </summary>
         public PaymentMethodResponseImage Image { get; set; }
 
-        /// <summary>
-        /// An object with several URL objects relevant to the payment method. Every URL object will contain an href and a type field.
-        /// </summary>
-        [JsonProperty("_links")]
+		/// <summary>
+		///		List of Issuers
+		/// </summary>
+		public List<Issuer.IssuerResponse> Issuers { get; set; }
+
+		/// <summary>
+		/// An object with several URL objects relevant to the payment method. Every URL object will contain an href and a type field.
+		/// </summary>
+		[JsonProperty("_links")]
         public PaymentMethodResponseLinks Links { get; set; }
 
         public override string ToString() {


### PR DESCRIPTION
As of v2 'Issuer API' is removed.
Presented is a first implementation of Issuers.
Usage:

	var IssuersList = new PaymentMethodClient(api_key)
		.GetPaymentMethodAsync(PaymentMethod.Ideal, Issuers: true).Result.Issuers;
