### PR TITLE
Add list methods that accept UrlObjectLink<>

### DIFF
--- a/Mollie.Api/Client/Abstract/IRefundClient.cs
+++ b/Mollie.Api/Client/Abstract/IRefundClient.cs
@@ -9,6 +9,7 @@ namespace Mollie.Api.Client.Abstract {
         Task<RefundResponse> CreateRefundAsync(string paymentId, RefundRequest refundRequest);
         Task<RefundResponse> GetRefundAsync(string paymentId, string refundId, bool testmode = false);
         Task<ListResponse<RefundResponse>> GetRefundListAsync(string paymentId, string from = null, int? limit = null, bool testmode = false);
+        Task<ListResponse<RefundResponse>> GetRefundListAsync(UrlObjectLink<ListResponse<RefundResponse>> url);
         Task<RefundResponse> GetRefundAsync(UrlObjectLink<RefundResponse> url);
     }
 }

--- a/Mollie.Api/Client/Abstract/ISettlementsClient.cs
+++ b/Mollie.Api/Client/Abstract/ISettlementsClient.cs
@@ -13,9 +13,13 @@ namespace Mollie.Api.Client.Abstract {
         Task<SettlementResponse> GetNextSettlement();
         Task<SettlementResponse> GetOpenSettlement();
         Task<ListResponse<SettlementResponse>> GetSettlementsListAsync(string reference = null, string from = null, int? limit = null);
+        Task<ListResponse<SettlementResponse>> GetSettlementsListAsync(UrlObjectLink<ListResponse<SettlementResponse>> url);
         Task<ListResponse<PaymentResponse>> GetSettlementPaymentsListAsync(string settlementId, string from = null, int? limit = null);
+        Task<ListResponse<PaymentResponse>> GetSettlementPaymentsListAsync(UrlObjectLink<ListResponse<PaymentResponse>> url);
         Task<ListResponse<RefundResponse>> GetSettlementRefundsListAsync(string settlementId, string from = null, int? limit = null);
+        Task<ListResponse<RefundResponse>> GetSettlementRefundsListAsync(UrlObjectLink<ListResponse<RefundResponse>> url);
         Task<ListResponse<ChargebackResponse>> GetSettlementChargebacksListAsync(string settlementId, string from = null, int? limit = null);
+        Task<ListResponse<ChargebackResponse>> GetSettlementChargebacksListAsync(UrlObjectLink<ListResponse<ChargebackResponse>> url);
         Task<SettlementResponse> GetSettlementAsync(UrlObjectLink<SettlementResponse> url);
         Task<ListResponse<CaptureResponse>> ListSettlementCapturesAsync(string settlementId);
     }

--- a/Mollie.Api/Client/RefundClient.cs
+++ b/Mollie.Api/Client/RefundClient.cs
@@ -36,6 +36,11 @@ namespace Mollie.Api.Client {
             return await this.GetListAsync<ListResponse<RefundResponse>>($"payments/{paymentId}/refunds", from, limit, queryParameters).ConfigureAwait(false);
         }
 
+        public async Task<ListResponse<RefundResponse>> GetRefundListAsync(UrlObjectLink<ListResponse<RefundResponse>> url)
+        {
+            return await this.GetAsync(url).ConfigureAwait(false);
+        }
+
         public async Task<RefundResponse> GetRefundAsync(UrlObjectLink<RefundResponse> url) {
             return await this.GetAsync(url).ConfigureAwait(false);
         }

--- a/Mollie.Api/Client/SettlementsClient.cs
+++ b/Mollie.Api/Client/SettlementsClient.cs
@@ -32,9 +32,19 @@ namespace Mollie.Api.Client {
             return await this.GetListAsync<ListResponse<SettlementResponse>>($"settlements{queryString}", offset, count).ConfigureAwait(false);
         }
 
+        public async Task<ListResponse<SettlementResponse>> GetSettlementsListAsync(UrlObjectLink<ListResponse<SettlementResponse>> url)
+        {
+            return await this.GetAsync(url).ConfigureAwait(false);
+        }
+
         public async Task<ListResponse<PaymentResponse>> GetSettlementPaymentsListAsync(string settlementId, string offset = null, int? count = null) {
             this.ValidateRequiredUrlParameter(nameof(settlementId), settlementId);
             return await this.GetListAsync<ListResponse<PaymentResponse>>($"settlements/{settlementId}/payments", offset, count).ConfigureAwait(false);
+        }
+
+        public async Task<ListResponse<PaymentResponse>> GetSettlementPaymentsListAsync(UrlObjectLink<ListResponse<PaymentResponse>> url)
+        {
+            return await this.GetAsync(url).ConfigureAwait(false);
         }
 
         public async Task<ListResponse<RefundResponse>> GetSettlementRefundsListAsync(string settlementId, string offset = null, int? count = null) {
@@ -42,9 +52,19 @@ namespace Mollie.Api.Client {
             return await this.GetListAsync<ListResponse<RefundResponse>>($"settlements/{settlementId}/refunds", offset, count).ConfigureAwait(false);
         }
 
+        public async Task<ListResponse<RefundResponse>> GetSettlementRefundsListAsync(UrlObjectLink<ListResponse<RefundResponse>> url)
+        {
+            return await this.GetAsync(url).ConfigureAwait(false);
+        }
+
         public async Task<ListResponse<ChargebackResponse>> GetSettlementChargebacksListAsync(string settlementId, string offset = null, int? count = null) {
             this.ValidateRequiredUrlParameter(nameof(settlementId), settlementId);
             return await this.GetListAsync<ListResponse<ChargebackResponse>>($"settlements/{settlementId}/chargebacks", offset, count).ConfigureAwait(false);
+        }
+
+        public async Task<ListResponse<ChargebackResponse>> GetSettlementChargebacksListAsync(UrlObjectLink<ListResponse<ChargebackResponse>> url)
+        {
+            return await this.GetAsync(url).ConfigureAwait(false);
         }
 
         public async Task<SettlementResponse> GetSettlementAsync(UrlObjectLink<SettlementResponse> url) {


### PR DESCRIPTION
I added some helper methods that accept the UrlObjectLinks so paging is easier with the Links.Next url.