### PR TITLE
Request QR Code in PaymentRequest

### DIFF
--- a/Mollie.Api/Client/PaymentClient.cs
+++ b/Mollie.Api/Client/PaymentClient.cs
@@ -19,7 +19,9 @@ namespace Mollie.Api.Client {
                 this.ValidateApiKeyIsOauthAccesstoken();
             }
 
-            return await this.PostAsync<PaymentResponse>("payments", paymentRequest).ConfigureAwait(false);
+            var qrCodeParameter = paymentRequest.IncludeQrCode == true ? "?include=details.qrCode" : string.Empty;
+
+            return await this.PostAsync<PaymentResponse>($"payments{qrCodeParameter}", paymentRequest).ConfigureAwait(false);
         }
 
 	    public async Task<PaymentResponse> GetPaymentAsync(string paymentId, bool testmode = false) {

--- a/Mollie.Api/Models/Payment/Request/PaymentRequest.cs
+++ b/Mollie.Api/Models/Payment/Request/PaymentRequest.cs
@@ -83,11 +83,17 @@ namespace Mollie.Api.Models.Payment.Request {
 		/// </summary>
 		public bool? Testmode { get; set; }
 
-		/// <summary>
-		///	Oauth only - Optional – Adding an Application Fee allows you to charge the merchant a small sum for the payment and transfer 
-		/// this to your own account.
+        /// <summary>
+		///	Optional – Set this to true to request a QR Code (if possible).
 		/// </summary>
-		public PaymentRequestApplicationFee ApplicationFee { get; set; }
+        [JsonIgnore]
+        public bool? IncludeQrCode { get; set; }
+
+        /// <summary>
+        ///	Oauth only - Optional – Adding an Application Fee allows you to charge the merchant a small sum for the payment and transfer
+        /// this to your own account.
+        /// </summary>
+        public PaymentRequestApplicationFee ApplicationFee { get; set; }
 
         public void SetMetadata(object metadataObj, JsonSerializerSettings jsonSerializerSettings = null) {
             this.Metadata = JsonConvert.SerializeObject(metadataObj, jsonSerializerSettings);

--- a/Mollie.Tests.Integration/Api/PaymentTests.cs
+++ b/Mollie.Tests.Integration/Api/PaymentTests.cs
@@ -353,7 +353,70 @@ namespace Mollie.Tests.Integration.Api {
             Assert.AreEqual(paymentResponse.RedirectUrl, result.RedirectUrl);
         }
 
-        private async Task<MandateResponse> GetFirstValidMandate() {
+        [Test]
+        [RetryOnFailure(BaseMollieApiTestClass.NumberOfRetries)]
+        public async Task CanCreateBancontantPaymentWithQrCode()
+        {
+            // When: we create a payment request with only the required parameters
+            PaymentRequest paymentRequest = new PaymentRequest()
+            {
+                Amount = new Amount(Currency.EUR, "100.00"),
+                Description = "Description",
+                RedirectUrl = this.DefaultRedirectUrl,
+                Method = PaymentMethod.Bancontact,
+                IncludeQrCode = true
+            };
+
+            // When: We send the payment request to Mollie
+            PaymentResponse result = await this._paymentClient.CreatePaymentAsync(paymentRequest);
+
+            // Then: Make sure we get a valid response
+            Assert.IsNotNull(result);
+
+            // Try to cast to a BancontactPaymentResponse
+            BancontactPaymentResponse bancontactResponse = result as BancontactPaymentResponse;
+
+            // Check if result is a BancontactPaymentResponse
+            Assert.IsNotNull(bancontactResponse);
+
+            // Check if bancontactResponse contains a QR Code
+            Assert.IsNotNull(bancontactResponse.Details?.QrCode);
+
+        }
+
+        [Test]
+        [RetryOnFailure(BaseMollieApiTestClass.NumberOfRetries)]
+        public async Task CanCreateKbcPaymentWithoutQrCode()
+        {
+            // When: we create a payment request with only the required parameters
+            PaymentRequest paymentRequest = new PaymentRequest()
+            {
+                Amount = new Amount(Currency.EUR, "100.00"),
+                Description = "Description",
+                RedirectUrl = this.DefaultRedirectUrl,
+                Method = PaymentMethod.Kbc,
+                IncludeQrCode = true
+            };
+
+            // When: We send the payment request to Mollie
+            PaymentResponse result = await this._paymentClient.CreatePaymentAsync(paymentRequest);
+
+            // Then: Make sure we get a valid response
+            Assert.IsNotNull(result);
+
+            // Try to cast to a KbcPaymentResponse
+            KbcPaymentResponse kbcResponse = result as KbcPaymentResponse;
+
+            // Check if result is a KbcPaymentResponse
+            Assert.IsNotNull(kbcResponse);
+
+            // Make sure that kbcResponse doesn't have details
+            Assert.IsNull(kbcResponse.Details);
+
+        }
+
+        private async Task<MandateResponse> GetFirstValidMandate()
+        {
             ListResponse<CustomerResponse> customers = await this._customerClient.GetCustomerListAsync();
             if (!customers.Items.Any()) {
                 Assert.Inconclusive("No customers found. Unable to test recurring payment tests");


### PR DESCRIPTION
- Added an optional bool to the PaymentRequest to include a QR Code.
- Changed the CreatPaymentAsync() method inside CreatePaymentAsync, to make it possible for requesting a QR Code with a PaymentRequest.
- Added 2 tests to the PaymentTests, for testing this new behavior. One test when using a payment method that can have a QR Code + one test when using a payment method that can't have a QR Code.