### PR TITLE
Added support for embedding refunds and chargebacks in Payments

### DIFF
--- a/Mollie.Api/Client/Abstract/IPaymentClient.cs
+++ b/Mollie.Api/Client/Abstract/IPaymentClient.cs
@@ -8,20 +8,20 @@ namespace Mollie.Api.Client.Abstract {
     public interface IPaymentClient {
         Task<PaymentResponse> CreatePaymentAsync(PaymentRequest paymentRequest, bool includeQrCode = false);
 
-		/// <summary>
-		///		Retrieve a single payment object by its payment identifier.
-		/// </summary>
-		/// <param name="paymentId">The payment's ID, for example tr_7UhSN1zuXS.</param>
-		/// <param name="testmode">Oauth - Optional – Set this to true to get a payment made in test mode. If you omit this parameter, you can only retrieve live mode payments.</param>
-		/// <returns></returns>
-		Task<PaymentResponse> GetPaymentAsync(string paymentId, bool testmode = false, bool includeQrCode = false, bool includeRemainderDetails = false);
+        /// <summary>
+        ///		Retrieve a single payment object by its payment identifier.
+        /// </summary>
+        /// <param name="paymentId">The payment's ID, for example tr_7UhSN1zuXS.</param>
+        /// <param name="testmode">Oauth - Optional – Set this to true to get a payment made in test mode. If you omit this parameter, you can only retrieve live mode payments.</param>
+        /// <returns></returns>
+        Task<PaymentResponse> GetPaymentAsync(string paymentId, bool testmode = false, bool includeQrCode = false, bool includeRemainderDetails = false, bool embedRefunds = false, bool embedChargebacks = false);
 
         /// <summary>
         /// Some payment methods are cancellable for an amount of time, usually until the next day. Or as long as the payment status is open. Payments may be cancelled manually from the Dashboard, or automatically by using this endpoint.
         /// </summary>
         /// <param name="paymentId"></param>
         /// <returns></returns>
-	    Task DeletePaymentAsync(string paymentId);
+        Task DeletePaymentAsync(string paymentId);
 
         /// <summary>
         /// Retrieve all payments created with the current payment profile, ordered from newest to oldest.
@@ -31,7 +31,7 @@ namespace Mollie.Api.Client.Abstract {
         /// <param name="profileId"></param>
         /// <param name="testmode"></param>
         /// <returns></returns>
-		Task<ListResponse<PaymentResponse>> GetPaymentListAsync(string from = null, int? limit = null, string profileId = null, bool testmode = false, bool includeQrCode = false);
+		Task<ListResponse<PaymentResponse>> GetPaymentListAsync(string from = null, int? limit = null, string profileId = null, bool testmode = false, bool includeQrCode = false, bool embedRefunds = false, bool embedChargebacks = false);
         Task<ListResponse<PaymentResponse>> GetPaymentListAsync(UrlObjectLink<ListResponse<PaymentResponse>> url);
         Task<PaymentResponse> GetPaymentAsync(UrlObjectLink<PaymentResponse> url);
         Task<PaymentResponse> UpdatePaymentAsync(string paymentId, PaymentUpdateRequest paymentUpdateRequest);

--- a/Mollie.Tests.Unit/Client/PaymentClientTests.cs
+++ b/Mollie.Tests.Unit/Client/PaymentClientTests.cs
@@ -34,7 +34,7 @@ namespace Mollie.Tests.Unit.Client {
             mockHttp.When($"{BaseMollieClient.ApiEndPoint}*")
                 .Respond("application/json", jsonToReturnInMockResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
-            PaymentClient paymentClient = new PaymentClient("abcde", httpClient); 
+            PaymentClient paymentClient = new PaymentClient("abcde", httpClient);
 
              // When: We send the request
              PaymentResponse paymentResponse = await paymentClient.CreatePaymentAsync(paymentRequest);
@@ -42,7 +42,7 @@ namespace Mollie.Tests.Unit.Client {
             // Then
             this.AssertPaymentIsEqual(paymentRequest, paymentResponse);
         }
-        
+
         [Test]
         public async Task CreatePaymentAsync_PaymentWithSinglePaymentMethod_RequestIsSerializedInExpectedFormat() {
             // Given: We create a payment request with a single payment method
@@ -68,10 +68,10 @@ namespace Mollie.Tests.Unit.Client {
             // When: We send the request
             PaymentResponse paymentResponse = await paymentClient.CreatePaymentAsync(paymentRequest);
 
-            // Then            
+            // Then
             mockHttp.VerifyNoOutstandingExpectation();
             this.AssertPaymentIsEqual(paymentRequest, paymentResponse);
-            Assert.AreEqual(paymentRequest.Method, paymentResponse.Method);            
+            Assert.AreEqual(paymentRequest.Method, paymentResponse.Method);
         }
 
         [Test]
@@ -186,8 +186,69 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-        }        
+        }
 
+        [Test]
+        public async Task GetPaymentAsync_EmbedRefunds_QueryStringContainsEmbedRefundsParameter()
+        {
+            // Given: We make a request to retrieve a payment with embedded refunds
+            const string paymentId = "abcde";
+            var mockHttp = this.CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}?embed=refunds", defaultPaymentJsonResponse);
+            HttpClient httpClient = mockHttp.ToHttpClient();
+            PaymentClient paymentClient = new PaymentClient("abcde", httpClient);
+
+            // When: We send the request
+            await paymentClient.GetPaymentAsync(paymentId, embedRefunds: true);
+
+            // Then
+            mockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        [Test]
+        public async Task GetPaymentListAsync_EmbedRefunds_QueryStringContainsEmbedRefundsParameter()
+        {
+            // Given: We make a request to retrieve a payment with embedded refunds
+            var mockHttp = this.CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments?embed=refunds", defaultPaymentJsonResponse);
+            HttpClient httpClient = mockHttp.ToHttpClient();
+            PaymentClient paymentClient = new PaymentClient("abcde", httpClient);
+
+            // When: We send the request
+            await paymentClient.GetPaymentListAsync(embedRefunds: true);
+
+            // Then
+            mockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        [Test]
+        public async Task GetPaymentAsync_EmbedChargebacks_QueryStringContainsEmbedChargebacksParameter()
+        {
+            // Given: We make a request to retrieve a payment with embedded refunds
+            const string paymentId = "abcde";
+            var mockHttp = this.CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}?embed=chargebacks", defaultPaymentJsonResponse);
+            HttpClient httpClient = mockHttp.ToHttpClient();
+            PaymentClient paymentClient = new PaymentClient("abcde", httpClient);
+
+            // When: We send the request
+            await paymentClient.GetPaymentAsync(paymentId, embedChargebacks: true);
+
+            // Then
+            mockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        [Test]
+        public async Task GetPaymentListAsync_EmbedChargebacks_QueryStringContainsEmbedChargebacksParameter()
+        {
+            // Given: We make a request to retrieve a payment with embedded refunds
+            var mockHttp = this.CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments?embed=chargebacks", defaultPaymentJsonResponse);
+            HttpClient httpClient = mockHttp.ToHttpClient();
+            PaymentClient paymentClient = new PaymentClient("abcde", httpClient);
+
+            // When: We send the request
+            await paymentClient.GetPaymentListAsync(embedChargebacks: true);
+
+            // Then
+            mockHttp.VerifyNoOutstandingExpectation();
+        }
 
         private void AssertPaymentIsEqual(PaymentRequest paymentRequest, PaymentResponse paymentResponse) {
             Assert.AreEqual(paymentRequest.Amount.Value, paymentResponse.Amount.Value);


### PR DESCRIPTION
Added support for including an `embed` parameter to the **Get Payment** and **List Payments** API calls.