### PR TITLE
Embedding of related resources Order API

### DIFF
--- a/Mollie.Api/Client/Abstract/IOrderClient.cs
+++ b/Mollie.Api/Client/Abstract/IOrderClient.cs
@@ -8,7 +8,7 @@ using Mollie.Api.Models.Url;
 namespace Mollie.Api.Client.Abstract {
     public interface IOrderClient {
         Task<OrderResponse> CreateOrderAsync(OrderRequest orderRequest);
-        Task<OrderResponse> GetOrderAsync(string orderId);
+        Task<OrderResponse> GetOrderAsync(string orderId, bool embedPayments = false, bool embedRefunds = false);
         Task<OrderResponse> UpdateOrderAsync(string orderId, OrderUpdateRequest orderUpdateRequest);
         Task<OrderResponse> UpdateOrderLinesAsync(string orderId, string orderLineId, OrderLineUpdateRequest orderLineUpdateRequest);
         Task CancelOrderAsync(string orderId);

--- a/Mollie.Api/Client/OrderClient.cs
+++ b/Mollie.Api/Client/OrderClient.cs
@@ -1,6 +1,9 @@
-﻿using System.Net.Http;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
+using Mollie.Api.Extensions;
 using Mollie.Api.Models.List;
 using Mollie.Api.Models.Order;
 using Mollie.Api.Models.Payment.Response;
@@ -16,8 +19,10 @@ namespace Mollie.Api.Client {
             return await this.PostAsync<OrderResponse>("orders", orderRequest).ConfigureAwait(false);
         }
 
-        public async Task<OrderResponse> GetOrderAsync(string orderId) {
-            return await this.GetAsync<OrderResponse>($"orders/{orderId}").ConfigureAwait(false); ;
+        public async Task<OrderResponse> GetOrderAsync(string orderId, bool embedPayments = false, bool embedRefunds = false)
+        {
+            var embeds = this.BuildEmbedParameter(embedPayments, embedRefunds);
+            return await this.GetAsync<OrderResponse>($"orders/{orderId}{embeds.ToQueryString()}").ConfigureAwait(false);
         }
 
         public async Task<OrderResponse> UpdateOrderAsync(string orderId, OrderUpdateRequest orderUpdateRequest) {
@@ -54,6 +59,28 @@ namespace Mollie.Api.Client {
 
         public async Task<ListResponse<RefundResponse>> GetOrderRefundListAsync(string orderId, string from = null, int? limit = null) {
             return await this.GetListAsync<ListResponse<RefundResponse>>($"orders/{orderId}/refunds", from, limit).ConfigureAwait(false);
+        }
+        private Dictionary<string, string> BuildEmbedParameter(bool embedPayments = false, bool embedRefunds = false)
+        {
+            var result = new Dictionary<string, string>();
+
+            var embedList = new List<string>();
+            if (embedPayments)
+            {
+                embedList.Add("payments");
+            }
+
+            if (embedRefunds)
+            {
+                embedList.Add("refunds");
+            }
+
+            if (embedList.Any())
+            {
+                result.Add("embed", string.Join(",", embedList));
+            }
+
+            return result;
         }
     }
 }

--- a/Mollie.Api/Models/Order/Response/OrderEmbeddedResponse.cs
+++ b/Mollie.Api/Models/Order/Response/OrderEmbeddedResponse.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using Mollie.Api.Extensions;
+using Mollie.Api.JsonConverters;
+using Mollie.Api.Models.Payment;
+using Mollie.Api.Models.Payment.Response;
+using Mollie.Api.Models.Refund;
+using Mollie.Api.Models.Subscription;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Mollie.Api.Models.Order {
+
+    public class OrderEmbeddedResponse : IResponseObject {
+
+        public IEnumerable<PaymentResponse> Payments { get; set; }
+
+        public IEnumerable<RefundResponse> Refunds { get; set; }
+
+    }
+}

--- a/Mollie.Api/Models/Order/Response/OrderResponse.cs
+++ b/Mollie.Api/Models/Order/Response/OrderResponse.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Mollie.Api.JsonConverters;
 using Mollie.Api.Models.Payment;
-using Mollie.Api.Models.Subscription;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -139,6 +138,9 @@ namespace Mollie.Api.Models.Order {
         public DateTime? CompletedAt { get; set; }
 
         public IEnumerable<OrderLineResponse> Lines { get; set; }
+
+        [JsonProperty("_embedded")]
+        public OrderEmbeddedResponse Embedded { get; set; }
 
         /// <summary>
         /// An object with several URL objects relevant to the order. Every URL object will contain an href and a type field.


### PR DESCRIPTION
This adds the ability to request the embeds from the order API. With these changes you would be able to request the order `payments` and `refunds` from a single request. 

See: https://docs.mollie.com/reference/v2/orders-api/get-order#embedding-of-related-resources