### PR TITLE
extension method to get derived payment statuses

### DIFF
--- a/Mollie.Api/Extensions/PaymentResponseExtensions.cs
+++ b/Mollie.Api/Extensions/PaymentResponseExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Mollie.Api.Models.Payment.Response;
+﻿using Mollie.Api.Models.Payment;
+using Mollie.Api.Models.Payment.Response;
 
 namespace Mollie.Api.Extensions
 {
@@ -14,6 +15,22 @@ namespace Mollie.Api.Extensions
         {
             var chargebacks = paymentResponse?.Links?.Chargebacks;
             return chargebacks != null;
+        }
+
+        public static PaymentStatus StatusExtended(this PaymentResponse paymentResponse)
+        {
+            if (paymentResponse.Status == PaymentStatus.Paid)
+            {
+                if (paymentResponse.IsRefunded())
+                {
+                    return PaymentStatus.Refunded;
+                }
+                if (paymentResponse.IsChargeback())
+                {
+                    return PaymentStatus.Charged_Back;
+                }
+            }
+            return paymentResponse.Status ?? PaymentStatus.Open;
         }
     }
 }

--- a/Mollie.Api/Extensions/PaymentResponseExtensions.cs
+++ b/Mollie.Api/Extensions/PaymentResponseExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Mollie.Api.Extensions
+﻿using Mollie.Api.Models.Payment.Response;
+
+namespace Mollie.Api.Extensions
 {
     public static class PaymentResponseExtensions
     {

--- a/Mollie.Api/Extensions/PaymentResponseExtensions.cs
+++ b/Mollie.Api/Extensions/PaymentResponseExtensions.cs
@@ -1,0 +1,17 @@
+﻿namespace Mollie.Api.Extensions
+{
+    public static class PaymentResponseExtensions
+    {
+        public static bool IsRefunded(this PaymentResponse paymentResponse)
+        {
+            var amountRefunded = paymentResponse?.AmountRefunded?.Value;
+            return !string.IsNullOrEmpty(amountRefunded) && amountRefunded != "0.00";
+        }
+
+        public static bool IsChargeback(this PaymentResponse paymentResponse)
+        {
+            var chargebacks = paymentResponse?.Links?.Chargebacks;
+            return chargebacks != null;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ PaymentResponse result = await paymentClient.CreatePaymentAsync(paymentRequest);
 CustomMetadataClass metadataResponse = result.GetMetadata<CustomMetadataClass>();
 ```
 
-### Retrieving a list off payments
+### Retrieving a list of payments
 Mollie allows you to set offset and count properties so you can paginate the list. The offset and count parameters are optional. The maximum number of payments you can request in a single roundtrip is 250. 
 ```c#
 IPaymentClient paymentClient = new PaymentClient("{yourApiKey}");


### PR DESCRIPTION
I found these methods useful. Maybe someone else will. Or maybe someone has a better idea.

https://docs.mollie.com/guides/webhooks#payments-api
There's no status for refunded or chargedback, but there is an API call.

https://docs.mollie.com/payments/status-changes#every-possible-payment-status
> In the v1 API, there were statuses for when payments were refunded, charged back, or paid out (settled). These statuses have been removed in v2. You can get the same information from other properties on the Payment object.

This PR uses the properties on the Payment object to infer these statuses.
