### PR TITLE
add description constructor Tokenrequest

### DIFF
--- a/Mollie.Api/Models/Connect/TokenRequest.cs
+++ b/Mollie.Api/Models/Connect/TokenRequest.cs
@@ -2,6 +2,9 @@
 
 namespace Mollie.Api.Models.Connect {
     public class TokenRequest {
+
+        /// <param name="code">This can be an authorization code or a refresh token. The correct grant type will be automatically selected</param>
+        /// <param name="redirectUri">The URL the merchant is sent back to once the request has been authorized. It must match the URL you set when registering your app. </param>
         public TokenRequest(string code, string redirectUri) {
             if (code.StartsWith("refresh_")) {
                 this.GrantType = "refresh_token";


### PR DESCRIPTION
I was confused on how to refresh the access token with a refresh token until I looked at the code.
Added a description for the constructor parameters to make it clear you can use a refresh token or a authorization code