### PR TITLE
Added UnknownReason to CreditCardFailureReason

### DIFF
--- a/Mollie.Api/Models/Payment/Response/Specific/CreditCardPaymentResponse.cs
+++ b/Mollie.Api/Models/Payment/Response/Specific/CreditCardPaymentResponse.cs
@@ -101,7 +101,8 @@ namespace Mollie.Api.Models.Payment.Response {
         [EnumMember(Value = "invalid_card_type")] InvalidCardType,
         [EnumMember(Value = "refused_by_issuer")] RefusedByIssuer,
         [EnumMember(Value = "insufficient_funds")] InsufficientFunds,
-        [EnumMember(Value = "inactive_card")] InactiveCard
+        [EnumMember(Value = "inactive_card")] InactiveCard,
+        [EnumMember(Value = "unknown_reason")] UnknownReason
     }
 
     /// <summary>
@@ -114,7 +115,8 @@ namespace Mollie.Api.Models.Payment.Response {
         Dankort,
         [EnumMember(Value = "Diners Club")] DinersClub,
         Discover,
-        [EnumMember(Value = "JCB Laser")] JcbLaser,
+        [EnumMember(Value = "JCB")] Jcb,
+        [EnumMember(Value = "Laser")] Laser,
         Maestro,
         Mastercard,
         Unionpay,


### PR DESCRIPTION
The value `unknown_reason` isn't documented, but it was returned in my production environment.

I also split JCB and Laser since it was wrongly implemented in this library. See https://docs.mollie.com/reference/v2/payments-api/get-payment#payment-method-specific-details
