### PR TITLE
Remove the optional retryPolicy parameter from AddMollieApi

### DIFF
--- a/src/Mollie.Api/DependencyInjection.cs
+++ b/src/Mollie.Api/DependencyInjection.cs
@@ -9,57 +9,56 @@ using Polly;
 namespace Mollie.Api {
     public static class DependencyInjection {
         public static IServiceCollection AddMollieApi(
-            this IServiceCollection services, 
-            Action<MollieOptions> mollieOptionsDelegate,
-            IAsyncPolicy<HttpResponseMessage> retryPolicy = null) {
+            this IServiceCollection services,
+            Action<MollieOptions> mollieOptionsDelegate) {
 
             MollieOptions mollieOptions = new MollieOptions();
             mollieOptionsDelegate.Invoke(mollieOptions);
             
             RegisterMollieApiClient<IBalanceClient, BalanceClient>(services, httpClient => 
-                new BalanceClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new BalanceClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<ICaptureClient, CaptureClient>(services, httpClient => 
-                new CaptureClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new CaptureClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IChargebacksClient, ChargebacksClient>(services, httpClient => 
-                new ChargebacksClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new ChargebacksClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IConnectClient, ConnectClient>(services, httpClient => 
-                new ConnectClient(mollieOptions.ClientId, mollieOptions.ClientSecret, httpClient), retryPolicy);
+                new ConnectClient(mollieOptions.ClientId, mollieOptions.ClientSecret, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<ICustomerClient, CustomerClient>(services, httpClient => 
-                new CustomerClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new CustomerClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IInvoicesClient, InvoicesClient>(services, httpClient => 
-                new InvoicesClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new InvoicesClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IMandateClient, MandateClient>(services, httpClient => 
-                new MandateClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new MandateClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IOnboardingClient, OnboardingClient>(services, httpClient => 
-                new OnboardingClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new OnboardingClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IOrderClient, OrderClient>(services, httpClient => 
-                new OrderClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new OrderClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IOrganizationsClient, OrganizationsClient>(services, httpClient => 
-                new OrganizationsClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new OrganizationsClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IPaymentClient, PaymentClient>(services, httpClient => 
-                new PaymentClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new PaymentClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IPaymentLinkClient, PaymentLinkClient>(services, httpClient => 
-                new PaymentLinkClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new PaymentLinkClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IPaymentMethodClient, PaymentMethodClient>(services, httpClient => 
-                new PaymentMethodClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new PaymentMethodClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IPermissionsClient, PermissionsClient>(services, httpClient => 
-                new PermissionsClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new PermissionsClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IProfileClient, ProfileClient>(services, httpClient => 
-                new ProfileClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new ProfileClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IRefundClient, RefundClient>(services, httpClient => 
-                new RefundClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new RefundClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<ISettlementsClient, SettlementsClient>(services, httpClient => 
-                new SettlementsClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new SettlementsClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IShipmentClient, ShipmentClient>(services, httpClient => 
-                new ShipmentClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new ShipmentClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<ISubscriptionClient, SubscriptionClient>(services, httpClient => 
-                new SubscriptionClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new SubscriptionClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<ITerminalClient, TerminalClient>(services, httpClient => 
-                new TerminalClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new TerminalClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IClientLinkClient, ClientLinkClient>(services, httpClient => 
-                new ClientLinkClient(mollieOptions.ClientId, mollieOptions.ApiKey, httpClient), retryPolicy);
+                new ClientLinkClient(mollieOptions.ClientId, mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IWalletClient, WalletClient>(services, httpClient => 
-                new WalletClient(mollieOptions.ApiKey, httpClient), retryPolicy);
+                new WalletClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
             
             return services;
         }


### PR DESCRIPTION
As requested in #354 removed the optional `retryPolicy` parameter in favor of the `MollieOptions.RetryPolicy`.