### PR TITLE
Updated payment status for API v2

### DIFF
--- a/Mollie.Api/Models/Payment/PaymentStatus.cs
+++ b/Mollie.Api/Models/Payment/PaymentStatus.cs
@@ -3,11 +3,9 @@
         Open,
         Canceled,
         Pending,
-        Paid,
-        PaidOut,
-        Refunded,
+        Authorized,
         Expired,
         Failed,
-        Charged_Back
+        Paid
     }
 }


### PR DESCRIPTION
Updated the payment status enum for the payment response to use the statuses from the v2 version of the Mollie API.

Fixes issue #110 