### PR TITLE
Add missing point PointOfSalePaymentResponseDetails properties

### DIFF
--- a/src/Mollie.Api/Models/Payment/Response/Specific/PointOfSalePaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/Specific/PointOfSalePaymentResponse.cs
@@ -1,9 +1,47 @@
 ﻿namespace Mollie.Api.Models.Payment.Response.Specific {
     public class PointOfSalePaymentResponse : PaymentResponse {
+        /// <summary>
+        /// An object with payment details.
+        /// </summary>
         public PointOfSalePaymentResponseDetails Details { get; set; }
     }
     
     public class PointOfSalePaymentResponseDetails {
+        /// <summary>
+        /// The identifier referring to the terminal this payment was created for. For example, term_utGtYu756h.
+        /// </summary>
         public string TerminalId { get; set; }
+        
+        /// <summary>
+        /// Only available if the payment has been completed - The last four digits of the card number.
+        /// </summary>
+        public string CardNumber { get; set; }
+        
+        /// <summary>
+        /// Only available if the payment has been completed - Unique alphanumeric representation of card, usable for
+        /// identifying returning customers.
+        /// </summary>
+        public string CardFingerprint { get; set; }
+        
+        /// <summary>
+        /// Only available if the payment has been completed and if the data is available - The card’s target audience.
+        ///
+        /// Check the Mollie.Api.Models.Payment.Response.CreditCardAudience class for a full list of known values.
+        /// </summary>
+        public string CardAudience { get; set; }
+        
+        /// <summary>
+        /// Only available if the payment has been completed - The card’s label. Note that not all labels can be
+        /// processed through Mollie.
+        ///
+        ///  Check the Mollie.Api.Models.Payment.Response.CreditCardLabel class for a full list of known values.
+        /// </summary>
+        public string CardLabel { get; set; }
+        
+        /// <summary>
+        /// Only available if the payment has been completed - The ISO 3166-1 alpha-2 country code of the country
+        /// the card was issued in. For example: BE.
+        /// </summary>
+        public string CardCountryCode { get; set; }
     }
 }

--- a/tests/Mollie.Tests.Integration/Api/PaymentTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/PaymentTests.cs
@@ -460,6 +460,11 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
             response.Should().BeOfType<PointOfSalePaymentResponse>();
             PointOfSalePaymentResponse posResponse = (PointOfSalePaymentResponse)response;
             posResponse.Details.TerminalId.Should().Be(paymentRequest.TerminalId);
+            posResponse.Details.CardNumber.Should().BeNull();
+            posResponse.Details.CardFingerprint.Should().BeNull();
+            posResponse.Details.CardAudience.Should().BeNull();
+            posResponse.Details.CardLabel.Should().BeNull();
+            posResponse.Details.CardCountryCode.Should().BeNull();
             posResponse.Method.Should().Be(PaymentMethod.PointOfSale);
         }
     }


### PR DESCRIPTION
Add support for the following properties in Point Of Sale details object:
- CardNumber
- CardFingerprint
- CardAudience
- CardLabel
- CardCountryCode