### PR TITLE
Add Giropay and Eps PaymentResponseDetails

### DIFF
--- a/Mollie.Api/Framework/Factories/PaymentResponseFactory.cs
+++ b/Mollie.Api/Framework/Factories/PaymentResponseFactory.cs
@@ -2,16 +2,24 @@
 using Mollie.Api.Models.Payment.Response;
 using Mollie.Api.Models.Payment.Response.Specific;
 
-namespace Mollie.Api.Framework.Factories {
-    public class PaymentResponseFactory {
-        public PaymentResponse Create(string paymentMethod) {
-            switch (paymentMethod) {
+namespace Mollie.Api.Framework.Factories
+{
+    public class PaymentResponseFactory
+    {
+        public PaymentResponse Create(string paymentMethod)
+        {
+            switch (paymentMethod)
+            {
                 case PaymentMethod.BankTransfer:
                     return new BankTransferPaymentResponse();
                 case PaymentMethod.CreditCard:
                     return new CreditCardPaymentResponse();
                 case PaymentMethod.Ideal:
                     return new IdealPaymentResponse();
+                case PaymentMethod.Giropay:
+                    return new GiropayPaymentResponse();
+                case PaymentMethod.Eps:
+                    return new EpsPaymentResponse();
                 case PaymentMethod.Bancontact:
                     return new BancontactPaymentResponse();
                 case PaymentMethod.PayPal:

--- a/Mollie.Api/Models/Payment/Response/Specific/EpsPaymentResponse.cs
+++ b/Mollie.Api/Models/Payment/Response/Specific/EpsPaymentResponse.cs
@@ -1,0 +1,28 @@
+﻿namespace Mollie.Api.Models.Payment.Response
+{
+    public class EpsPaymentResponse : PaymentResponse
+    {
+        /// <summary>
+        /// An object with the consumer bank account details.
+        /// </summary>
+        public EpsPaymentResponseDetails Details { get; set; }
+    }
+
+    public class EpsPaymentResponseDetails
+    {
+        /// <summary>
+        /// Only available if the payment has been completed – The consumer's name.
+        /// </summary>
+        public string ConsumerName { get; set; }
+
+        /// <summary>
+        /// Only available if the payment has been completed – The consumer's IBAN.
+        /// </summary>
+        public string ConsumerAccount { get; set; }
+
+        /// <summary>
+        /// Only available if the payment has been completed – The consumer's bank's BIC.
+        /// </summary>
+        public string ConsumerBic { get; set; }
+    }
+}

--- a/Mollie.Api/Models/Payment/Response/Specific/GiropayPaymentResponse.cs
+++ b/Mollie.Api/Models/Payment/Response/Specific/GiropayPaymentResponse.cs
@@ -1,0 +1,28 @@
+﻿namespace Mollie.Api.Models.Payment.Response
+{
+    public class GiropayPaymentResponse : PaymentResponse
+    {
+        /// <summary>
+        /// An object with the consumer bank account details.
+        /// </summary>
+        public GiropayPaymentResponseDetails Details { get; set; }
+    }
+
+    public class GiropayPaymentResponseDetails
+    {
+        /// <summary>
+        /// Only available if the payment has been completed – The consumer's name.
+        /// </summary>
+        public string ConsumerName { get; set; }
+
+        /// <summary>
+        /// Only available if the payment has been completed – The consumer's IBAN.
+        /// </summary>
+        public string ConsumerAccount { get; set; }
+
+        /// <summary>
+        /// Only available if the payment has been completed – The consumer's bank's BIC.
+        /// </summary>
+        public string ConsumerBic { get; set; }
+    }
+}


### PR DESCRIPTION
The Giropay and Eps PaymentResponseDetails are missing.

According to Mollie technical support it is missing from the documentation but the data is returned by the API.

-- Dutch email from Mollie technical support --
We "spraken" elkaar onlangs via Mollie chat over de specificaties van de Live API key.
 
Jouw vraag was of consumerName, consumerAccount, en consumerBic ook in de Live API key staan. Ik heb dit uitgezocht via onze Tech Support en nu antwoord op gekregen. Het antwoord is dat deze inderdaad in de Live API key staan, ook voor de betaalmethoden EPS en Giropay. Kortom, wat je zag bij de Test API key, zul je ook zien bij de Live API key. Mocht er nog iets anders zijn waarmee ik je van dienst kan zijn, dan hoor ik dat graag. Voor nu wens ik je nog een fijne dag verder.