### PR TITLE
Add missing payment method endpoints + przelewy24 payment method

### DIFF
--- a/Mollie.Api/Client/Abstract/IPaymentMethodClient.cs
+++ b/Mollie.Api/Client/Abstract/IPaymentMethodClient.cs
@@ -1,15 +1,15 @@
 ﻿using System.Threading.Tasks;
 using Mollie.Api.Models;
 using Mollie.Api.Models.List;
-
 using Mollie.Api.Models.Payment;
 using Mollie.Api.Models.PaymentMethod;
 using Mollie.Api.Models.Url;
 
 namespace Mollie.Api.Client.Abstract {
     public interface IPaymentMethodClient {
-		Task<PaymentMethodResponse> GetPaymentMethodAsync(PaymentMethod paymentMethod, bool? includeIssuers = null, string locale = null);
-        Task<ListResponse<PaymentMethodResponse>> GetPaymentMethodListAsync(SequenceType? sequenceType = null, string locale = null, Amount amount = null);
+		Task<PaymentMethodResponse> GetPaymentMethodAsync(PaymentMethod paymentMethod, bool? includeIssuers = null, string locale = null, bool? includePricing = null, string profileId = null, bool? testmode = null);
+        Task<ListResponse<PaymentMethodResponse>> GetAllPaymentMethodListAsync(string locale = null, bool? includeIssuers = null, bool? includePricing = null);
+        Task<ListResponse<PaymentMethodResponse>> GetPaymentMethodListAsync(SequenceType? sequenceType = null, string locale = null, Amount amount = null, bool? includeIssuers = null, bool? includePricing = null, string profileId = null, bool? testmode = null);
         Task<PaymentMethodResponse> GetPaymentMethodAsync(UrlObjectLink<PaymentMethodResponse> url);
     }
 }

--- a/Mollie.Api/Client/PaymentMethodClient.cs
+++ b/Mollie.Api/Client/PaymentMethodClient.cs
@@ -5,43 +5,84 @@ using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Models;
 using Mollie.Api.Models.List;
-
 using Mollie.Api.Models.Payment;
 using Mollie.Api.Models.PaymentMethod;
 using Mollie.Api.Models.Url;
 
-namespace Mollie.Api.Client {
-    public class PaymentMethodClient : BaseMollieClient, IPaymentMethodClient {
-        public PaymentMethodClient(string apiKey, HttpClient httpClient = null) : base(apiKey, httpClient) {
+namespace Mollie.Api.Client
+{
+    public class PaymentMethodClient : BaseMollieClient, IPaymentMethodClient
+    {
+        public PaymentMethodClient(string apiKey, HttpClient httpClient = null) : base(apiKey, httpClient)
+        {
         }
 
-        public async Task<ListResponse<PaymentMethodResponse>> GetPaymentMethodListAsync(SequenceType? sequenceType = null, string locale = null, Amount amount = null) {
+        public async Task<PaymentMethodResponse> GetPaymentMethodAsync(PaymentMethod paymentMethod, bool? includeIssuers = null, string locale = null, bool? includePricing = null, string profileId = null, bool? testmode = null)
+        {
+            Dictionary<string, string> parameters = new Dictionary<string, string>();
+
+            parameters.AddValueIfNotNullOrEmpty("locale", locale);
+            AddOauthParameters(parameters, profileId, testmode);
+            AddIncludeParameters(parameters, includeIssuers, includePricing);
+
+            return await this.GetAsync<PaymentMethodResponse>($"methods/{paymentMethod.ToString().ToLower()}{parameters.ToQueryString()}").ConfigureAwait(false);
+        }
+
+        public async Task<ListResponse<PaymentMethodResponse>> GetAllPaymentMethodListAsync(string locale = null, bool? includeIssuers = null, bool? includePricing = null)
+        {
+            Dictionary<string, string> parameters = new Dictionary<string, string>();
+
+            parameters.AddValueIfNotNullOrEmpty("locale", locale);
+            AddIncludeParameters(parameters, includeIssuers, includePricing);
+
+            return await this.GetListAsync<ListResponse<PaymentMethodResponse>>("methods/all", null, null, parameters).ConfigureAwait(false);
+        }
+
+        public async Task<ListResponse<PaymentMethodResponse>> GetPaymentMethodListAsync(SequenceType? sequenceType = null, string locale = null, Amount amount = null, bool? includeIssuers = null, bool? includePricing = null, string profileId = null, bool? testmode = null)
+        {
             Dictionary<string, string> parameters = new Dictionary<string, string>() {
-                {nameof(sequenceType), sequenceType.ToString().ToLower()},
-                {nameof(locale), locale},
+                {"sequenceType", sequenceType.ToString().ToLower()},
+                {"locale", locale},
                 {"amount[value]", amount?.Value},
                 {"amount[currency]", amount?.Currency}
             };
 
+            AddOauthParameters(parameters, profileId, testmode);
+            AddIncludeParameters(parameters, includeIssuers, includePricing);
+
             return await this.GetListAsync<ListResponse<PaymentMethodResponse>>("methods", null, null, parameters).ConfigureAwait(false);
         }
 
-        public async Task<PaymentMethodResponse> GetPaymentMethodAsync(UrlObjectLink<PaymentMethodResponse> url) {
+        public async Task<PaymentMethodResponse> GetPaymentMethodAsync(UrlObjectLink<PaymentMethodResponse> url)
+        {
             return await this.GetAsync(url).ConfigureAwait(false);
         }
 
-		public async Task<PaymentMethodResponse> GetPaymentMethodAsync(PaymentMethod paymentMethod, bool? includeIssuers = null, string locale = null) {
-			var parameters = new Dictionary<string, string>();
-		    if (includeIssuers == true) {
-		        parameters.Add("include", "issuers");
-            }
-		    if (locale != null) {
-		        parameters.Add(nameof(locale), locale);
-            }
-				
-			string queryString = parameters.ToQueryString();
+        private void AddOauthParameters(Dictionary<string, string> parameters, string profileId = null, bool? testmode = null)
+        {
+            if (!string.IsNullOrWhiteSpace(profileId) || testmode.HasValue)
+            {
+                this.ValidateApiKeyIsOauthAccesstoken();
 
-			return await this.GetAsync<PaymentMethodResponse>($"methods/{paymentMethod.ToString().ToLower()}{queryString}").ConfigureAwait(false);
-		}
-	}
+                parameters.AddValueIfNotNullOrEmpty("profileId", profileId);
+                if (testmode.HasValue)
+                {
+                    parameters.AddValueIfNotNullOrEmpty("testmode", testmode.Value.ToString().ToLower());
+                }
+            }
+        }
+
+        private void AddIncludeParameters(Dictionary<string, string> parameters, bool? includeIssuers = null, bool? includePricing = null)
+        {
+            if (includeIssuers == true)
+            {
+                parameters.Add("include", "issuers");
+            }
+
+            if (includePricing == true)
+            {
+                parameters.Add("include", "pricing");
+            }
+        }
+    }
 }

--- a/Mollie.Api/Extensions/DictionaryExtensions.cs
+++ b/Mollie.Api/Extensions/DictionaryExtensions.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Mollie.Tests.Integration")]
 namespace Mollie.Api.Extensions {
     internal static class DictionaryExtensions {
         public static string ToQueryString(this IDictionary<string, string> parameters) {

--- a/Mollie.Api/Models/Payment/PaymentMethod.cs
+++ b/Mollie.Api/Models/Payment/PaymentMethod.cs
@@ -21,5 +21,7 @@ namespace Mollie.Api.Models.Payment {
         [EnumMember(Value = "paysafecard")] PaySafeCard,
         [EnumMember(Value = "sofort")] Sofort,
         [EnumMember(Value = "refund")] Refund,
+        [EnumMember(Value = "klarnapaylater")] KlarnaPayLater,
+        [EnumMember(Value = "klarnasliceit")] KlarnaSliceIt,
     }
 }

--- a/Mollie.Api/Models/Payment/PaymentMethod.cs
+++ b/Mollie.Api/Models/Payment/PaymentMethod.cs
@@ -23,5 +23,6 @@ namespace Mollie.Api.Models.Payment {
         [EnumMember(Value = "refund")] Refund,
         [EnumMember(Value = "klarnapaylater")] KlarnaPayLater,
         [EnumMember(Value = "klarnasliceit")] KlarnaSliceIt,
+        [EnumMember(Value = "przelewy24")] Przelewy24,
     }
 }

--- a/Mollie.Api/Models/Payment/Request/Przelewy24PaymentRequest.cs
+++ b/Mollie.Api/Models/Payment/Request/Przelewy24PaymentRequest.cs
@@ -1,0 +1,15 @@
+namespace Mollie.Api.Models.Payment.Request
+{
+    public class Przelewy24PaymentRequest : PaymentRequest
+    {
+        public Przelewy24PaymentRequest()
+        {
+            this.Method = PaymentMethod.Przelewy24;
+        }
+
+        /// <summary>
+        /// Consumer’s email address, this is required for Przelewy24 payments.
+        /// </summary>
+        public string BillingEmail { get; set; }
+    }
+}

--- a/Mollie.Api/Models/PaymentMethod/PaymentMethodResponse.cs
+++ b/Mollie.Api/Models/PaymentMethod/PaymentMethodResponse.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System.Collections.Generic;
 using Mollie.Api.Models.Issuer;
+using Mollie.Api.Models.PaymentMethod.Pricing;
 
 namespace Mollie.Api.Models.PaymentMethod {
     public class PaymentMethodResponse : IResponseObject {
@@ -15,19 +16,24 @@ namespace Mollie.Api.Models.PaymentMethod {
         public Payment.PaymentMethod Id { get; set; }
 
         /// <summary>
-        ///     The full name of the payment method.
+        /// The full name of the payment method.
         /// </summary>
         public string Description { get; set; }
 
         /// <summary>
-        ///     URLs of images representing the payment method.
+        /// URLs of images representing the payment method.
         /// </summary>
         public PaymentMethodResponseImage Image { get; set; }
 
 		/// <summary>
-		///		List of Issuers
+		///	List of Issuers
 		/// </summary>
 		public List<IssuerResponse> Issuers { get; set; }
+
+        /// <summary>
+        /// Pricing set of the payment method what will be include if you add the parameter.
+        /// </summary>
+        public List<PricingResponse> Pricing { get; set; }
 
 		/// <summary>
 		/// An object with several URL objects relevant to the payment method. Every URL object will contain an href and a type field.

--- a/Mollie.Api/Models/PaymentMethod/Pricing/FixedPricingResponse.cs
+++ b/Mollie.Api/Models/PaymentMethod/Pricing/FixedPricingResponse.cs
@@ -1,0 +1,15 @@
+﻿namespace Mollie.Api.Models.PaymentMethod.Pricing
+{
+    public class FixedPricingResponse : IResponseObject
+    {
+        /// <summary>
+        /// The ISO 4217 currency code.
+        /// </summary>
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// A string containing the exact amount in the given currency.
+        /// </summary>
+        public decimal Value { get; set; }
+    }
+}

--- a/Mollie.Api/Models/PaymentMethod/Pricing/PricingResponse.cs
+++ b/Mollie.Api/Models/PaymentMethod/Pricing/PricingResponse.cs
@@ -1,0 +1,20 @@
+﻿namespace Mollie.Api.Models.PaymentMethod.Pricing
+{
+    public class PricingResponse : IResponseObject
+    {
+        /// <summary>
+        /// The area or product-type where the pricing is applied for, translated in the optional locale passed.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The fixed price per transaction
+        /// </summary>
+        public FixedPricingResponse Fixed { get; set; }
+
+        /// <summary>
+        /// A string containing the percentage what will be charged over the payment amount besides the fixed price.
+        /// </summary>
+        public decimal Variable { get; set; }
+    }
+}

--- a/Mollie.Tests.Integration/Api/PaymentMethodTests.cs
+++ b/Mollie.Tests.Integration/Api/PaymentMethodTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using Mollie.Api.Models.List;
-
 using Mollie.Api.Models.Payment;
 using Mollie.Api.Models.PaymentMethod;
 using Mollie.Tests.Integration.Framework;
@@ -10,6 +9,7 @@ using NUnit.Framework;
 namespace Mollie.Tests.Integration.Api {
     [TestFixture]
     public class PaymentMethodTests : BaseMollieApiTestClass {
+
         [Test]
         public async Task CanRetrievePaymentMethodList() {
             // When: Retrieve payment list with default settings
@@ -65,6 +65,68 @@ namespace Mollie.Tests.Integration.Api {
 
             // Then: Issuers should not be included
             Assert.IsNull(paymentMethod.Issuers);
+        }
+
+        [Test]
+        public async Task CanRetrievePricing()
+        {
+            // When: retrieving the ideal method we can include the issuers
+            PaymentMethodResponse paymentMethod = await this._paymentMethodClient.GetPaymentMethodAsync(PaymentMethod.Ideal, includePricing: true);
+
+            // Then: We should have one or multiple issuers
+            Assert.IsNotNull(paymentMethod);
+            Assert.IsTrue(paymentMethod.Pricing.Any());
+        }
+
+        [Test]
+        public async Task DoNotRetrievePricingWhenIncludeIsFalse()
+        {
+            // When: retrieving the ideal method with the include parameter set to false
+            PaymentMethodResponse paymentMethod = await this._paymentMethodClient.GetPaymentMethodAsync(PaymentMethod.Ideal, includePricing: false);
+
+            // Then: Issuers should not be included
+            Assert.IsNull(paymentMethod.Pricing);
+        }
+
+        [Test]
+        public async Task DoNotRetrievePricingWhenIncludeIsNull()
+        {
+            // When: retrieving the ideal method with the include parameter set to null
+            PaymentMethodResponse paymentMethod = await this._paymentMethodClient.GetPaymentMethodAsync(PaymentMethod.Ideal, includePricing: null);
+
+            // Then: Issuers should not be included
+            Assert.IsNull(paymentMethod.Pricing);
+        }
+
+        [Test]
+        public async Task CanRetrieveAllMethods()
+        {
+            // When: retrieving the all mollie payment methods
+            ListResponse<PaymentMethodResponse> paymentMethods = await this._paymentMethodClient.GetAllPaymentMethodListAsync();
+
+            // Then: We should have multiple issuers
+            Assert.IsNotNull(paymentMethods);
+            Assert.IsTrue(paymentMethods.Items.Any());
+        }
+
+        [Test]
+        public async Task CanRetrievePricingForAllMethods()
+        {
+            // When: retrieving the ideal method we can include the issuers
+            ListResponse<PaymentMethodResponse> paymentMethods = await this._paymentMethodClient.GetAllPaymentMethodListAsync(includePricing: true);
+
+            // Then: We should have prices available
+            Assert.IsTrue(paymentMethods.Items.Any(x => x.Pricing != null && x.Pricing.Any(y => y.Fixed.Value > 0)));
+        }
+
+        [Test]
+        public async Task CanRetrieveIssuersForAllMethods()
+        {
+            // When: retrieving the all mollie payment methods we can include the issuers
+            ListResponse<PaymentMethodResponse> paymentMethods = await this._paymentMethodClient.GetAllPaymentMethodListAsync(includeIssuers: true);
+
+            // Then: We should have one or multiple issuers
+            Assert.IsTrue(paymentMethods.Items.Any(x => x.Issuers != null));
         }
     }
 }

--- a/Mollie.Tests.Integration/Api/PaymentTests.cs
+++ b/Mollie.Tests.Integration/Api/PaymentTests.cs
@@ -13,7 +13,6 @@ using NUnit.Framework;
 
 namespace Mollie.Tests.Integration.Api {
     using System.Linq;
-
     using Mollie.Api.Models.Customer;
     using Mollie.Api.Models.Mandate;
 
@@ -115,6 +114,7 @@ namespace Mollie.Tests.Integration.Api {
         [TestCase(typeof(PaymentRequest), PaymentMethod.Belfius, typeof(BelfiusPaymentResponse))]
         [TestCase(typeof(KbcPaymentRequest), PaymentMethod.Kbc, typeof(KbcPaymentResponse))]
         [TestCase(typeof(PaymentRequest), null, typeof(PaymentResponse))]
+        //[TestCase(typeof(Przelewy24PaymentRequest), PaymentMethod.Przelewy24, typeof(PaymentResponse))] // Payment option is not enabled in website profile
         public async Task CanCreateSpecificPaymentType(Type paymentType, PaymentMethod? paymentMethod, Type expectedResponseType) {
             // If: we create a specific payment type with some bank transfer specific values
             PaymentRequest paymentRequest = (PaymentRequest) Activator.CreateInstance(paymentType);
@@ -122,6 +122,12 @@ namespace Mollie.Tests.Integration.Api {
             paymentRequest.Description = "Description";
             paymentRequest.RedirectUrl = this.DefaultRedirectUrl;
             paymentRequest.Method = paymentMethod;
+
+            // Set required billing email for Przelewy24
+            if (paymentRequest is Przelewy24PaymentRequest request)
+            {
+                request.BillingEmail = "example@example.com";
+            }
 
             // When: We send the payment request to Mollie
             PaymentResponse result = await this._paymentClient.CreatePaymentAsync(paymentRequest);

--- a/Mollie.Tests.Integration/Extensions/DictionaryExtensionsTests.cs
+++ b/Mollie.Tests.Integration/Extensions/DictionaryExtensionsTests.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Mollie.Api.Extensions;
+using NUnit.Framework;
+
+namespace Mollie.Tests.Integration.Extensions
+{
+    [TestFixture]
+    public class DictionaryExtensionsTests
+    {
+
+        [Test]
+        public void CanCreateUrlQueryFromDictionary()
+        {
+            // Arrange
+            var parameters = new Dictionary<string, string>()
+            {
+                {"include", "issuers"},
+                {"testmode", "true"}
+            };
+            var expected = "?include=issuers&testmode=true";
+
+            // Act
+            var result = parameters.ToQueryString();
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void CanCreateUrlQueryFromEmptyDictionary()
+        {
+            // Arrange
+            var parameters = new Dictionary<string, string>();
+            string expected = string.Empty;
+
+            // Act
+            var result = parameters.ToQueryString();
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void CanAddParameterToDictionaryIfNotEmptyDictionary()
+        {
+            // Arrange
+            var parameters = new Dictionary<string, string>();
+            var parameterName = "include";
+            var parameterValue = "issuers";
+
+            // Act
+            parameters.AddValueIfNotNullOrEmpty(parameterName, parameterValue);
+
+            // Assert
+            Assert.IsTrue(parameters.Any());
+            Assert.AreEqual(parameterValue, parameters[parameterName]);
+        }
+
+        [Test]
+        public void CannotAddParameterToDictionaryIfEmptyDictionary()
+        {
+            // Arrange
+            var parameters = new Dictionary<string, string>();
+
+            // Act
+            parameters.AddValueIfNotNullOrEmpty("include", "");
+
+            // Assert
+            Assert.IsFalse(parameters.Any());
+        }
+    }
+}

--- a/Mollie.Tests.Integration/Mollie.Tests.Integration.csproj
+++ b/Mollie.Tests.Integration/Mollie.Tests.Integration.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Api\PaymentTests.cs" />
     <Compile Include="Api\RefundTests.cs" />
     <Compile Include="Api\SubscriptionTests.cs" />
+    <Compile Include="Extensions\DictionaryExtensionsTests.cs" />
     <Compile Include="Framework\BaseMollieApiTestClass.cs" />
     <Compile Include="Framework\JsonConverterServiceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
- Added missing payment method endpoints
- Added missing payment method Oauth parameters
- Added dictionary extensions tests
- Added przelewy24 payment method (Closes #104)

Coudn't enable the przelewy24 payment unit test because the "payment option is not enabled in website profile" Error message