### PR TITLE
Extend payment requests

### DIFF
--- a/Mollie.Api/Models/Payment/Request/ApplePayPaymentRequest.cs
+++ b/Mollie.Api/Models/Payment/Request/ApplePayPaymentRequest.cs
@@ -1,0 +1,14 @@
+﻿namespace Mollie.Api.Models.Payment.Request {
+    public class ApplePayPaymentRequest : PaymentRequest {
+        public ApplePayPaymentRequest()
+        {
+            this.Method = PaymentMethod.ApplePay;
+        }
+
+        /// <summary>
+        /// Optional - The Apple Pay Payment Token object (encoded as JSON) that is part of the result of authorizing a payment
+        /// request. The token contains the payment information needed to authorize the payment.
+        /// </summary>
+        public string ApplePayPaymentToken { get; set; }
+    }
+}

--- a/Mollie.Api/Models/Payment/Request/CreditCardPaymentRequest.cs
+++ b/Mollie.Api/Models/Payment/Request/CreditCardPaymentRequest.cs
@@ -15,5 +15,11 @@ namespace Mollie.Api.Models.Payment.Request {
         /// protection, and thus improve conversion.
         /// </summary>
         public AddressObject ShippingAddress { get; set; }
+
+        /// <summary>
+        /// The card token you get from Mollie Components. The token contains the card information
+        /// (such as card holder, card number and expiry date) needed to complete the payment.
+        /// </summary>
+        public string CardToken { get; set; }
     }
 }


### PR DESCRIPTION
Adds new `ApplePayPaymentRequest` class to create payment using Apple Pay payment token object.
Adds `CardToken` field to `CreditCardPaymentRequest` which enables the use of Mollie Components.

We're trying to implement Apple Pay, once thats done we will create a PR to create an Apple Pay Payment Session using the Mollie API (https://docs.mollie.com/reference/v2/wallets-api/request-apple-pay-payment-session)