### PR TITLE
Added amounts for payment method

### DIFF
--- a/Mollie.Api/Models/PaymentMethod/PaymentMethodResponse.cs
+++ b/Mollie.Api/Models/PaymentMethod/PaymentMethodResponse.cs
@@ -21,6 +21,16 @@ namespace Mollie.Api.Models.PaymentMethod {
         public string Description { get; set; }
 
         /// <summary>
+        /// Minimum payment amount required to use this payment method.
+        /// </summary>
+        public Amount MinimumAmount { get; set; }
+
+        /// <summary>
+        /// Maximum payment amount allowed when using this payment method. (Could be null)
+        /// </summary>
+        public Amount MaximumAmount { get; set; }
+
+        /// <summary>
         /// URLs of images representing the payment method.
         /// </summary>
         public PaymentMethodResponseImage Image { get; set; }


### PR DESCRIPTION
Adds the ability to use the minimum amount and maximum amount specified for payment methods.

See: https://docs.mollie.com/reference/v2/methods-api/get-method#response