### PR TITLE
Bugfix: Use the retrypolicy from the options when available

### DIFF
--- a/src/Mollie.Api/DependencyInjection.cs
+++ b/src/Mollie.Api/DependencyInjection.cs
@@ -9,68 +9,71 @@ using Polly;
 namespace Mollie.Api {
     public static class DependencyInjection {
         public static IServiceCollection AddMollieApi(
-            this IServiceCollection services, 
+            this IServiceCollection services,
             Action<MollieOptions> mollieOptionsDelegate,
             IAsyncPolicy<HttpResponseMessage> retryPolicy = null) {
 
             MollieOptions mollieOptions = new MollieOptions();
             mollieOptionsDelegate.Invoke(mollieOptions);
-            
-            RegisterMollieApiClient<IBalanceClient, BalanceClient>(services, httpClient => 
+
+            if (retryPolicy is null && mollieOptions.RetryPolicy is not null)
+                retryPolicy = mollieOptions.RetryPolicy;
+
+            RegisterMollieApiClient<IBalanceClient, BalanceClient>(services, httpClient =>
                 new BalanceClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<ICaptureClient, CaptureClient>(services, httpClient => 
+            RegisterMollieApiClient<ICaptureClient, CaptureClient>(services, httpClient =>
                 new CaptureClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IChargebacksClient, ChargebacksClient>(services, httpClient => 
+            RegisterMollieApiClient<IChargebacksClient, ChargebacksClient>(services, httpClient =>
                 new ChargebacksClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IConnectClient, ConnectClient>(services, httpClient => 
+            RegisterMollieApiClient<IConnectClient, ConnectClient>(services, httpClient =>
                 new ConnectClient(mollieOptions.ClientId, mollieOptions.ClientSecret, httpClient), retryPolicy);
-            RegisterMollieApiClient<ICustomerClient, CustomerClient>(services, httpClient => 
+            RegisterMollieApiClient<ICustomerClient, CustomerClient>(services, httpClient =>
                 new CustomerClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IInvoicesClient, InvoicesClient>(services, httpClient => 
+            RegisterMollieApiClient<IInvoicesClient, InvoicesClient>(services, httpClient =>
                 new InvoicesClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IMandateClient, MandateClient>(services, httpClient => 
+            RegisterMollieApiClient<IMandateClient, MandateClient>(services, httpClient =>
                 new MandateClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IOnboardingClient, OnboardingClient>(services, httpClient => 
+            RegisterMollieApiClient<IOnboardingClient, OnboardingClient>(services, httpClient =>
                 new OnboardingClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IOrderClient, OrderClient>(services, httpClient => 
+            RegisterMollieApiClient<IOrderClient, OrderClient>(services, httpClient =>
                 new OrderClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IOrganizationsClient, OrganizationsClient>(services, httpClient => 
+            RegisterMollieApiClient<IOrganizationsClient, OrganizationsClient>(services, httpClient =>
                 new OrganizationsClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IPaymentClient, PaymentClient>(services, httpClient => 
+            RegisterMollieApiClient<IPaymentClient, PaymentClient>(services, httpClient =>
                 new PaymentClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IPaymentLinkClient, PaymentLinkClient>(services, httpClient => 
+            RegisterMollieApiClient<IPaymentLinkClient, PaymentLinkClient>(services, httpClient =>
                 new PaymentLinkClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IPaymentMethodClient, PaymentMethodClient>(services, httpClient => 
+            RegisterMollieApiClient<IPaymentMethodClient, PaymentMethodClient>(services, httpClient =>
                 new PaymentMethodClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IPermissionsClient, PermissionsClient>(services, httpClient => 
+            RegisterMollieApiClient<IPermissionsClient, PermissionsClient>(services, httpClient =>
                 new PermissionsClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IProfileClient, ProfileClient>(services, httpClient => 
+            RegisterMollieApiClient<IProfileClient, ProfileClient>(services, httpClient =>
                 new ProfileClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IRefundClient, RefundClient>(services, httpClient => 
+            RegisterMollieApiClient<IRefundClient, RefundClient>(services, httpClient =>
                 new RefundClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<ISettlementsClient, SettlementsClient>(services, httpClient => 
+            RegisterMollieApiClient<ISettlementsClient, SettlementsClient>(services, httpClient =>
                 new SettlementsClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IShipmentClient, ShipmentClient>(services, httpClient => 
+            RegisterMollieApiClient<IShipmentClient, ShipmentClient>(services, httpClient =>
                 new ShipmentClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<ISubscriptionClient, SubscriptionClient>(services, httpClient => 
+            RegisterMollieApiClient<ISubscriptionClient, SubscriptionClient>(services, httpClient =>
                 new SubscriptionClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<ITerminalClient, TerminalClient>(services, httpClient => 
+            RegisterMollieApiClient<ITerminalClient, TerminalClient>(services, httpClient =>
                 new TerminalClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IClientLinkClient, ClientLinkClient>(services, httpClient => 
+            RegisterMollieApiClient<IClientLinkClient, ClientLinkClient>(services, httpClient =>
                 new ClientLinkClient(mollieOptions.ClientId, mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IWalletClient, WalletClient>(services, httpClient => 
+            RegisterMollieApiClient<IWalletClient, WalletClient>(services, httpClient =>
                 new WalletClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            
+
             return services;
         }
 
         static void RegisterMollieApiClient<TInterface, TImplementation>(
             IServiceCollection services,
             Func<HttpClient, TImplementation> factory,
-            IAsyncPolicy<HttpResponseMessage> retryPolicy = null) 
+            IAsyncPolicy<HttpResponseMessage> retryPolicy = null)
             where TInterface : class
             where TImplementation : class, TInterface {
-            
+
             IHttpClientBuilder clientBuilder = services.AddHttpClient<TInterface, TImplementation>(factory);
             if (retryPolicy != null) {
                 clientBuilder.AddPolicyHandler(retryPolicy);

--- a/src/Mollie.Api/DependencyInjection.cs
+++ b/src/Mollie.Api/DependencyInjection.cs
@@ -16,8 +16,9 @@ namespace Mollie.Api {
             MollieOptions mollieOptions = new MollieOptions();
             mollieOptionsDelegate.Invoke(mollieOptions);
 
-            if (retryPolicy is null && mollieOptions.RetryPolicy is not null)
+            if (retryPolicy == null && mollieOptions.RetryPolicy != null) { 
                 retryPolicy = mollieOptions.RetryPolicy;
+            }
 
             RegisterMollieApiClient<IBalanceClient, BalanceClient>(services, httpClient =>
                 new BalanceClient(mollieOptions.ApiKey, httpClient), retryPolicy);

--- a/src/Mollie.Api/DependencyInjection.cs
+++ b/src/Mollie.Api/DependencyInjection.cs
@@ -9,14 +9,14 @@ using Polly;
 namespace Mollie.Api {
     public static class DependencyInjection {
         public static IServiceCollection AddMollieApi(
-            this IServiceCollection services,
+            this IServiceCollection services, 
             Action<MollieOptions> mollieOptionsDelegate,
             IAsyncPolicy<HttpResponseMessage> retryPolicy = null) {
 
             MollieOptions mollieOptions = new MollieOptions();
             mollieOptionsDelegate.Invoke(mollieOptions);
 
-            if (retryPolicy == null && mollieOptions.RetryPolicy != null) { 
+            if (retryPolicy == null && mollieOptions.RetryPolicy != null) {
                 retryPolicy = mollieOptions.RetryPolicy;
             }
 
@@ -64,17 +64,17 @@ namespace Mollie.Api {
                 new ClientLinkClient(mollieOptions.ClientId, mollieOptions.ApiKey, httpClient), retryPolicy);
             RegisterMollieApiClient<IWalletClient, WalletClient>(services, httpClient =>
                 new WalletClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-
+            
             return services;
         }
 
         static void RegisterMollieApiClient<TInterface, TImplementation>(
             IServiceCollection services,
             Func<HttpClient, TImplementation> factory,
-            IAsyncPolicy<HttpResponseMessage> retryPolicy = null)
+            IAsyncPolicy<HttpResponseMessage> retryPolicy = null) 
             where TInterface : class
             where TImplementation : class, TInterface {
-
+            
             IHttpClientBuilder clientBuilder = services.AddHttpClient<TInterface, TImplementation>(factory);
             if (retryPolicy != null) {
                 clientBuilder.AddPolicyHandler(retryPolicy);

--- a/src/Mollie.Api/DependencyInjection.cs
+++ b/src/Mollie.Api/DependencyInjection.cs
@@ -16,7 +16,7 @@ namespace Mollie.Api {
             MollieOptions mollieOptions = new MollieOptions();
             mollieOptionsDelegate.Invoke(mollieOptions);
 
-            if (retryPolicy == null && mollieOptions.RetryPolicy != null) {
+            if (retryPolicy == null) {
                 retryPolicy = mollieOptions.RetryPolicy;
             }
 

--- a/src/Mollie.Api/DependencyInjection.cs
+++ b/src/Mollie.Api/DependencyInjection.cs
@@ -20,49 +20,49 @@ namespace Mollie.Api {
                 retryPolicy = mollieOptions.RetryPolicy;
             }
 
-            RegisterMollieApiClient<IBalanceClient, BalanceClient>(services, httpClient =>
+            RegisterMollieApiClient<IBalanceClient, BalanceClient>(services, httpClient => 
                 new BalanceClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<ICaptureClient, CaptureClient>(services, httpClient =>
+            RegisterMollieApiClient<ICaptureClient, CaptureClient>(services, httpClient => 
                 new CaptureClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IChargebacksClient, ChargebacksClient>(services, httpClient =>
+            RegisterMollieApiClient<IChargebacksClient, ChargebacksClient>(services, httpClient => 
                 new ChargebacksClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IConnectClient, ConnectClient>(services, httpClient =>
+            RegisterMollieApiClient<IConnectClient, ConnectClient>(services, httpClient => 
                 new ConnectClient(mollieOptions.ClientId, mollieOptions.ClientSecret, httpClient), retryPolicy);
-            RegisterMollieApiClient<ICustomerClient, CustomerClient>(services, httpClient =>
+            RegisterMollieApiClient<ICustomerClient, CustomerClient>(services, httpClient => 
                 new CustomerClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IInvoicesClient, InvoicesClient>(services, httpClient =>
+            RegisterMollieApiClient<IInvoicesClient, InvoicesClient>(services, httpClient => 
                 new InvoicesClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IMandateClient, MandateClient>(services, httpClient =>
+            RegisterMollieApiClient<IMandateClient, MandateClient>(services, httpClient => 
                 new MandateClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IOnboardingClient, OnboardingClient>(services, httpClient =>
+            RegisterMollieApiClient<IOnboardingClient, OnboardingClient>(services, httpClient => 
                 new OnboardingClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IOrderClient, OrderClient>(services, httpClient =>
+            RegisterMollieApiClient<IOrderClient, OrderClient>(services, httpClient => 
                 new OrderClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IOrganizationsClient, OrganizationsClient>(services, httpClient =>
+            RegisterMollieApiClient<IOrganizationsClient, OrganizationsClient>(services, httpClient => 
                 new OrganizationsClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IPaymentClient, PaymentClient>(services, httpClient =>
+            RegisterMollieApiClient<IPaymentClient, PaymentClient>(services, httpClient => 
                 new PaymentClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IPaymentLinkClient, PaymentLinkClient>(services, httpClient =>
+            RegisterMollieApiClient<IPaymentLinkClient, PaymentLinkClient>(services, httpClient => 
                 new PaymentLinkClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IPaymentMethodClient, PaymentMethodClient>(services, httpClient =>
+            RegisterMollieApiClient<IPaymentMethodClient, PaymentMethodClient>(services, httpClient => 
                 new PaymentMethodClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IPermissionsClient, PermissionsClient>(services, httpClient =>
+            RegisterMollieApiClient<IPermissionsClient, PermissionsClient>(services, httpClient => 
                 new PermissionsClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IProfileClient, ProfileClient>(services, httpClient =>
+            RegisterMollieApiClient<IProfileClient, ProfileClient>(services, httpClient => 
                 new ProfileClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IRefundClient, RefundClient>(services, httpClient =>
+            RegisterMollieApiClient<IRefundClient, RefundClient>(services, httpClient => 
                 new RefundClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<ISettlementsClient, SettlementsClient>(services, httpClient =>
+            RegisterMollieApiClient<ISettlementsClient, SettlementsClient>(services, httpClient => 
                 new SettlementsClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IShipmentClient, ShipmentClient>(services, httpClient =>
+            RegisterMollieApiClient<IShipmentClient, ShipmentClient>(services, httpClient => 
                 new ShipmentClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<ISubscriptionClient, SubscriptionClient>(services, httpClient =>
+            RegisterMollieApiClient<ISubscriptionClient, SubscriptionClient>(services, httpClient => 
                 new SubscriptionClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<ITerminalClient, TerminalClient>(services, httpClient =>
+            RegisterMollieApiClient<ITerminalClient, TerminalClient>(services, httpClient => 
                 new TerminalClient(mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IClientLinkClient, ClientLinkClient>(services, httpClient =>
+            RegisterMollieApiClient<IClientLinkClient, ClientLinkClient>(services, httpClient => 
                 new ClientLinkClient(mollieOptions.ClientId, mollieOptions.ApiKey, httpClient), retryPolicy);
-            RegisterMollieApiClient<IWalletClient, WalletClient>(services, httpClient =>
+            RegisterMollieApiClient<IWalletClient, WalletClient>(services, httpClient => 
                 new WalletClient(mollieOptions.ApiKey, httpClient), retryPolicy);
             
             return services;


### PR DESCRIPTION
Currently, you can set the retry policy in the `Action<MollieOptions> mollieOptionsDelegate` when calling the `AddMollieApi`, but the `RetryPolicy` property of the options is never used. Instead the `retryPolicy` (optional) parameter is used (if provided).

This PR adds an `if` statement that checks if the retryPolicy is not yet set, if so, the use the policy from the options.

As shown in the screenshot: The property is only set in the entire solution, but never used.
![Screenshot showing no usage of property](https://github.com/Viincenttt/MollieApi/assets/18616295/de47a5f9-1264-441d-8796-7e7b3b7c037f)

Current workaround:

Don't use the `RetryPolicy` property, but use the available optional parameter.
```
builder.Services.AddMollieApi(options =>
{
    options.ApiKey = builder.Configuration["Mollie:ApiKey"];
}, MollieHttpRetryPolicies.TransientHttpErrorRetryPolicy());
```