### PR TITLE
Made "Method" in SettlementPeriodRevenue nullable.

### DIFF
--- a/Mollie.Api/Models/Settlement/SettlementPeriodRevenue.cs
+++ b/Mollie.Api/Models/Settlement/SettlementPeriodRevenue.cs
@@ -30,6 +30,6 @@
 		/// <summary>
 		/// The payment method ID, if applicable.
 		/// </summary>
-		public Payment.PaymentMethod Method { get; set; }
+		public Payment.PaymentMethod? Method { get; set; }
 	}
 }


### PR DESCRIPTION
This can be null according to the spec. The spec says "The payment method ID, if applicable.". When it's null it results in an Exception while parsing the response json.