### PR TITLE
Fix link to Mollie API doc index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MollieApi
 ![](https://github.com/Viincenttt/MollieApi/workflows/Run%20automated%20tests/badge.svg)
 
-This project allows you to easily add the [Mollie payment provider](https://www.mollie.com) to your application. Mollie has excellent [documentation](https://www.mollie.com/nl/docs/overzicht) which I highly recommend you read before using this library. 
+This project allows you to easily add the [Mollie payment provider](https://www.mollie.com) to your application. Mollie has excellent [documentation](https://docs.mollie.com/) which I highly recommend you read before using this library. 
 
 ## Support
 If you have encounter any issues while using this library or have any feature requests, feel free to open an issue on GitHub. If you need help integrating the Mollie API into your .NET application, please contact me on [LinkedIn](https://www.linkedin.com/in/vincent-kok-4aa44211/). 


### PR DESCRIPTION
Replaces an outdated link to the Mollie API doc index with the current one.