### PR TITLE
Add new refund list request without paymentId parameter

### DIFF
--- a/Mollie.Api/Client/RefundClient.cs
+++ b/Mollie.Api/Client/RefundClient.cs
@@ -15,6 +15,11 @@ namespace Mollie.Api.Client {
                 .ConfigureAwait(false);
         }
 
+        public async Task<ListResponse<RefundResponse>> GetRefundListAsync(string from = null, int? limit = null) {
+            return await this.GetListAsync<ListResponse<RefundResponse>>($"refunds", from, limit)
+                .ConfigureAwait(false);
+        }
+        
         public async Task<ListResponse<RefundResponse>> GetRefundListAsync(string paymentId, string from = null, int? limit = null) {
             return await this.GetListAsync<ListResponse<RefundResponse>>($"payments/{paymentId}/refunds", from, limit)
                 .ConfigureAwait(false);


### PR DESCRIPTION
The api specifies a refund list can be fetched without the need for a payment Id.