### PR TITLE
Creditcard failures are causing deserialization errors

### DIFF
--- a/Mollie.Api/Models/Payment/Response/Specific/CreditCardPaymentResponse.cs
+++ b/Mollie.Api/Models/Payment/Response/Specific/CreditCardPaymentResponse.cs
@@ -104,7 +104,8 @@
         public const string InvalidCardNumber = "invalid_card_number";
         public const string InvalidCvv = "invalid_cvv";
         public const string InvalidCardHolderName = "invalid_card_holder_name";
-        public const string CardExpired = "CardExpired";
+        public const string CardExpired = "card_expired";
+				public const string CardDeclined = "card_declined";
         public const string InvalidCardType = "invalid_card_type";
         public const string RefusedByIssuer = "refused_by_issuer";
         public const string InsufficientFunds = "insufficient_funds";


### PR DESCRIPTION
Not all possible creditcard payment failure reasons are available which is causing deserialization errors in our software:

![image](https://user-images.githubusercontent.com/37297985/131845368-dd4046c6-e412-49b6-96ec-ec2e9c4bad5d.png)
