### PR TITLE
Minor changes to Mollie.Api.Models.Amount

### DIFF
--- a/Mollie.Api/Models/Amount.cs
+++ b/Mollie.Api/Models/Amount.cs
@@ -1,5 +1,10 @@
-﻿namespace Mollie.Api.Models {
-    public class Amount {
+﻿using System;
+using System.Globalization;
+
+namespace Mollie.Api.Models
+{
+    public class Amount
+    {
         /// <summary>
         /// An ISO 4217 currency code. The currencies supported depend on the payment methods that are enabled on your account.
         /// </summary>
@@ -10,14 +15,34 @@
         /// </summary>
         public string Value { get; set; }
 
-        public Amount(string currency, string value) {
+        public Amount(string currency, string value)
+        {
             this.Currency = currency;
             this.Value = value;
         }
 
+        /// <summary>
+        /// Constructor for constructing based on a decimal value
+        /// </summary>
+        /// <param name="currency"></param>
+        /// <param name="value"></param>
+        public Amount(string currency, decimal value)
+        {
+            this.Currency = currency;
+            this.Value = value.ToString("0.00", CultureInfo.InvariantCulture);
+        }
+
         public Amount() { }
 
-        public override string ToString() {
+        /// <summary>
+        /// Implicit cast operator from Amount to decimal.
+        /// </summary>
+        /// <param name="amount"></param>
+        public static implicit operator decimal(Amount amount)
+            => Decimal.TryParse(amount.Value, NumberStyles.Number, CultureInfo.InvariantCulture, out var a) ? a : throw new InvalidCastException($"Cannot convert {amount.Value} to decimal");
+
+        public override string ToString()
+        {
             return $"{this.Value} {this.Currency}";
         }
     }

--- a/Mollie.Tests.Unit/Framework/AmountConversionTests.cs
+++ b/Mollie.Tests.Unit/Framework/AmountConversionTests.cs
@@ -1,0 +1,26 @@
+﻿using Mollie.Api.Framework;
+using Mollie.Api.Models;
+using Mollie.Api.Models.Payment.Response;
+using NUnit.Framework;
+using System;
+
+namespace Mollie.Tests.Unit.Framework {
+
+    [TestFixture]
+    public class AmountConversionTests
+    {
+        [Test]
+        public void InvalidAmountValueWillThrowInvalidCastException() {
+            
+            // Initiate Amount with invalid decimal value
+            var amount = new Amount() { Currency = Currency.EUR, Value = "NotAValidDecimal" };
+
+            // When: We implicitly cast Amount to decimal
+            // Then: An InvalidCastException will be thrown
+            Assert.Throws<InvalidCastException>(() =>
+            {
+                decimal a = amount;
+            });
+        }
+    }
+}


### PR DESCRIPTION
- Added new constructor which makes it able to construct Amount with a decimal value.
- Added implicit cast operator for Amount to decimal.

Most webshops using Mollie trade in EUR. In most of my implementations I only use Amount.Value property which I need to cast to decimal every time. With this implicit operator you can directly use Amount as decimal. If the Value property contains an invalid decimal, the cast will throw an InvalidCastException.
Also you can construct Amount with a decimal instead.