### PR TITLE
Added currency parameter for GetPaymentMethodAsync

### DIFF
--- a/Mollie.Api/Client/Abstract/IPaymentMethodClient.cs
+++ b/Mollie.Api/Client/Abstract/IPaymentMethodClient.cs
@@ -7,7 +7,7 @@ using Mollie.Api.Models.Url;
 
 namespace Mollie.Api.Client.Abstract {
     public interface IPaymentMethodClient {
-		Task<PaymentMethodResponse> GetPaymentMethodAsync(PaymentMethod paymentMethod, bool? includeIssuers = null, string locale = null, bool? includePricing = null, string profileId = null, bool? testmode = null);
+		Task<PaymentMethodResponse> GetPaymentMethodAsync(PaymentMethod paymentMethod, bool? includeIssuers = null, string locale = null, bool? includePricing = null, string profileId = null, bool? testmode = null, string currency = null);
         Task<ListResponse<PaymentMethodResponse>> GetAllPaymentMethodListAsync(string locale = null, bool? includeIssuers = null, bool? includePricing = null);
         Task<ListResponse<PaymentMethodResponse>> GetPaymentMethodListAsync(SequenceType? sequenceType = null, string locale = null, Amount amount = null, bool? includeIssuers = null, bool? includePricing = null, string profileId = null, bool? testmode = null, Resource? resource = null);
         Task<PaymentMethodResponse> GetPaymentMethodAsync(UrlObjectLink<PaymentMethodResponse> url);

--- a/Mollie.Api/Client/PaymentMethodClient.cs
+++ b/Mollie.Api/Client/PaymentMethodClient.cs
@@ -17,10 +17,11 @@ namespace Mollie.Api.Client
         public PaymentMethodClient(string apiKey, HttpClient httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public async Task<PaymentMethodResponse> GetPaymentMethodAsync(PaymentMethod paymentMethod, bool? includeIssuers = null, string locale = null, bool? includePricing = null, string profileId = null, bool? testmode = null) {
+        public async Task<PaymentMethodResponse> GetPaymentMethodAsync(PaymentMethod paymentMethod, bool? includeIssuers = null, string locale = null, bool? includePricing = null, string profileId = null, bool? testmode = null, string currency = null) {
             Dictionary<string, string> parameters = new Dictionary<string, string>();
 
             parameters.AddValueIfNotNullOrEmpty("locale", locale);
+            parameters.AddValueIfNotNullOrEmpty("currency", currency);
             this.AddOauthParameters(parameters, profileId, testmode);
             this.BuildIncludeParameter(parameters, includeIssuers, includePricing);
 


### PR DESCRIPTION
Added a `currency` parameter for `GetPaymentMethodAsync`. When this parameter is provided Mollie will check the availability of the currency for the payment method. Furthermore it will return the amounts in the provided currency.