### PR TITLE
Fix for Order Lines in Order Refund

### DIFF
--- a/Mollie.Api/Models/Order/Request/OrderRefundRequest.cs
+++ b/Mollie.Api/Models/Order/Request/OrderRefundRequest.cs
@@ -6,7 +6,7 @@ namespace Mollie.Api.Models.Order {
         /// An array of objects containing the order line details you want to create a refund for. If you send
         /// an empty array, the entire order will be refunded.
         /// </summary>
-        public IEnumerable<OrderLineRequest> Lines { get; set; }
+        public IEnumerable<OrderLineDetails> Lines { get; set; }
 
         /// <summary>
         /// The description of the refund you are creating. This will be shown to the consumer on their card or


### PR DESCRIPTION
Changed the OrderRefundRequest reference from `OrderLineRequest` to `OrderLineDetails` in order to be able to provide the order line `id`.

Fixes: #142