### PR TITLE
feat: add testmode option for refund calls

### DIFF
--- a/Mollie.Api/Client/Abstract/IRefundClient.cs
+++ b/Mollie.Api/Client/Abstract/IRefundClient.cs
@@ -5,10 +5,10 @@ using Mollie.Api.Models.Url;
 
 namespace Mollie.Api.Client.Abstract {
     public interface IRefundClient {
-        Task CancelRefundAsync(string paymentId, string refundId);
+        Task CancelRefundAsync(string paymentId, string refundId, bool? testmode = default);
         Task<RefundResponse> CreateRefundAsync(string paymentId, RefundRequest refundRequest);
-        Task<RefundResponse> GetRefundAsync(string paymentId, string refundId);
-        Task<ListResponse<RefundResponse>> GetRefundListAsync(string paymentId, string from = null, int? limit = null);
+        Task<RefundResponse> GetRefundAsync(string paymentId, string refundId, bool? testmode = default);
+        Task<ListResponse<RefundResponse>> GetRefundListAsync(string paymentId, string from = null, int? limit = null, bool? testmode = default);
         Task<RefundResponse> GetRefundAsync(UrlObjectLink<RefundResponse> url);
     }
 }

--- a/Mollie.Api/Client/RefundClient.cs
+++ b/Mollie.Api/Client/RefundClient.cs
@@ -1,6 +1,8 @@
-﻿using System.Net.Http;
+﻿using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
+using Mollie.Api.Extensions;
 using Mollie.Api.Models.List;
 using Mollie.Api.Models.Refund;
 using Mollie.Api.Models.Url;
@@ -19,24 +21,36 @@ namespace Mollie.Api.Client {
             return await this.PostAsync<RefundResponse>($"payments/{paymentId}/refunds", refundRequest).ConfigureAwait(false);
         }
 
-        public async Task<ListResponse<RefundResponse>> GetRefundListAsync(string from = null, int? limit = null) {
-            return await this.GetListAsync<ListResponse<RefundResponse>>($"refunds", from, limit).ConfigureAwait(false);
+        public async Task<ListResponse<RefundResponse>> GetRefundListAsync(string from = null, int? limit = null, bool? testmode = default) {
+            var queryParameters = this.BuildQueryParameters(testmode: testmode);
+            
+            return await this.GetListAsync<ListResponse<RefundResponse>>($"refunds", from, limit, queryParameters).ConfigureAwait(false);
         }
         
-        public async Task<ListResponse<RefundResponse>> GetRefundListAsync(string paymentId, string from = null, int? limit = null) {
-            return await this.GetListAsync<ListResponse<RefundResponse>>($"payments/{paymentId}/refunds", from, limit).ConfigureAwait(false);
+        public async Task<ListResponse<RefundResponse>> GetRefundListAsync(string paymentId, string from = null, int? limit = null, bool? testmode = default) {
+            var queryParameters = this.BuildQueryParameters(testmode: testmode);
+
+            return await this.GetListAsync<ListResponse<RefundResponse>>($"payments/{paymentId}/refunds", from, limit, queryParameters).ConfigureAwait(false);
         }
 
         public async Task<RefundResponse> GetRefundAsync(UrlObjectLink<RefundResponse> url) {
             return await this.GetAsync(url).ConfigureAwait(false);
         }
 
-        public async Task<RefundResponse> GetRefundAsync(string paymentId, string refundId) {
-            return await this.GetAsync<RefundResponse>($"payments/{paymentId}/refunds/{refundId}").ConfigureAwait(false);
+        public async Task<RefundResponse> GetRefundAsync(string paymentId, string refundId, bool? testmode = default) {
+            var queryParameters = this.BuildQueryParameters(testmode: testmode);
+            return await this.GetAsync<RefundResponse>($"payments/{paymentId}/refunds/{refundId}{queryParameters.ToQueryString()}").ConfigureAwait(false);
         }
 
-        public async Task CancelRefundAsync(string paymentId, string refundId) {
-            await this.DeleteAsync($"payments/{paymentId}/refunds/{refundId}").ConfigureAwait(false);
+        public async Task CancelRefundAsync(string paymentId, string refundId, bool? testmode = default) {
+            var queryParameters = this.BuildQueryParameters(testmode: testmode);
+            await this.DeleteAsync($"payments/{paymentId}/refunds/{refundId}{queryParameters.ToQueryString()}").ConfigureAwait(false);
+        }
+        
+        private Dictionary<string, string> BuildQueryParameters(bool? testmode = false) {
+            var result = new Dictionary<string, string>();
+            result.AddValueIfTrue(nameof(testmode), testmode);
+            return result;
         }
     }
 }

--- a/Mollie.Api/Extensions/DictionaryExtensions.cs
+++ b/Mollie.Api/Extensions/DictionaryExtensions.cs
@@ -22,7 +22,13 @@ namespace Mollie.Api.Extensions {
 
         public static void AddValueIfTrue(this IDictionary<string, string> dictionary, string key, bool value) {
             if (value) {
-                dictionary.Add(key, value.ToString().ToLower());
+                dictionary.Add(key, bool.TrueString.ToLower());
+            }
+        }
+        
+        public static void AddValueIfTrue(this IDictionary<string, string> dictionary, string key, bool? value) {
+            if (value == true) {
+                dictionary.Add(key, bool.TrueString.ToLower());
             }
         }
     }


### PR DESCRIPTION
Refunds are missing the testmode option. Ran into this while developing a refund integration.