### PR TITLE
Bug or instead of and

### DIFF
--- a/Mollie.Api/Client/PaymentLinkClient.cs
+++ b/Mollie.Api/Client/PaymentLinkClient.cs
@@ -18,7 +18,7 @@ namespace Mollie.Api.Client
 
         public async Task<PaymentLinkResponse> CreatePaymentLinkAsync(PaymentLinkRequest paymentLinkRequest)
         {
-            if (!string.IsNullOrWhiteSpace(paymentLinkRequest.ProfileId) || paymentLinkRequest.Testmode.HasValue)
+            if (!string.IsNullOrWhiteSpace(paymentLinkRequest.ProfileId) && paymentLinkRequest.Testmode.HasValue)
             {
                 this.ValidateApiKeyIsOauthAccesstoken();
             }


### PR DESCRIPTION
I'm pretty sure that this should be an and. Received an oath token exception when I was using Testmode.

The ValidateApiKeyIsOauthAccesstoken should only be triggered. If the paymentLinkRequest.ProfileId is filled in. To be honest not even sure if the Testmode should be there at all.