### PR TITLE
Replace init with set in all models

### DIFF
--- a/src/Mollie.Api/Models/Amount.cs
+++ b/src/Mollie.Api/Models/Amount.cs
@@ -15,12 +15,12 @@ namespace Mollie.Api.Models {
         /// <summary>
         /// An ISO 4217 currency code. The currencies supported depend on the payment methods that are enabled on your account.
         /// </summary>
-        public required string Currency { get; init; }
+        public required string Currency { get; set; }
 
         /// <summary>
         /// An ISO 4217 currency code. The currencies supported depend on the payment methods that are enabled on your account.
         /// </summary>
-        public required string Value { get; init; }
+        public required string Value { get; set; }
 
         [JsonConstructor]
         [SetsRequiredMembers]

--- a/src/Mollie.Api/Models/ApplicationFee.cs
+++ b/src/Mollie.Api/Models/ApplicationFee.cs
@@ -3,11 +3,11 @@
 		/// <summary>
 		///	The amount in EURO that the app wants to charge, e.g. 10.00 if the app would want to charge €10.00.
 		/// </summary>
-		public required Amount Amount { get; init; }
+		public required Amount Amount { get; set; }
 
 		/// <summary>
 		///	The description of the application fee. This will appear on settlement reports to the merchant and to you.
 		/// </summary>
-		public required string Description { get; init; }
+		public required string Description { get; set; }
 	}
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceReport/BalanceReportAmount.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceReport/BalanceReportAmount.cs
@@ -1,7 +1,7 @@
 ﻿namespace Mollie.Api.Models.Balance.Response.BalanceReport {
     public record BalanceReportAmount {
-        public required Amount Amount { get; init; }
-        
+        public required Amount Amount { get; set; }
+
         public override string ToString() {
             return Amount.ToString();
         }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceReport/BalanceReportAmountWithSubtotals.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceReport/BalanceReportAmountWithSubtotals.cs
@@ -2,6 +2,6 @@
 
 namespace Mollie.Api.Models.Balance.Response.BalanceReport {
     public record BalanceReportAmountWithSubtotals : BalanceReportAmount {
-        public required IEnumerable<BalanceReportSubtotals> Subtotals { get; init; }
+        public required IEnumerable<BalanceReportSubtotals> Subtotals { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceReport/BalanceReportLinks.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceReport/BalanceReportLinks.cs
@@ -5,11 +5,11 @@ namespace Mollie.Api.Models.Balance.Response.BalanceReport {
         /// <summary>
         /// The API resource URL of the balance report itself.
         /// </summary>
-        public required UrlObjectLink<BalanceReportResponse> Self { get; init; }
-        
+        public required UrlObjectLink<BalanceReportResponse> Self { get; set; }
+
         /// <summary>
         /// The URL to the order retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceReport/BalanceReportResponse.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceReport/BalanceReportResponse.cs
@@ -6,30 +6,30 @@ namespace Mollie.Api.Models.Balance.Response.BalanceReport {
         /// <summary>
         /// Indicates the response contains a balance report object. Will always contain balance-report for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
-        
+        public required string Resource { get; set; }
+
         /// <summary>
         /// The ID of a Balance this report is generated for.
         /// </summary>
-        public required string BalanceId { get; init; }
-        
+        public required string BalanceId { get; set; }
+
         /// <summary>
         /// The time zone used for the from and until parameters. Currently only time zone Europe/Amsterdam is supported.
         /// </summary>
-        public required string TimeZone { get; init; }
-        
+        public required string TimeZone { get; set; }
+
         /// <summary>
         /// The start date of the report, in YYYY-MM-DD format. The from date is ‘inclusive’, and in Central European Time.
         /// This means a report with for example from: 2020-01-01 will include movements of 2020-01-01 0:00:00 CET and onwards.
         /// </summary>
-        public required DateTime From { get; init; }
-        
+        public required DateTime From { get; set; }
+
         /// <summary>
         /// The end date of the report, in YYYY-MM-DD format. The until date is ‘exclusive’, and in Central European Time.
         /// This means a report with for example until: 2020-02-01 will include movements up until 2020-01-31 23:59:59 CET.
         /// </summary>
-        public required DateTime Until { get; init; }
-        
+        public required DateTime Until { get; set; }
+
         /// <summary>
         /// You can retrieve reports in two different formats. With the status-balances format, transactions are grouped by status
         /// (e.g. pending, available), then by direction of movement (e.g. moved from pending to available), then by transaction type,
@@ -41,12 +41,12 @@ namespace Mollie.Api.Models.Balance.Response.BalanceReport {
         /// Both reporting formats will always contain opening and closing amounts that correspond to the start and end dates of the report.
         /// Possible values: status-balances transaction-categories
         /// </summary>
-        public required string Grouping { get; init; }
-        
+        public required string Grouping { get; set; }
+
         /// <summary>
         /// An object with several URL objects relevant to the balance report.
         /// </summary>
         [JsonProperty("_links")]
-        public required BalanceReportLinks Links { get; init; }
+        public required BalanceReportLinks Links { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceReport/BalanceReportSubtotals.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceReport/BalanceReportSubtotals.cs
@@ -4,10 +4,10 @@ namespace Mollie.Api.Models.Balance.Response.BalanceReport {
     public record BalanceReportSubtotals {
         public string? TransactionType { get; set; }
         public string? Method { get; set; }
-        public string? PrepaymentPartType { get; init; }
-        public required string FeeType { get; init; }
-        public required int Count { get; init; }
-        public required Amount Amount { get; init; }
+        public string? PrepaymentPartType { get; set; }
+        public required string FeeType { get; set; }
+        public required int Count { get; set; }
+        public required Amount Amount { get; set; }
         public IEnumerable<BalanceReportSubtotals>? Subtotals { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/StatusBalance/StatusBalanceAvailableBalance.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/StatusBalance/StatusBalanceAvailableBalance.cs
@@ -1,8 +1,8 @@
 ﻿namespace Mollie.Api.Models.Balance.Response.BalanceReport.Specific.StatusBalance {
     public record StatusBalanceAvailableBalance {
-        public required BalanceReportAmount Open { get; init; }
-        public required BalanceReportAmount Close { get; init; }
-        public required BalanceReportAmountWithSubtotals MovedFromPending { get; init; }
-        public required BalanceReportAmountWithSubtotals ImmediatelyAvailable { get; init; }
+        public required BalanceReportAmount Open { get; set; }
+        public required BalanceReportAmount Close { get; set; }
+        public required BalanceReportAmountWithSubtotals MovedFromPending { get; set; }
+        public required BalanceReportAmountWithSubtotals ImmediatelyAvailable { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/StatusBalance/StatusBalanceReportResponse.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/StatusBalance/StatusBalanceReportResponse.cs
@@ -1,5 +1,5 @@
 ﻿namespace Mollie.Api.Models.Balance.Response.BalanceReport.Specific.StatusBalance {
     public record StatusBalanceReportResponse : BalanceReportResponse {
-        public required StatusBalancesTotal Totals { get; init; }
+        public required StatusBalancesTotal Totals { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/StatusBalance/StatusBalancesPendingBalance.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/StatusBalance/StatusBalancesPendingBalance.cs
@@ -1,8 +1,8 @@
 ﻿namespace Mollie.Api.Models.Balance.Response.BalanceReport.Specific.StatusBalance {
     public record StatusBalancesPendingBalance {
-        public required BalanceReportAmount Open { get; init; }
-        public required BalanceReportAmount Close { get; init; }
-        public required BalanceReportAmountWithSubtotals Pending { get; init; }
-        public required BalanceReportAmountWithSubtotals MovedToAvailable { get; init; }
+        public required BalanceReportAmount Open { get; set; }
+        public required BalanceReportAmount Close { get; set; }
+        public required BalanceReportAmountWithSubtotals Pending { get; set; }
+        public required BalanceReportAmountWithSubtotals MovedToAvailable { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/StatusBalance/StatusBalancesTotal.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/StatusBalance/StatusBalancesTotal.cs
@@ -1,6 +1,6 @@
 ﻿namespace Mollie.Api.Models.Balance.Response.BalanceReport.Specific.StatusBalance {
     public record StatusBalancesTotal {
-        public required StatusBalancesPendingBalance PendingBalance { get; init; }
-        public required StatusBalanceAvailableBalance AvailableBalance { get; init; }
+        public required StatusBalancesPendingBalance PendingBalance { get; set; }
+        public required StatusBalanceAvailableBalance AvailableBalance { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/TransactionCategories/TransactionCategoriesReportResponse.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/TransactionCategories/TransactionCategoriesReportResponse.cs
@@ -1,5 +1,5 @@
 ﻿namespace Mollie.Api.Models.Balance.Response.BalanceReport.Specific.TransactionCategories {
     public record TransactionCategoriesReportResponse : BalanceReportResponse {
-        public required TransactionCategoriesTotal Totals { get; init; }
+        public required TransactionCategoriesTotal Totals { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/TransactionCategories/TransactionCategoriesSummaryBalances.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/TransactionCategories/TransactionCategoriesSummaryBalances.cs
@@ -1,6 +1,6 @@
 ﻿namespace Mollie.Api.Models.Balance.Response.BalanceReport.Specific.TransactionCategories {
     public record TransactionCategoriesSummaryBalances {
-        public required BalanceReportAmount Pending { get; init; }
-        public required BalanceReportAmount Available { get; init; }
+        public required BalanceReportAmount Pending { get; set; }
+        public required BalanceReportAmount Available { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/TransactionCategories/TransactionCategoriesTotal.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/TransactionCategories/TransactionCategoriesTotal.cs
@@ -2,15 +2,15 @@
 
 namespace Mollie.Api.Models.Balance.Response.BalanceReport.Specific.TransactionCategories {
     public record TransactionCategoriesTotal {
-        public required TransactionCategoriesSummaryBalances Open { get; init; }
-        public required TransactionCategoriesSummaryBalances Close { get; init; }
-        public required TransactionCategoriesTransaction Payments { get; init; }
-        public required TransactionCategoriesTransaction Refunds { get; init; }
-        public required TransactionCategoriesTransaction Chargebacks { get; init; }
-        public required TransactionCategoriesTransaction Capital { get; init; }
-        public required TransactionCategoriesTransaction Transfers { get; init; }
+        public required TransactionCategoriesSummaryBalances Open { get; set; }
+        public required TransactionCategoriesSummaryBalances Close { get; set; }
+        public required TransactionCategoriesTransaction Payments { get; set; }
+        public required TransactionCategoriesTransaction Refunds { get; set; }
+        public required TransactionCategoriesTransaction Chargebacks { get; set; }
+        public required TransactionCategoriesTransaction Capital { get; set; }
+        public required TransactionCategoriesTransaction Transfers { get; set; }
         [JsonProperty("fee-prepayments")]
-        public required TransactionCategoriesTransaction FeePrepayments { get; init; }
-        public required TransactionCategoriesTransaction Corrections { get; init; }
+        public required TransactionCategoriesTransaction FeePrepayments { get; set; }
+        public required TransactionCategoriesTransaction Corrections { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/TransactionCategories/TransactionCategoriesTransaction.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceReport/Specific/TransactionCategories/TransactionCategoriesTransaction.cs
@@ -1,7 +1,7 @@
 ﻿namespace Mollie.Api.Models.Balance.Response.BalanceReport.Specific.TransactionCategories {
     public record TransactionCategoriesTransaction {
-        public required BalanceReportAmountWithSubtotals Pending { get; init; }
-        public required BalanceReportAmountWithSubtotals MovedToAvailable { get; init; }
-        public required BalanceReportAmountWithSubtotals ImmediatelyAvailable { get; init; }
+        public required BalanceReportAmountWithSubtotals Pending { get; set; }
+        public required BalanceReportAmountWithSubtotals MovedToAvailable { get; set; }
+        public required BalanceReportAmountWithSubtotals ImmediatelyAvailable { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceResponse.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceResponse.cs
@@ -7,65 +7,65 @@ namespace Mollie.Api.Models.Balance.Response {
         /// <summary>
         /// Indicates the response contains a balance object. Will always contain balance for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         /// The identifier uniquely referring to this balance. Mollie assigns this identifier at balance creation time. For example bal_gVMhHKqSSRYJyPsuoPNFH.
         /// </summary>
-        public required string Id { get; init; }
-        
+        public required string Id { get; set; }
+
         /// <summary>
         /// The balance’s date and time of creation, in ISO 8601 format.
         /// </summary>
-        public required DateTime CreatedAt { get; init; }
-        
+        public required DateTime CreatedAt { get; set; }
+
         /// <summary>
-        /// The balance’s ISO 4217 currency code. 
+        /// The balance’s ISO 4217 currency code.
         /// </summary>
-        public required string Currency { get; init; }
-        
+        public required string Currency { get; set; }
+
         /// <summary>
         /// The status of the balance.
         /// </summary>
         [JsonConverter(typeof(StringEnumConverter))]
-        public required BalanceResponseStatus Status { get; init; }
-        
+        public required BalanceResponseStatus Status { get; set; }
+
         /// <summary>
         /// The frequency at which the available amount on the balance will be settled to the configured transfer destination.
         /// See transferDestination.
         /// </summary>
-        public required string TransferFrequency { get; init; }
-        
+        public required string TransferFrequency { get; set; }
+
         /// <summary>
         /// The minimum amount configured for scheduled automatic settlements. As soon as the amount on the balance exceeds this threshold,
         /// the complete balance will be paid out to the transferDestination according to the configured transferFrequency.
         /// </summary>
-        public required Amount TransferThreshold { get; init; }
-        
+        public required Amount TransferThreshold { get; set; }
+
         /// <summary>
         /// The transfer reference set to be included in all the transfers for this balance. Either a string or null.
         /// </summary>
         public string? TransferReference { get; set; }
-        
+
         /// <summary>
         /// The destination where the available amount will be automatically transferred to according to the configured transferFrequency.
         /// </summary>
-        public required BalanceTransferDestination TransferDestination { get; init; }
-        
+        public required BalanceTransferDestination TransferDestination { get; set; }
+
         /// <summary>
         /// The amount directly available on the balance, e.g. {"currency":"EUR", "value":"100.00"}.
         /// </summary>
-        public required Amount AvailableAmount { get; init; }
-        
+        public required Amount AvailableAmount { get; set; }
+
         /// <summary>
         /// The total amount that is queued to be transferred to your balance. For example, a credit card payment can take a few days to clear.
         /// </summary>
-        public required Amount PendingAmount { get; init; }
-        
+        public required Amount PendingAmount { get; set; }
+
         /// <summary>
         /// An object with several URL objects relevant to the balance. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required BalanceResponseLinks Links { get; init; }
+        public required BalanceResponseLinks Links { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceResponseLinks.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceResponseLinks.cs
@@ -5,11 +5,11 @@ namespace Mollie.Api.Models.Balance.Response {
         /// <summary>
         /// The API resource URL of the balance itself.
         /// </summary>
-        public required UrlObjectLink<BalanceResponse> Self { get; init; }
-        
+        public required UrlObjectLink<BalanceResponse> Self { get; set; }
+
         /// <summary>
         /// The URL to the order retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/BalanceTransaction.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/BalanceTransaction.cs
@@ -6,43 +6,43 @@ namespace Mollie.Api.Models.Balance.Response.BalanceTransaction {
         /// Indicates the response contains a balance transaction object. Will always contain balance_transaction
         /// for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
-        
+        public required string Resource { get; set; }
+
         /// <summary>
         /// The identifier uniquely referring to this balance transaction. Mollie assigns this identifier at
         /// transaction creation time. For example baltr_QM24QwzUWR4ev4Xfgyt29d.
         /// </summary>
-        public required string Id { get; init; }
-        
+        public required string Id { get; set; }
+
         /// <summary>
         /// The type of movement, for example payment or refund. See Mollie docs for a full list of values
         /// </summary>
-        public required string Type { get; init; }
-        
+        public required string Type { get; set; }
+
         /// <summary>
         /// The final amount that was moved to or from the balance, e.g. {"currency":"EUR", "value":"100.00"}.
         /// If the transaction moves funds away from the balance, for example when it concerns a refund, the
         /// amount will be negative.
         /// </summary>
-        public required Amount ResultAmount { get; init; }
-        
+        public required Amount ResultAmount { get; set; }
+
         /// <summary>
         /// The amount that was to be moved to or from the balance, excluding deductions. If the transaction
         /// moves funds away from the balance, for example when it concerns a refund, the amount will be negative.
         /// </summary>
-        public required Amount InitialAmount { get; init; }
-        
+        public required Amount InitialAmount { get; set; }
+
         /// <summary>
         /// The total amount of deductions withheld from the movement. For example, if a €10,00 payment comes in
         /// with a €0,29 fee, the deductions amount will be {"currency":"EUR", "value":"-0.29"}. When moving funds
         /// to a balance, we always round the deduction to a ‘real’ amount. Any differences between these realtime
         /// rounded amounts and the final invoice will be compensated when the invoice is generated.
         /// </summary>
-        public required Amount Deductions { get; init; }
-        
+        public required Amount Deductions { get; set; }
+
         /// <summary>
         /// The date and time of the movement, in ISO 8601 format.
         /// </summary>
-        public required DateTime CreatedAt { get; init; }
+        public required DateTime CreatedAt { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/BalanceTransactionResponse.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/BalanceTransactionResponse.cs
@@ -7,23 +7,23 @@ namespace Mollie.Api.Models.Balance.Response.BalanceTransaction {
         /// The number of transactions found in _embedded, which is either the requested number
         /// (with a maximum of 250) or the default number.
         /// </summary>
-        public required int Count { get; init; }
-        
+        public required int Count { get; set; }
+
         /// <summary>
         /// The object containing the queried data.
         /// </summary>
         [JsonProperty("_embedded")]
-        public required BalanceTransactionEmbeddedResponse Embedded { get; init; }
-        
+        public required BalanceTransactionEmbeddedResponse Embedded { get; set; }
+
         /// <summary>
         /// Links to help navigate through the lists of balance transactions. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required BalanceTransactionResponseLinks Links { get; init; }
+        public required BalanceTransactionResponseLinks Links { get; set; }
     }
 
     public class BalanceTransactionEmbeddedResponse {
         [JsonProperty("balance_transactions")]
-        public required IEnumerable<BalanceTransaction> BalanceTransactions { get; init; }
+        public required IEnumerable<BalanceTransaction> BalanceTransactions { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/BalanceTransactionResponseLinks.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/BalanceTransactionResponseLinks.cs
@@ -5,21 +5,21 @@ namespace Mollie.Api.Models.Balance.Response.BalanceTransaction {
         /// <summary>
         /// The URL to the current set of balance transactions.
         /// </summary>
-        public required UrlObjectLink<BalanceTransactionResponse> Self { get; init; }
-        
+        public required UrlObjectLink<BalanceTransactionResponse> Self { get; set; }
+
         /// <summary>
         /// The previous set of balance transactions, if available.
         /// </summary>
-        public required UrlLink Previous { get; init; }
-        
+        public required UrlLink Previous { get; set; }
+
         /// <summary>
         /// The next set of balance transactions, if available.
         /// </summary>
-        public required UrlLink Next { get; init; }
-        
+        public required UrlLink Next { get; set; }
+
         /// <summary>
         /// The URL to the balance transactions list endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/Specific/CaptureBalanceTransaction.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/Specific/CaptureBalanceTransaction.cs
@@ -1,10 +1,10 @@
 ﻿namespace Mollie.Api.Models.Balance.Response.BalanceTransaction.Specific {
     public class CaptureBalanceTransaction : BalanceTransaction {
-        public required CaptureTransactionContext Context { get; init; }
+        public required CaptureTransactionContext Context { get; set; }
     }
-    
+
     public class CaptureTransactionContext {
-        public required string PaymentId { get; init; }
-        public required string CaptureId { get; init; }
+        public required string PaymentId { get; set; }
+        public required string CaptureId { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/Specific/ChargebackBalanceTransaction.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/Specific/ChargebackBalanceTransaction.cs
@@ -1,10 +1,10 @@
 ﻿namespace Mollie.Api.Models.Balance.Response.BalanceTransaction.Specific {
     public class ChargebackBalanceTransaction : BalanceTransaction {
-        public required ChargebackTransactionContext Context { get; init; }
+        public required ChargebackTransactionContext Context { get; set; }
     }
-    
+
     public class ChargebackTransactionContext {
-        public required string PaymentId { get; init; }
-        public required string ChargebackId { get; init; }
+        public required string PaymentId { get; set; }
+        public required string ChargebackId { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/Specific/InvoiceBalanceTransaction.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/Specific/InvoiceBalanceTransaction.cs
@@ -1,9 +1,9 @@
 ﻿namespace Mollie.Api.Models.Balance.Response.BalanceTransaction.Specific {
     public class InvoiceBalanceTransaction : BalanceTransaction {
-        public required InvoiceTransactionContext Context { get; init; }
+        public required InvoiceTransactionContext Context { get; set; }
     }
-    
+
     public class InvoiceTransactionContext {
-        public required string InvoiceId { get; init; }
+        public required string InvoiceId { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/Specific/PaymentBalanceTransaction.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/Specific/PaymentBalanceTransaction.cs
@@ -1,9 +1,9 @@
 ﻿namespace Mollie.Api.Models.Balance.Response.BalanceTransaction.Specific {
     public class PaymentBalanceTransaction : BalanceTransaction {
-        public required PaymentTransactionContext Context { get; init; }
+        public required PaymentTransactionContext Context { get; set; }
     }
-    
+
     public class PaymentTransactionContext {
-        public required string PaymentId { get; init; }
+        public required string PaymentId { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/Specific/RefundBalanceTransaction.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/Specific/RefundBalanceTransaction.cs
@@ -1,10 +1,10 @@
 ﻿namespace Mollie.Api.Models.Balance.Response.BalanceTransaction.Specific {
     public class RefundBalanceTransaction : BalanceTransaction {
-        public required RefundTransactionContext Context { get; init; }
+        public required RefundTransactionContext Context { get; set; }
     }
-    
+
     public class RefundTransactionContext {
-        public required string PaymentId { get; init; }
-        public required string RefundId { get; init; }
+        public required string PaymentId { get; set; }
+        public required string RefundId { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/Specific/SettlementBalanceTransaction.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceTransaction/Specific/SettlementBalanceTransaction.cs
@@ -1,10 +1,10 @@
 ﻿namespace Mollie.Api.Models.Balance.Response.BalanceTransaction.Specific {
     public class SettlementBalanceTransaction : BalanceTransaction {
-        public required SettlementTransactionContext Context { get; init; }
+        public required SettlementTransactionContext Context { get; set; }
     }
-    
+
     public class SettlementTransactionContext {
-        public required string TransferId { get; init; }
-        public required string SettlementId { get; init; }
+        public required string TransferId { get; set; }
+        public required string SettlementId { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Balance/Response/BalanceTransferDestination.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceTransferDestination.cs
@@ -3,17 +3,17 @@ namespace Mollie.Api.Models.Balance.Response {
         /// <summary>
         /// The default destination of automatic scheduled transfers. Currently only bank-account is supported.
         /// </summary>
-        public required string Type { get; init; }
-        
+        public required string Type { get; set; }
+
         /// <summary>
         /// The configured bank account number of the beneficiary the balance amount is to be transferred to.
         /// </summary>
-        public required string BankAccount { get; init; }
-        
+        public required string BankAccount { get; set; }
+
         /// <summary>
         /// The full name of the beneficiary the balance amount is to be transferred to.
         /// </summary>
-        public required string BeneficiaryName { get; init; }
+        public required string BeneficiaryName { get; set; }
 
         public override string ToString() {
             return $"{Type} - {BankAccount} - {BeneficiaryName}";

--- a/src/Mollie.Api/Models/Capture/Response/CaptureResponse.cs
+++ b/src/Mollie.Api/Models/Capture/Response/CaptureResponse.cs
@@ -8,53 +8,53 @@ namespace Mollie.Api.Models.Capture.Response
         /// <summary>
         /// Indicates the response contains a capture object. Will always contain capture for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         /// The capture’s unique identifier, for example cpt_4qqhO89gsT.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// The mode used to create this capture.
         /// Possible values: live test
         /// </summary>
-        public required string Mode { get; init; }
+        public required string Mode { get; set; }
 
         /// <summary>
         /// The amount captured.
         /// </summary>
-        public required Amount Amount { get; init; }
+        public required Amount Amount { get; set; }
 
         /// <summary>
         /// The capture’s status.
         /// </summary>
-        public required string Status { get; init; }
+        public required string Status { get; set; }
 
         /// <summary>
         /// This optional field will contain the amount that will be settled to your account, converted to the currency your account is settled in. It follows the same syntax as the amount property.
         /// </summary>
-        public required Amount SettlementAmount { get; init; }
+        public required Amount SettlementAmount { get; set; }
 
         /// <summary>
         /// The unique identifier of the payment this capture was created for, for example: tr_7UhSN1zuXS
         /// </summary>
-        public required string PaymentId { get; init; }
+        public required string PaymentId { get; set; }
 
         /// <summary>
         /// The unique identifier of the shipment that triggered the creation of this capture, for example: shp_3wmsgCJN4U
         /// </summary>
-        public required string ShipmentId { get; init; }
+        public required string ShipmentId { get; set; }
 
         /// <summary>
         /// The unique identifier of the settlement this capture was settled with, for example: stl_jDk30akdN
         /// </summary>
-        public required string SettlementId { get; init; }
+        public required string SettlementId { get; set; }
 
         /// <summary>
         /// The capture’s date and time of creation, in ISO 8601 format.
         /// </summary>
-        public required DateTime CreatedAt { get; init; }
+        public required DateTime CreatedAt { get; set; }
 
         /// <summary>
         /// The optional metadata you provided upon payment creation. Metadata can be used to link an order to a payment.
@@ -66,6 +66,6 @@ namespace Mollie.Api.Models.Capture.Response
         /// The optional metadata you provided upon capture creation. Metadata can for example be used to link an bookkeeping ID to a capture.
         /// </summary>
         [JsonProperty("_links")]
-        public required CaptureResponseLinks Links { get; init; }
+        public required CaptureResponseLinks Links { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Capture/Response/CaptureResponseLinks.cs
+++ b/src/Mollie.Api/Models/Capture/Response/CaptureResponseLinks.cs
@@ -8,26 +8,26 @@ namespace Mollie.Api.Models.Capture.Response {
         /// <summary>
         /// The API resource URL of the capture itself.
         /// </summary>
-        public required UrlObjectLink<CaptureResponse> Self { get; init; }
+        public required UrlObjectLink<CaptureResponse> Self { get; set; }
 
         /// <summary>
         /// The API resource URL of the payment the capture belongs to.
         /// </summary>
-        public required UrlObjectLink<PaymentResponse> Payment { get; init; }
+        public required UrlObjectLink<PaymentResponse> Payment { get; set; }
 
         /// <summary>
         /// The API resource URL of the shipment that triggered the capture to be created.
         /// </summary>
-        public required UrlObjectLink<ShipmentResponse> Shipment { get; init; }
+        public required UrlObjectLink<ShipmentResponse> Shipment { get; set; }
 
         /// <summary>
         /// The API resource URL of the settlement this capture has been settled with. Not present if not yet settled.
         /// </summary>
-        public required UrlObjectLink<SettlementResponse> Settlement { get; init; }
+        public required UrlObjectLink<SettlementResponse> Settlement { get; set; }
 
         /// <summary>
         /// The URL to the order retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Chargeback/Response/ChargebackResponse.cs
+++ b/src/Mollie.Api/Models/Chargeback/Response/ChargebackResponse.cs
@@ -6,12 +6,12 @@ namespace Mollie.Api.Models.Chargeback.Response {
 		/// <summary>
 		/// The chargeback's unique identifier, for example chb_n9z0tp.
 		/// </summary>
-		public required string Id { get; init; }
+		public required string Id { get; set; }
 
         /// <summary>
         /// The amount charged back.
         /// </summary>
-        public required Amount Amount { get; init; }
+        public required Amount Amount { get; set; }
 
         /// <summary>
         /// This optional field will contain the amount that will be deducted from your account, converted to the currency
@@ -22,7 +22,7 @@ namespace Mollie.Api.Models.Chargeback.Response {
         /// <summary>
         /// The date and time the chargeback was issued, in ISO 8601 format.
         /// </summary>
-        public required DateTime CreatedAt { get; init; }
+        public required DateTime CreatedAt { get; set; }
 
         /// <summary>
         /// The date and time the chargeback was reversed, in ISO 8601 format.
@@ -32,7 +32,7 @@ namespace Mollie.Api.Models.Chargeback.Response {
         /// <summary>
         /// The id of the payment this chargeback belongs to.
         /// </summary>
-		public required string PaymentId { get; init; }
+		public required string PaymentId { get; set; }
 
 		/// <summary>
         /// The reason given for a Chargeback, this can help determine the cost for the chargeback
@@ -43,6 +43,6 @@ namespace Mollie.Api.Models.Chargeback.Response {
         /// An object with several URL objects relevant to the chargeback. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required ChargebackResponseLinks Links { get; init; }
+        public required ChargebackResponseLinks Links { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Chargeback/Response/ChargebackResponseLinks.cs
+++ b/src/Mollie.Api/Models/Chargeback/Response/ChargebackResponseLinks.cs
@@ -7,12 +7,12 @@ namespace Mollie.Api.Models.Chargeback.Response {
         /// <summary>
         /// The API resource URL of the chargeback itself.
         /// </summary>
-        public required UrlObjectLink<ChargebackResponse> Self { get; init; }
+        public required UrlObjectLink<ChargebackResponse> Self { get; set; }
 
         /// <summary>
         /// The API resource URL of the payment this chargeback belongs to.
         /// </summary>
-        public required UrlObjectLink<PaymentResponse> Payment { get; init; }
+        public required UrlObjectLink<PaymentResponse> Payment { get; set; }
 
         /// <summary>
         /// The API resource URL of the settlement this payment has been settled with. Not present if not yet settled.
@@ -22,6 +22,6 @@ namespace Mollie.Api.Models.Chargeback.Response {
         /// <summary>
         /// The URL to the chargeback retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Chargeback/Response/ChargebackResponseReason.cs
+++ b/src/Mollie.Api/Models/Chargeback/Response/ChargebackResponseReason.cs
@@ -3,10 +3,10 @@ namespace Mollie.Api.Models.Chargeback.Response {
         /// <summary>
         /// The reason for the chargeback, these are documented here on Mollie's website https://help.mollie.com/hc/en-us/articles/115000309865-Why-did-my-direct-debit-payment-fail-
         /// </summary>
-        public required string Code { get; init; }
+        public required string Code { get; set; }
         /// <summary>
         /// an accompanying note to the code
         /// </summary>
-        public required string Description { get; init; }
+        public required string Description { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/ClientLink/Request/ClientLinkOwner.cs
+++ b/src/Mollie.Api/Models/ClientLink/Request/ClientLinkOwner.cs
@@ -5,18 +5,18 @@
         /// <summary>
         /// The email address of your customer.
         /// </summary>
-        public required string Email { get; init; }
-        
+        public required string Email { get; set; }
+
         /// <summary>
         /// The given name (first name) of your customer.
         /// </summary>
-        public required string GivenName { get; init; }
-        
+        public required string GivenName { get; set; }
+
         /// <summary>
         /// The family name (surname) of your customer.
         /// </summary>
-        public required string FamilyName { get; init; }
-        
+        public required string FamilyName { get; set; }
+
         /// <summary>
         /// Allows you to preset the language to be used in the login / authorize flow. When this parameter is
         /// omitted, the browser language will be used instead. You can provide any xx_XX format ISO 15897 locale,

--- a/src/Mollie.Api/Models/ClientLink/Request/ClientLinkRequest.cs
+++ b/src/Mollie.Api/Models/ClientLink/Request/ClientLinkRequest.cs
@@ -5,25 +5,25 @@
         /// <summary>
         /// Personal data of your customer which is required for this endpoint.
         /// </summary>
-        public required ClientLinkOwner Owner { get; init; }
-        
+        public required ClientLinkOwner Owner { get; set; }
+
         /// <summary>
         /// Name of the organization.
         /// </summary>
-        public required string Name { get; init; }
-        
+        public required string Name { get; set; }
+
         /// <summary>
         /// Address of the organization. Note that the country parameter
         /// must always be provided.
         /// </summary>
-        public required AddressObject Address { get; init; }
-        
+        public required AddressObject Address { get; set; }
+
         /// <summary>
         /// The Chamber of Commerce (or local equivalent) registration number
         /// of the organization.
         /// </summary>
         public string? RegistrationNumber { get; set; }
-        
+
         /// <summary>
         /// The VAT number of the organization, if based in the European Union
         /// or the United Kingdom.

--- a/src/Mollie.Api/Models/ClientLink/Response/ClientLinkResponse.cs
+++ b/src/Mollie.Api/Models/ClientLink/Response/ClientLinkResponse.cs
@@ -2,11 +2,11 @@
 
 namespace Mollie.Api.Models.ClientLink.Response {
     public record ClientLinkResponse {
-        public required string Id { get; init; }
-        
-        public required string Resource { get; init; }
-        
+        public required string Id { get; set; }
+
+        public required string Resource { get; set; }
+
         [JsonProperty("_links")]
-        public required ClientLinkResponseLinks Links { get; init; }
+        public required ClientLinkResponseLinks Links { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/ClientLink/Response/ClientLinkResponseLinks.cs
+++ b/src/Mollie.Api/Models/ClientLink/Response/ClientLinkResponseLinks.cs
@@ -2,7 +2,7 @@
 
 namespace Mollie.Api.Models.ClientLink.Response {
     public record ClientLinkResponseLinks {
-        public required UrlLink ClientLink { get; init; }
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink ClientLink { get; set; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Connect/Request/RevokeTokenRequest.cs
+++ b/src/Mollie.Api/Models/Connect/Request/RevokeTokenRequest.cs
@@ -6,11 +6,11 @@ namespace Mollie.Api.Models.Connect.Request {
         /// Type of the token you want to revoke.
         /// </summary>
         [JsonProperty("token_type_hint")]
-        public required string TokenTypeHint { get; init; }
+        public required string TokenTypeHint { get; set; }
 
         /// <summary>
         /// The token you want to revoke
         /// </summary>
-        public required string Token { get; init; }
+        public required string Token { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Connect/Response/TokenResponse.cs
+++ b/src/Mollie.Api/Models/Connect/Response/TokenResponse.cs
@@ -6,32 +6,32 @@ namespace Mollie.Api.Models.Connect.Response {
         ///     The access token, with which you will be able to access the Mollie API on the merchant's behalf.
         /// </summary>
         [JsonProperty("access_token")]
-        public required string AccessToken { get; init; }
+        public required string AccessToken { get; set; }
 
         /// <summary>
         ///     The refresh token, with which you will be able to retrieve new access tokens on this endpoint. Please note that the
         ///     refresh token does not expire.
         /// </summary>
         [JsonProperty("refresh_token")]
-        public required string RefreshToken { get; init; }
+        public required string RefreshToken { get; set; }
 
         /// <summary>
         ///     The number of seconds left before the access token expires. Be sure to renew your access token before this reaches
         ///     zero.
         /// </summary>
         [JsonProperty("expires_in")]
-        public required int ExpiresIn { get; init; }
+        public required int ExpiresIn { get; set; }
 
         /// <summary>
         ///     As per OAuth standards, the provided access token can only be used with bearer authentication.
         ///     Possible values: bearer
         /// </summary>
         [JsonProperty("token_type")]
-        public required string TokenType { get; init; }
+        public required string TokenType { get; set; }
 
         /// <summary>
         ///     A space separated list of permissions. Please refer to OAuth: Permissions for the full permission list.
         /// </summary>
-        public required string Scope { get; init; }
+        public required string Scope { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Customer/Response/CustomerResponse.cs
+++ b/src/Mollie.Api/Models/Customer/Response/CustomerResponse.cs
@@ -8,13 +8,13 @@ namespace Mollie.Api.Models.Customer.Response {
         /// <summary>
         /// Indicates the response contains a customer object. Will always contain customer for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         /// The customer's unique identifier, for example cst_4pmbK7CqtT.
         /// Store this identifier for later recurring payments.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// The mode used to create this payment. Mode determines whether a payment is real or a test payment.
@@ -48,13 +48,13 @@ namespace Mollie.Api.Models.Customer.Response {
         /// <summary>
         /// DateTime when user was created.
         /// </summary>
-        public required DateTime CreatedAt { get; init; }
+        public required DateTime CreatedAt { get; set; }
 
         /// <summary>
         /// An object with several URL objects relevant to the customer. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required CustomerResponseLinks Links { get; init; }
+        public required CustomerResponseLinks Links { get; set; }
 
         public T? GetMetadata<T>(JsonSerializerSettings? jsonSerializerSettings = null) {
             return Metadata != null ? JsonConvert.DeserializeObject<T>(Metadata, jsonSerializerSettings) : default;

--- a/src/Mollie.Api/Models/Customer/Response/CustomerResponseLinks.cs
+++ b/src/Mollie.Api/Models/Customer/Response/CustomerResponseLinks.cs
@@ -8,7 +8,7 @@ namespace Mollie.Api.Models.Customer.Response {
         /// <summary>
         /// The API resource URL of the customer itself.
         /// </summary>
-        public required UrlObjectLink<CustomerResponse> Self { get; init; }
+        public required UrlObjectLink<CustomerResponse> Self { get; set; }
 
         /// <summary>
         /// The API resource URL of the subscriptions belonging to the Customer, if there are no subscriptions this parameter is omitted.
@@ -23,6 +23,6 @@ namespace Mollie.Api.Models.Customer.Response {
         /// <summary>
         /// The URL to the customer retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Error/MollieErrorMessage.cs
+++ b/src/Mollie.Api/Models/Error/MollieErrorMessage.cs
@@ -3,8 +3,8 @@
 namespace Mollie.Api.Models.Error {
     public record MollieErrorMessage {
         public int Status { get; set; }
-        public required string Title { get; init; }
-        public required string Detail { get; init; }
+        public required string Title { get; set; }
+        public required string Detail { get; set; }
 
         /// <summary>
         /// The errors that are returned by the Connect client have a different format for some reason

--- a/src/Mollie.Api/Models/Invoice/Response/InvoiceLine.cs
+++ b/src/Mollie.Api/Models/Invoice/Response/InvoiceLine.cs
@@ -3,26 +3,26 @@
 		/// <summary>
 		/// The administrative period (YYYY) on which the line should be booked.
 		/// </summary>
-		public required string Period { get; init; }
+		public required string Period { get; set; }
 
 		/// <summary>
 		/// Description of the product.
 		/// </summary>
-		public required string Description { get; init; }
+		public required string Description { get; set; }
 
 		/// <summary>
 		/// Number of products invoiced (usually number of payments).
 		/// </summary>
-		public required int Count { get; init; }
+		public required int Count { get; set; }
 
 		/// <summary>
 		/// Optional – VAT percentage rate that applies to this product.
 		/// </summary>
-		public required decimal VatPercentage { get; init; }
+		public required decimal VatPercentage { get; set; }
 
 		/// <summary>
 		/// Amount excluding VAT.
 		/// </summary>
-		public required Amount Amount { get; init; }
+		public required Amount Amount { get; set; }
 	}
 }

--- a/src/Mollie.Api/Models/Invoice/Response/InvoiceResponse.cs
+++ b/src/Mollie.Api/Models/Invoice/Response/InvoiceResponse.cs
@@ -6,17 +6,17 @@ namespace Mollie.Api.Models.Invoice.Response {
         /// <summary>
         /// Indicates the response contains an invoice object. Will always contain invoice for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
 		/// <summary>
 		/// The invoice's unique identifier, for example inv_FrvewDA3Pr.
 		/// </summary>
-		public required string Id { get; init; }
+		public required string Id { get; set; }
 
 		/// <summary>
 		/// The reference number of the invoice. An example value would be: 2016.10000.
 		/// </summary>
-		public required string Reference { get; init; }
+		public required string Reference { get; set; }
 
 		/// <summary>
 		/// Optional – The VAT number to which the invoice was issued to (if applicable).
@@ -27,12 +27,12 @@ namespace Mollie.Api.Models.Invoice.Response {
 		/// Status of the invoices - See the Mollie.Api.Models.Invoice.InvoiceStatus class for
 		/// a full list of known values
 		/// </summary>
-		public required string Status { get; init; }
+		public required string Status { get; set; }
 
 		/// <summary>
 		/// The invoice date (in YYYY-MM-DD format).
 		/// </summary>
-		public required string IssuedAt { get; init; }
+		public required string IssuedAt { get; set; }
 
 		/// <summary>
 		/// Optional – The date on which the invoice was paid (in YYYY-MM-DD format). Only for paid invoices.
@@ -47,29 +47,29 @@ namespace Mollie.Api.Models.Invoice.Response {
         /// <summary>
         /// Total amount of the invoice excluding VAT, e.g. {"currency":Currency.EUR, "value":"100.00"}.
         /// </summary>
-        public required Amount NetAmount { get; init; }
+        public required Amount NetAmount { get; set; }
 
         /// <summary>
         /// VAT amount of the invoice. Only for merchants registered in the Netherlands. For EU merchants, VAT
         /// will be shifted to recipient; article 44 and 196 EU VAT Directive 2006/112. For merchants outside the
         /// EU, no VAT will be charged.
         /// </summary>
-        public required Amount VatAmount { get; init; }
+        public required Amount VatAmount { get; set; }
 
         /// <summary>
         /// Total amount of the invoice including VAT.
         /// </summary>
-        public required Amount GrossAmount { get; init; }
+        public required Amount GrossAmount { get; set; }
 
         /// <summary>
         /// The collection of products which make up the invoice.
         /// </summary>
-        public required List<InvoiceLine> Lines { get; init; }
+        public required List<InvoiceLine> Lines { get; set; }
 
 		/// <summary>
 		/// Useful URLs to related resources.
 		/// </summary>
 		[JsonProperty("_links")]
-		public required InvoiceResponseLinks Links { get; init; }
+		public required InvoiceResponseLinks Links { get; set; }
 	}
 }

--- a/src/Mollie.Api/Models/Invoice/Response/InvoiceResponseLinks.cs
+++ b/src/Mollie.Api/Models/Invoice/Response/InvoiceResponseLinks.cs
@@ -5,7 +5,7 @@ namespace Mollie.Api.Models.Invoice.Response {
         /// <summary>
         /// The API resource URL of the invoice itself.
         /// </summary>
-        public required UrlObjectLink<InvoiceResponse> Self { get; init; }
+        public required UrlObjectLink<InvoiceResponse> Self { get; set; }
 
         /// <summary>
         /// The URL to the PDF version of the invoice. The URL will expire after 60 minutes.
@@ -15,6 +15,6 @@ namespace Mollie.Api.Models.Invoice.Response {
         /// <summary>
         /// The URL to the invoice retrieval endpoint documentation.
         /// </summary>
-		public required UrlLink Documentation { get; init; }
+		public required UrlLink Documentation { get; set; }
 	}
 }

--- a/src/Mollie.Api/Models/Issuer/Response/IssuerResponse.cs
+++ b/src/Mollie.Api/Models/Issuer/Response/IssuerResponse.cs
@@ -3,23 +3,23 @@
         /// <summary>
         /// Contains "issuer"
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         ///     The issuer's unique identifier, for example ideal_ABNANL2A. When creating a payment, specify this ID as the issuer
         ///     parameter to forward
         ///     the consumer to their banking environment directly.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         ///     The issuer's full name, for example 'ABN AMRO'.
         /// </summary>
-        public required string Name { get; init; }
+        public required string Name { get; set; }
 
         /// <summary>
         ///     Different Issuer Image icons (iDEAL).
         /// </summary>
-        public required IssuerResponseImage Image { get; init; }
+        public required IssuerResponseImage Image { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Issuer/Response/IssuerResponseImage.cs
+++ b/src/Mollie.Api/Models/Issuer/Response/IssuerResponseImage.cs
@@ -3,9 +3,9 @@
 	/// URLs of images representing the issuer.
 	/// </summary>
 	public record IssuerResponseImage {
-		public required string Size1x { get; init; }
-		public required string Size2x { get; init; }
-		public required string Svg { get; init; }
+		public required string Size1x { get; set; }
+		public required string Size2x { get; set; }
+		public required string Svg { get; set; }
 
 		public override string ToString() {
 			return Size1x;

--- a/src/Mollie.Api/Models/List/Response/ListResponse.cs
+++ b/src/Mollie.Api/Models/List/Response/ListResponse.cs
@@ -8,9 +8,9 @@ namespace Mollie.Api.Models.List.Response {
 
         [JsonConverter(typeof(ListResponseConverter))]
         [JsonProperty("_embedded")]
-        public required List<T> Items { get; init; }
+        public required List<T> Items { get; set; }
 
         [JsonProperty("_links")]
-        public required ListResponseLinks<T> Links { get; init; }
+        public required ListResponseLinks<T> Links { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/List/Response/ListResponseLinks.cs
+++ b/src/Mollie.Api/Models/List/Response/ListResponseLinks.cs
@@ -8,7 +8,7 @@ namespace Mollie.Api.Models.List.Response {
         /// <summary>
         /// The URL to the current set of payments.
         /// </summary>
-        public required UrlObjectLink<ListResponse<T>> Self { get; init; }
+        public required UrlObjectLink<ListResponse<T>> Self { get; set; }
 
         /// <summary>
         /// The previous set of objects, if available.
@@ -23,6 +23,6 @@ namespace Mollie.Api.Models.List.Response {
         /// <summary>
         /// The URL to the payments list endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Mandate/Request/MandateRequest.cs
+++ b/src/Mollie.Api/Models/Mandate/Request/MandateRequest.cs
@@ -5,12 +5,12 @@ namespace Mollie.Api.Models.Mandate.Request {
         /// <summary>
         /// Payment method of the mandate - Possible values: `directdebit` `paypal`
         /// </summary>
-        public required string Method { get; init; }
+        public required string Method { get; set; }
 
         /// <summary>
         /// Required - Name of consumer you add to the mandate
         /// </summary>
-        public required string ConsumerName { get; init; }
+        public required string ConsumerName { get; set; }
 
         /// <summary>
         /// Optional - The date when the mandate was signed.

--- a/src/Mollie.Api/Models/Mandate/Request/PayPalMandateRequest.cs
+++ b/src/Mollie.Api/Models/Mandate/Request/PayPalMandateRequest.cs
@@ -9,11 +9,11 @@
         /// <summary>
         /// Required For Paypal - The consumer's email address.
         /// </summary>
-        public required string ConsumerEmail { get; init; }
+        public required string ConsumerEmail { get; set; }
 
         /// <summary>
         /// Required for `paypal` mandates - The billing agreement ID given by PayPal.
         /// </summary>
-        public required string PaypalBillingAgreementId { get; init; }
+        public required string PaypalBillingAgreementId { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Mandate/Request/SepaDirectDebitMandateRequest.cs
+++ b/src/Mollie.Api/Models/Mandate/Request/SepaDirectDebitMandateRequest.cs
@@ -9,7 +9,7 @@
         /// <summary>
         /// Required for `directdebit` mandates - Consumer's IBAN account
         /// </summary>
-        public required string ConsumerAccount { get; init; }
+        public required string ConsumerAccount { get; set; }
 
         /// <summary>
         /// Optional - The consumer's bank's BIC / SWIFT code.

--- a/src/Mollie.Api/Models/Mandate/Response/MandateResponse.cs
+++ b/src/Mollie.Api/Models/Mandate/Response/MandateResponse.cs
@@ -6,23 +6,23 @@ namespace Mollie.Api.Models.Mandate.Response {
         /// <summary>
         /// Indicates the response contains a mandate object. Will always contain mandate for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         /// Unique identifier of you mandate.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// Current status of mandate - See the Mollie.Api.Models.Mandate.MandateStatus class for a full
         /// list of known values.
         /// </summary>
-        public required string Status { get; init; }
+        public required string Status { get; set; }
 
         /// <summary>
         /// Payment method of the mandate - See the Mollie.Api.Models.Payment.PaymentMethod class for a full list of known values.
         /// </summary>
-        public required string Method { get; init; }
+        public required string Method { get; set; }
 
         /// <summary>
         /// Mandate details that are different per payment method. Available fields depend on that payment method.
@@ -42,13 +42,13 @@ namespace Mollie.Api.Models.Mandate.Response {
         /// <summary>
         /// DateTime when mandate was created.
         /// </summary>
-        public DateTime CreatedAt { get; init; }
+        public DateTime CreatedAt { get; set; }
 
         /// <summary>
         /// An object with several URL objects relevant to the mandate. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required MandateResponseLinks Links { get; init; }
+        public required MandateResponseLinks Links { get; set; }
     }
 
     public class MandateDetails {

--- a/src/Mollie.Api/Models/Mandate/Response/MandateResponseLinks.cs
+++ b/src/Mollie.Api/Models/Mandate/Response/MandateResponseLinks.cs
@@ -6,16 +6,16 @@ namespace Mollie.Api.Models.Mandate.Response {
         /// <summary>
         /// The API resource URL of the mandate itself.
         /// </summary>
-        public required UrlObjectLink<MandateResponse> Self { get; init; }
+        public required UrlObjectLink<MandateResponse> Self { get; set; }
 
         /// <summary>
         /// The API resource URL of the customer the mandate is for.
         /// </summary>
-        public required UrlObjectLink<CustomerResponse> Customer { get; init; }
+        public required UrlObjectLink<CustomerResponse> Customer { get; set; }
 
         /// <summary>
         /// The URL to the mandate retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Onboarding/Response/OnboardingStatusResponse.cs
+++ b/src/Mollie.Api/Models/Onboarding/Response/OnboardingStatusResponse.cs
@@ -6,7 +6,7 @@ namespace Mollie.Api.Models.Onboarding.Response {
         /// <summary>
         /// Indicates the response contains an onboarding object. Will always contain onboarding for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         /// The name of the organization.
@@ -22,7 +22,7 @@ namespace Mollie.Api.Models.Onboarding.Response {
         /// The current status of the organization’s onboarding process. See the Mollie.Api.Models.Onboarding.Response.OnboardingStatus
         /// class for a full list of known values.
         /// </summary>
-        public required string Status { get; init; }
+        public required string Status { get; set; }
 
         /// <summary>
         /// Whether or not the organization can receive payments.
@@ -38,6 +38,6 @@ namespace Mollie.Api.Models.Onboarding.Response {
         /// An object with several URL objects relevant to the organization. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required OnboardingStatusResponseLinks Links { get; init; }
+        public required OnboardingStatusResponseLinks Links { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Onboarding/Response/OnboardingStatusResponseLinks.cs
+++ b/src/Mollie.Api/Models/Onboarding/Response/OnboardingStatusResponseLinks.cs
@@ -9,12 +9,12 @@ namespace Mollie.Api.Models.Onboarding.Response {
         /// <summary>
         /// The API resource URL of this endpoint itself.
         /// </summary>
-        public required UrlLink Self { get; init; }
+        public required UrlLink Self { get; set; }
 
         /// <summary>
         /// The URL of the onboarding process in Mollie Dashboard. You can redirect your customer to here for e.g. completing the onboarding process.
         /// </summary>
-        public required UrlLink Dashboard { get; init; }
+        public required UrlLink Dashboard { get; set; }
 
         /// <summary>
         /// The API resource URL of the organization.
@@ -24,6 +24,6 @@ namespace Mollie.Api.Models.Onboarding.Response {
         /// <summary>
         /// The URL to the onboarding status retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Order/Request/ManageOrderLines/ManageOrderLinesAddOperation.cs
+++ b/src/Mollie.Api/Models/Order/Request/ManageOrderLines/ManageOrderLinesAddOperation.cs
@@ -1,7 +1,7 @@
 namespace Mollie.Api.Models.Order.Request.ManageOrderLines {
     public record ManageOrderLinesAddOperation : ManageOrderLinesOperation {
-        public required ManageOrderLinesAddOperationData Data { get; init; }
-        
+        public required ManageOrderLinesAddOperationData Data { get; set; }
+
         public ManageOrderLinesAddOperation() {
             Operation = OrderLineOperation.Add;
         }

--- a/src/Mollie.Api/Models/Order/Request/ManageOrderLines/ManageOrderLinesCancelOperation.cs
+++ b/src/Mollie.Api/Models/Order/Request/ManageOrderLines/ManageOrderLinesCancelOperation.cs
@@ -1,7 +1,7 @@
 namespace Mollie.Api.Models.Order.Request.ManageOrderLines {
     public record ManageOrderLinesCancelOperation : ManageOrderLinesOperation {
-        public required ManagerOrderLinesCancelOperationData Data { get; init; }
-        
+        public required ManagerOrderLinesCancelOperationData Data { get; set; }
+
         public ManageOrderLinesCancelOperation() {
             Operation = OrderLineOperation.Cancel;
         }

--- a/src/Mollie.Api/Models/Order/Request/ManageOrderLines/ManageOrderLinesRequest.cs
+++ b/src/Mollie.Api/Models/Order/Request/ManageOrderLines/ManageOrderLinesRequest.cs
@@ -5,6 +5,6 @@ namespace Mollie.Api.Models.Order.Request.ManageOrderLines {
         /// <summary>
         /// List of operations to be processed.
         /// </summary>
-        public required IList<ManageOrderLinesOperation> Operations { get; init; }
+        public required IList<ManageOrderLinesOperation> Operations { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Order/Request/ManageOrderLines/ManageOrderLinesUpdateOperation.cs
+++ b/src/Mollie.Api/Models/Order/Request/ManageOrderLines/ManageOrderLinesUpdateOperation.cs
@@ -1,6 +1,6 @@
 namespace Mollie.Api.Models.Order.Request.ManageOrderLines {
     public record ManageOrderLinesUpdateOperation : ManageOrderLinesOperation {
-        public required ManageOrderLinesUpdateOperationData Data { get; init; }
+        public required ManageOrderLinesUpdateOperationData Data { get; set; }
 
         public ManageOrderLinesUpdateOperation() {
             Operation = OrderLineOperation.Update;

--- a/src/Mollie.Api/Models/Order/Request/ManageOrderLines/ManageOrderLinesUpdateOperationData.cs
+++ b/src/Mollie.Api/Models/Order/Request/ManageOrderLines/ManageOrderLinesUpdateOperationData.cs
@@ -1,5 +1,5 @@
 namespace Mollie.Api.Models.Order.Request.ManageOrderLines {
     public record ManageOrderLinesUpdateOperationData : OrderLineUpdateRequest {
-        public required string Id { get; init; } 
+        public required string Id { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Order/Request/OrderLineCancellationRequest.cs
+++ b/src/Mollie.Api/Models/Order/Request/OrderLineCancellationRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Mollie.Api.Models.Order.Request {
     public record OrderLineCancellationRequest {
-        public required IEnumerable<OrderLineDetails> Lines { get; init; }
+        public required IEnumerable<OrderLineDetails> Lines { get; set; }
 
         /// <summary>
         ///	Oauth only - Optional

--- a/src/Mollie.Api/Models/Order/Request/OrderLineDetails.cs
+++ b/src/Mollie.Api/Models/Order/Request/OrderLineDetails.cs
@@ -1,6 +1,6 @@
 ﻿namespace Mollie.Api.Models.Order.Request {
     public record OrderLineDetails {
-        public required string Id { get; init; }
+        public required string Id { get; set; }
         public int? Quantity { get; set; }
         public Amount? Amount { get; set; }
     }

--- a/src/Mollie.Api/Models/Order/Request/OrderLineRequest.cs
+++ b/src/Mollie.Api/Models/Order/Request/OrderLineRequest.cs
@@ -18,17 +18,17 @@ namespace Mollie.Api.Models.Order.Request {
         /// <summary>
         /// A description of the order line, for example LEGO 4440 Forest Police Station.
         /// </summary>
-        public required string Name { get; init; }
+        public required string Name { get; set; }
 
         /// <summary>
         /// The number of items in the order line.
         /// </summary>
-        public required int Quantity { get; init; }
+        public required int Quantity { get; set; }
 
         /// <summary>
         /// The price of a single item in the order line.
         /// </summary>
-        public required Amount UnitPrice { get; init; }
+        public required Amount UnitPrice { get; set; }
 
         /// <summary>
         /// Any discounts applied to the order line. For example, if you have a two-for-one sale, you should pass the
@@ -40,20 +40,20 @@ namespace Mollie.Api.Models.Order.Request {
         /// The total amount of the line, including VAT and discounts. Adding all totalAmount values together should
         /// result in the same amount as the amount top level property.
         /// </summary>
-        public required Amount TotalAmount { get; init; }
+        public required Amount TotalAmount { get; set; }
 
         /// <summary>
         /// The VAT rate applied to the order line, for example "21.00" for 21%. The vatRate should be passed as a
         /// string and not as a float to ensure the correct number of decimals are passed.
         /// </summary>
-        public required string VatRate { get; init; }
+        public required string VatRate { get; set; }
 
         /// <summary>
         /// The amount of value-added tax on the line. The totalAmount field includes VAT, so the vatAmount can be
         /// calculated with the formula totalAmount × (vatRate / (100 + vatRate)). Any deviations from this will
         /// result in an error.
         /// </summary>
-        public required Amount VatAmount { get; init; }
+        public required Amount VatAmount { get; set; }
 
         /// <summary>
         /// The SKU, EAN, ISBN or UPC of the product sold. The maximum character length is 64.

--- a/src/Mollie.Api/Models/Order/Request/OrderRefundRequest.cs
+++ b/src/Mollie.Api/Models/Order/Request/OrderRefundRequest.cs
@@ -8,7 +8,7 @@ namespace Mollie.Api.Models.Order.Request {
         /// An array of objects containing the order line details you want to create a refund for. If you send
         /// an empty array, the entire order will be refunded.
         /// </summary>
-        public required IEnumerable<OrderLineDetails> Lines { get; init; }
+        public required IEnumerable<OrderLineDetails> Lines { get; set; }
 
         /// <summary>
         /// The description of the refund you are creating. This will be shown to the consumer on their card or

--- a/src/Mollie.Api/Models/Order/Request/OrderRequest.cs
+++ b/src/Mollie.Api/Models/Order/Request/OrderRequest.cs
@@ -10,18 +10,18 @@ namespace Mollie.Api.Models.Order.Request {
         /// The total amount of the order, including VAT and discounts. This is the amount that will be charged
         /// to your customer.
         /// </summary>
-        public required Amount Amount { get; init; }
+        public required Amount Amount { get; set; }
 
         /// <summary>
         /// The order number. For example, 16738. We recommend that each order should have a unique order number.
         /// </summary>
-        public required string OrderNumber { get; init; }
+        public required string OrderNumber { get; set; }
 
         /// <summary>
         /// The lines in the order. Each line contains details such as a description of the item ordered, its
         /// price et cetera.
         /// </summary>
-        public required IEnumerable<OrderLineRequest> Lines { get; init; }
+        public required IEnumerable<OrderLineRequest> Lines { get; set; }
 
         /// <summary>
         /// The billing person and address for the order.
@@ -65,7 +65,7 @@ namespace Mollie.Api.Models.Order.Request {
         /// <summary>
         /// Allows you to preset the language to be used in the hosted payment pages shown to the consumer.
         /// </summary>
-        public required string Locale { get; init; }
+        public required string Locale { get; set; }
 
         /// <summary>
         /// Normally, a payment method selection screen is shown. However, when using this parameter, your customer

--- a/src/Mollie.Api/Models/Order/Response/OrderLineResponse.cs
+++ b/src/Mollie.Api/Models/Order/Response/OrderLineResponse.cs
@@ -7,12 +7,12 @@ namespace Mollie.Api.Models.Order.Response {
         /// <summary>
         /// The order line’s unique identifier, for example odl_dgtxyl.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// The ID of the order the line belongs too, for example ord_kEn1PlbGa.
         /// </summary>
-        public required string OrderId { get; init; }
+        public required string OrderId { get; set; }
 
         /// <summary>
         /// The type of product bought, for example, a physical or a digital product. See the
@@ -23,73 +23,73 @@ namespace Mollie.Api.Models.Order.Response {
         /// <summary>
         /// A description of the order line, for example LEGO 4440 Forest Police Station.
         /// </summary>
-        public required string Name { get; init; }
+        public required string Name { get; set; }
 
         /// <summary>
         /// Status of the order line - See the Mollie.Api.Models.Order.OrderLineStatus class for
         /// a full list of known values.
         /// </summary>
-        public required string Status { get; init; }
+        public required string Status { get; set; }
 
         /// <summary>
         /// Whether or not the order line can be (partially) canceled.
         /// </summary>
-        public required bool IsCancelable { get; init; }
+        public required bool IsCancelable { get; set; }
 
         /// <summary>
         /// The number of items in the order line.
         /// </summary>
-        public required int Quantity { get; init; }
+        public required int Quantity { get; set; }
 
         /// <summary>
         /// The number of items that are shipped for this order line.
         /// </summary>
-        public required int QuantityShipped { get; init; }
+        public required int QuantityShipped { get; set; }
 
         /// <summary>
         /// The total amount that is shipped for this order line.
         /// </summary>
-        public required Amount AmountShipped { get; init; }
+        public required Amount AmountShipped { get; set; }
 
         /// <summary>
         /// The number of items that are refunded for this order line.
         /// </summary>
-        public required int QuantityRefunded { get; init; }
+        public required int QuantityRefunded { get; set; }
 
         /// <summary>
         /// The total amount that is refunded for this order line.
         /// </summary>
-        public required Amount AmountRefunded { get; init; }
+        public required Amount AmountRefunded { get; set; }
 
         /// <summary>
         /// The number of items that are canceled in this order line.
         /// </summary>
-        public required int QuantityCanceled { get; init; }
+        public required int QuantityCanceled { get; set; }
 
         /// <summary>
         /// The total amount that is canceled in this order line.
         /// </summary>
-        public required Amount AmountCanceled { get; init; }
+        public required Amount AmountCanceled { get; set; }
 
         /// <summary>
         /// The number of items that can still be shipped for this order line.
         /// </summary>
-        public required int ShippableQuantity { get; init; }
+        public required int ShippableQuantity { get; set; }
 
         /// <summary>
         /// The number of items that can still be refunded for this order line.
         /// </summary>
-        public required int RefundableQuantity { get; init; }
+        public required int RefundableQuantity { get; set; }
 
         /// <summary>
         /// The number of items that can still be canceled for this order line.
         /// </summary>
-        public required int CancelableQuantity { get; init; }
+        public required int CancelableQuantity { get; set; }
 
         /// <summary>
         /// The price of a single item in the order line.
         /// </summary>
-        public required Amount UnitPrice { get; init; }
+        public required Amount UnitPrice { get; set; }
 
         /// <summary>
         /// Any discounts applied to the order line. For example, if you have a two-for-one sale, you should pass the
@@ -101,20 +101,20 @@ namespace Mollie.Api.Models.Order.Response {
         /// The total amount of the line, including VAT and discounts. Adding all totalAmount values together should
         /// result in the same amount as the amount top level property.
         /// </summary>
-        public required Amount TotalAmount { get; init; }
+        public required Amount TotalAmount { get; set; }
 
         /// <summary>
         /// The VAT rate applied to the order line, for example "21.00" for 21%. The vatRate should be passed as a
         /// string and not as a float to ensure the correct number of decimals are passed.
         /// </summary>
-        public required string VatRate { get; init; }
+        public required string VatRate { get; set; }
 
         /// <summary>
         /// The amount of value-added tax on the line. The totalAmount field includes VAT, so the vatAmount can be
         /// calculated with the formula totalAmount × (vatRate / (100 + vatRate)). Any deviations from this will
         /// result in an error.
         /// </summary>
-        public required Amount VatAmount { get; init; }
+        public required Amount VatAmount { get; set; }
 
         /// <summary>
         /// The SKU, EAN, ISBN or UPC of the product sold. The maximum character length is 64.
@@ -124,7 +124,7 @@ namespace Mollie.Api.Models.Order.Response {
         /// <summary>
         /// The order line’s date and time of creation
         /// </summary>
-        public required DateTime CreatedAt { get; init; }
+        public required DateTime CreatedAt { get; set; }
 
         /// <summary>
         /// An object with several URL objects relevant to the order line. Every URL object will contain an href and a type field.

--- a/src/Mollie.Api/Models/Order/Response/OrderRefundResponse.cs
+++ b/src/Mollie.Api/Models/Order/Response/OrderRefundResponse.cs
@@ -6,12 +6,12 @@ namespace Mollie.Api.Models.Order.Response {
         /// <summary>
         /// The unique identifier of the order this refund was created for. For example: ord_stTC2WHAuS.
         /// </summary>
-        public required string OrderId { get; init; }
+        public required string OrderId { get; set; }
 
         /// <summary>
         /// An array of order line objects as described in Get order. Only available if the refund was created via the
         /// Create Order Refund API.
         /// </summary>
-        public required IEnumerable<OrderLineResponse> Lines { get; init; }
+        public required IEnumerable<OrderLineResponse> Lines { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Order/Response/OrderResponse.cs
+++ b/src/Mollie.Api/Models/Order/Response/OrderResponse.cs
@@ -9,17 +9,17 @@ namespace Mollie.Api.Models.Order.Response {
         /// <summary>
         /// Indicates the response contains an order object. Will always contain order for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         /// The order’s unique identifier, for example ord_vsKJpSsabw.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// The profile the order was created on, for example pfl_v9hTwCvYqw.
         /// </summary>
-        public required string ProfileId { get; init; }
+        public required string ProfileId { get; set; }
 
         /// <summary>
         /// The payment method last used when paying for the order - See the
@@ -36,7 +36,7 @@ namespace Mollie.Api.Models.Order.Response {
         /// <summary>
         /// The total amount of the order, including VAT and discounts.
         /// </summary>
-        public required Amount Amount { get; init; }
+        public required Amount Amount { get; set; }
 
         /// <summary>
         /// The amount captured, thus far. The captured amount will be settled to your account.
@@ -51,12 +51,12 @@ namespace Mollie.Api.Models.Order.Response {
         /// <summary>
         /// The status of the order - See the Mollie.Api.Models.Order.OrderStatus class for a full list of known values.
         /// </summary>
-        public required string Status { get; init; }
+        public required string Status { get; set; }
 
         /// <summary>
         /// Whether or not the order can be (partially) canceled.
         /// </summary>
-        public required bool IsCancelable { get; init; }
+        public required bool IsCancelable { get; set; }
 
         /// <summary>
         /// The person and the address the order is billed to. See below.
@@ -71,7 +71,7 @@ namespace Mollie.Api.Models.Order.Response {
         /// <summary>
         /// Your order number that was used when creating the order.
         /// </summary>
-        public required string OrderNumber { get; init; }
+        public required string OrderNumber { get; set; }
 
         /// <summary>
         /// The person and the address the order is billed to. See below.
@@ -81,7 +81,7 @@ namespace Mollie.Api.Models.Order.Response {
         /// <summary>
         /// The locale used during checkout.
         /// </summary>
-        public required string Locale { get; init; }
+        public required string Locale { get; set; }
 
         /// <summary>
         /// Provide any data you like, for example a string or a JSON object. We will save the data
@@ -116,7 +116,7 @@ namespace Mollie.Api.Models.Order.Response {
         /// <summary>
         /// The order’s date and time of creation, in ISO 8601 format.
         /// </summary>
-        public required DateTime CreatedAt { get; init; }
+        public required DateTime CreatedAt { get; set; }
 
         /// <summary>
         /// The date and time the order will expire, in ISO 8601 format. Note that you have until this date to fully ship the
@@ -149,7 +149,7 @@ namespace Mollie.Api.Models.Order.Response {
         /// </summary>
         public DateTime? CompletedAt { get; set; }
 
-        public required IEnumerable<OrderLineResponse> Lines { get; init; }
+        public required IEnumerable<OrderLineResponse> Lines { get; set; }
 
         [JsonProperty("_embedded")]
         public OrderEmbeddedResponse? Embedded { get; set; }
@@ -158,7 +158,7 @@ namespace Mollie.Api.Models.Order.Response {
         /// An object with several URL objects relevant to the order. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required OrderResponseLinks Links { get; init; }
+        public required OrderResponseLinks Links { get; set; }
 
         public T? GetMetadata<T>(JsonSerializerSettings? jsonSerializerSettings = null) {
             return Metadata != null ? JsonConvert.DeserializeObject<T>(Metadata, jsonSerializerSettings) : default;

--- a/src/Mollie.Api/Models/Order/Response/OrderResponseLinks.cs
+++ b/src/Mollie.Api/Models/Order/Response/OrderResponseLinks.cs
@@ -5,7 +5,7 @@ namespace Mollie.Api.Models.Order.Response {
         /// <summary>
         /// The API resource URL of the order itself.
         /// </summary>
-        public required UrlObjectLink<OrderResponse> Self { get; init; }
+        public required UrlObjectLink<OrderResponse> Self { get; set; }
 
         /// <summary>
         /// The URL your customer should visit to make the payment for the order.
@@ -16,6 +16,6 @@ namespace Mollie.Api.Models.Order.Response {
         /// <summary>
         /// The URL to the order retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Organization/OrganizationResponse.cs
+++ b/src/Mollie.Api/Models/Organization/OrganizationResponse.cs
@@ -5,52 +5,52 @@ namespace Mollie.Api.Models.Organization {
         /// <summary>
         /// Indicates the response contains a organization object.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         ///     The organization's identifier, for example org_1234567.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// The organization's official name.
         /// </summary>
-        public required string Name { get; init; }
-        
+        public required string Name { get; set; }
+
         /// <summary>
         /// The organization's email.
         /// </summary>
-        public required string Email { get; init; }
+        public required string Email { get; set; }
 
         /// <summary>
         /// The preferred locale of the merchant which has been set in Mollie Dashboard.
         /// </summary>
-        public required string Locale { get; init; }
+        public required string Locale { get; set; }
 
         /// <summary>
         /// The address of the organization.
         /// </summary>
-        public required AddressObject Address { get; init; }
+        public required AddressObject Address { get; set; }
 
         /// <summary>
         /// The registration number of the organization at the (local) chamber of commerce.
         /// </summary>
-        public required string RegistrationNumber { get; init; }
+        public required string RegistrationNumber { get; set; }
 
         /// <summary>
         /// The VAT number of the organization, if based in the European Union. The VAT number has been checked with the VIES by Mollie.
         /// </summary>
-        public required string VatNumber { get; init; }
+        public required string VatNumber { get; set; }
 
         /// <summary>
         /// The organization’s VAT regulation, if based in the European Union. Either shifted (VAT is shifted) or dutch (Dutch VAT rate).
         /// </summary>
-        public required string VatRegulation { get; init; }
+        public required string VatRegulation { get; set; }
 
         /// <summary>
         /// An object with several URL objects relevant to the organization. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required OrganizationResponseLinks Links { get; init; }
+        public required OrganizationResponseLinks Links { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Organization/OrganizationResponseLinks.cs
+++ b/src/Mollie.Api/Models/Organization/OrganizationResponseLinks.cs
@@ -13,7 +13,7 @@ namespace Mollie.Api.Models.Organization {
         /// <summary>
         /// The API resource URL of the organization itself.
         /// </summary>
-        public required UrlObjectLink<OrganizationResponse> Self { get; init; }
+        public required UrlObjectLink<OrganizationResponse> Self { get; set; }
 
         /// <summary>
         /// The API resource URL where the organization’s chargebacks can be retrieved.
@@ -53,11 +53,11 @@ namespace Mollie.Api.Models.Organization {
         /// <summary>
         /// The URL to the organization dashboard
         /// </summary>
-        public required UrlLink Dashboard { get; init; }
+        public required UrlLink Dashboard { get; set; }
 
         /// <summary>
         /// The URL to the payment method retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Payment/Request/PaymentRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentRequest.cs
@@ -9,7 +9,7 @@ namespace Mollie.Api.Models.Payment.Request {
         /// <summary>
         /// The amount that you want to charge, e.g. {"currency":"EUR", "value":"100.00"} if you would want to charge €100.00.
         /// </summary>
-        public required Amount Amount { get; init; }
+        public required Amount Amount { get; set; }
 
         /// <summary>
         /// The description of the payment you’re creating. This will be shown to the consumer on their card or bank statement
@@ -17,7 +17,7 @@ namespace Mollie.Api.Models.Payment.Request {
         /// description is also visible in any exports you generate. We recommend you use a unique identifier so that you can
         /// always link the payment to the order.This is particularly useful for bookkeeping.
         /// </summary>
-        public required string Description { get; init; }
+        public required string Description { get; set; }
 
         /// <summary>
         /// Required - The URL the consumer will be redirected to after the payment process. It could make sense for the

--- a/src/Mollie.Api/Models/Payment/Request/PaymentRoutingRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentRoutingRequest.cs
@@ -12,7 +12,7 @@ namespace Mollie.Api.Models.Payment.Request
         /// <summary>
         /// The destination of this portion of the payment.
         /// </summary>
-        public required RoutingDestination Destination { get; init; }
+        public required RoutingDestination Destination { get; set; }
 
         /// <summary>
         /// Optionally, schedule this portion of the payment to be transferred to its destination on a later date. If no date is given, the funds become available to the balance as soon as the payment succeeds.

--- a/src/Mollie.Api/Models/Payment/Response/PaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentResponse.cs
@@ -9,29 +9,29 @@ namespace Mollie.Api.Models.Payment.Response {
         /// <summary>
         /// Indicates the response contains a payment object. Will always contain payment for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         /// The identifier uniquely referring to this payment. Mollie assigns this identifier randomly at payment creation
         /// time. For example tr_7UhSN1zuXS. Its ID will always be used by Mollie to refer to a certain payment.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// The mode used to create this payment. Mode determines whether a payment is real or a test payment.
         /// </summary>
-        public required Mode Mode { get; init; }
+        public required Mode Mode { get; set; }
 
         /// <summary>
         /// The payment's date and time of creation, in ISO 8601 format.
         /// </summary>
-        public required DateTime CreatedAt { get; init; }
+        public required DateTime CreatedAt { get; set; }
 
         /// <summary>
         /// The payment's status. Please refer to the page about statuses for more info about which statuses occur at what
         /// point. See the Mollie.Api.Models.Payment.PaymentStatus class for a full list of known values.
         /// </summary>
-        public required string Status { get; init; }
+        public required string Status { get; set; }
 
         /// <summary>
         /// Whether or not the payment can be canceled.
@@ -74,7 +74,7 @@ namespace Mollie.Api.Models.Payment.Response {
         /// <summary>
         /// The amount of the payment, e.g. {"currency":"EUR", "value":"100.00"} for a €100.00 payment.
         /// </summary>
-        public required Amount Amount { get; init; }
+        public required Amount Amount { get; set; }
 
         /// <summary>
         /// Only available when refunds are available for this payment – The total amount in EURO that is already refunded. For
@@ -109,7 +109,7 @@ namespace Mollie.Api.Models.Payment.Response {
         /// The URL the consumer will be redirected to after completing or cancelling the payment process.
         /// </summary>
         public string? RedirectUrl { get; set; }
-        
+
         /// <summary>
         /// The optional redirect URL you provided during payment creation. Consumer that explicitly cancel the payment
         /// will be redirected to this URL if provided, or otherwise to the redirectUrl instead — see above.
@@ -125,7 +125,7 @@ namespace Mollie.Api.Models.Payment.Response {
         /// <summary>
         /// The URL Mollie will call as soon an important status change takes place.
         /// </summary>
-        public required string WebhookUrl { get; init; }
+        public required string WebhookUrl { get; set; }
 
         /// <summary>
         /// An optional routing configuration that you provided, which enables you to route a successful payment, or part of the payment, to one or more connected accounts.
@@ -136,7 +136,7 @@ namespace Mollie.Api.Models.Payment.Response {
 
         /// <summary>
         /// The payment method used for this payment, either forced on creation by specifying the method parameter, or chosen
-        /// by the consumer our payment method selection screen. See the Mollie.Api.Models.Payment.PaymentMethod class for a 
+        /// by the consumer our payment method selection screen. See the Mollie.Api.Models.Payment.PaymentMethod class for a
         /// full list of known values.
         /// </summary>
         public string? Method { get; set; }
@@ -161,7 +161,7 @@ namespace Mollie.Api.Models.Payment.Response {
         /// <summary>
         /// The identifier referring to the profile this payment was created on. For example, pfl_QkEhN94Ba.
         /// </summary>
-        public required string ProfileId { get; init; }
+        public required string ProfileId { get; set; }
 
         /// <summary>
         /// This optional field will contain the amount that will be settled to your account, converted to the currency your
@@ -180,11 +180,11 @@ namespace Mollie.Api.Models.Payment.Response {
         public string? CustomerId { get; set; }
 
         /// <summary>
-        /// Indicates which type of payment this is in a recurring sequence. Set to first for first payments that allow the customer to agree 
+        /// Indicates which type of payment this is in a recurring sequence. Set to first for first payments that allow the customer to agree
         /// to automatic recurring charges taking place on their account in the future. Set to recurring for payments where the customer’s card
         /// is charged automatically. See the Mollie.Api.Models.Payment.SequenceType class for a full list of known values.
         /// </summary>
-        public required string SequenceType { get; init; }
+        public required string SequenceType { get; set; }
 
         /// <summary>
         /// Only available for recurring payments – If the payment is a recurring payment, this field will hold the ID of the
@@ -207,20 +207,20 @@ namespace Mollie.Api.Models.Payment.Response {
         /// The application fee, if the payment was created with one.
         /// </summary>
         public ApplicationFee? ApplicationFee { get; set; }
-        
+
         /// <summary>
         /// Indicates whether the capture will be scheduled automatically or not. Set to manual for payments that can be captured
         /// manually using the Create capture endpoint. Set to automatic by default, which indicates the payment will be captured
         /// automatically, without having to separately request it.
         /// </summary>
         public string? CaptureMode { get; set; }
-        
+
         /// <summary>
         /// Indicates the interval to wait before the payment is captured, for example 8 hours or 2 days. The capture delay will be
         /// added to the date and time the payment became authorized.
         /// </summary>
         public string? CaptureDelay { get; set; }
-        
+
         /// <summary>
         /// Indicates the datetime on which the merchant has to have captured the payment, before we can no longer guarantee a
         /// successful capture, in ISO 8601 format. This parameter is omitted if the payment is not authorized (yet).

--- a/src/Mollie.Api/Models/Payment/Response/PaymentResponseLinks.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentResponseLinks.cs
@@ -11,7 +11,7 @@ namespace Mollie.Api.Models.Payment.Response {
         /// <summary>
         /// The API resource URL of the payment itself.
         /// </summary>
-        public required UrlObjectLink<PaymentResponse> Self { get; init; }
+        public required UrlObjectLink<PaymentResponse> Self { get; set; }
 
         /// <summary>
         /// The URL your customer should visit to make the payment. This is where you should redirect the consumer to.
@@ -26,7 +26,7 @@ namespace Mollie.Api.Models.Payment.Response {
         /// <summary>
         /// Direct link to the payment in the Mollie Dashboard.
         /// </summary>
-        public required UrlLink Dashboard { get; init; }
+        public required UrlLink Dashboard { get; set; }
 
         /// <summary>
         /// The API resource URL of the refunds that belong to this payment.
@@ -51,7 +51,7 @@ namespace Mollie.Api.Models.Payment.Response {
         /// <summary>
         /// The URL to the payment retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
 
         /// <summary>
         /// The API resource URL of the mandate linked to this payment. Not present if a one-off payment.

--- a/src/Mollie.Api/Models/Payment/Response/PaymentRoutingResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentRoutingResponse.cs
@@ -8,23 +8,23 @@ namespace Mollie.Api.Models.Payment.Response
         /// <summary>
         /// Indicates the response contains a routing object. Will always contain route for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         /// The identifier uniquely referring to this route. Mollie assigns this identifier randomly at payment creation
         /// time. For example rt_k6cjd01h. Its ID will always be used by Mollie to refer to a certain route.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// If more than one routing object is given, the routing objects must indicate what portion of the total payment amount is being routed.
         /// </summary>
-        public required Amount Amount { get; init; }
+        public required Amount Amount { get; set; }
 
         /// <summary>
         /// The destination of this portion of the payment.
         /// </summary>
-        public required RoutingDestination Destination { get; init; }
+        public required RoutingDestination Destination { get; set; }
 
         /// <summary>
         /// Optional property you provided to schedule this portion of the payment to be transferred to its destination on a later date.

--- a/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/BancontactPaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/BancontactPaymentResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Mollie.Api.Models.Payment.Response.PaymentSpecificParameters {
     public record BancontactPaymentResponse : PaymentResponse {
-        public required BancontactPaymentResponseDetails Details { get; init; }
+        public required BancontactPaymentResponseDetails Details { get; set; }
     }
 
     public record BancontactPaymentResponseDetails {

--- a/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/BankTransferPaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/BankTransferPaymentResponse.cs
@@ -3,36 +3,36 @@ using Newtonsoft.Json;
 
 namespace Mollie.Api.Models.Payment.Response.PaymentSpecificParameters {
     public record BankTransferPaymentResponse : PaymentResponse {
-        public required BankTransferPaymentResponseDetails Details { get; init; }
+        public required BankTransferPaymentResponseDetails Details { get; set; }
 
         /// <summary>
         /// For bank transfer payments, the _links object will contain some additional URL objects relevant to the payment.
         /// </summary>
         [JsonProperty("_links")]
-        public new required BankTransferPaymentResponseLinks Links { get; init; }
+        public new required BankTransferPaymentResponseLinks Links { get; set; }
     }
 
     public record BankTransferPaymentResponseDetails {
         /// <summary>
         /// The name of the bank the consumer should wire the amount to.
         /// </summary>
-        public required string BankName { get; init; }
+        public required string BankName { get; set; }
 
         /// <summary>
         ///  The IBAN the consumer should wire the amount to.
         /// </summary>
-        public required string BankAccount { get; init; }
+        public required string BankAccount { get; set; }
 
         /// <summary>
         /// The BIC of the bank the consumer should wire the amount to.
         /// </summary>
-        public required string BankBic { get; init; }
+        public required string BankBic { get; set; }
 
         /// <summary>
         /// The reference the consumer should use when wiring the amount. Note you should not apply any formatting here; show
         /// it to the consumer as-is.
         /// </summary>
-        public required string TransferReference { get; init; }
+        public required string TransferReference { get; set; }
 
         /// <summary>
         /// Only available if the payment has been completed � The consumer's name.
@@ -66,12 +66,12 @@ namespace Mollie.Api.Models.Payment.Response.PaymentSpecificParameters {
         /// <summary>
         /// A link to a hosted payment page where your customer can check the status of their payment.
         /// </summary>
-        public required UrlLink Status { get; init; }
+        public required UrlLink Status { get; set; }
 
         /// <summary>
         /// A link to a hosted payment page where your customer can finish the payment using an alternative payment method also
         /// activated on your website profile.
         /// </summary>
-        public required UrlLink PayOnline { get; init; }
+        public required UrlLink PayOnline { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/BelfiusPaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/BelfiusPaymentResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace Mollie.Api.Models.Payment.Response.PaymentSpecificParameters {
     public record BelfiusPaymentResponse : PaymentResponse {
-        public required BelfiusPaymentResponseDetails Details { get; init; }
+        public required BelfiusPaymentResponseDetails Details { get; set; }
     }
 
     public record BelfiusPaymentResponseDetails {

--- a/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/CreditCardPaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/CreditCardPaymentResponse.cs
@@ -3,7 +3,7 @@
         /// <summary>
         /// An object with credit card details.
         /// </summary>
-        public required CreditCardPaymentResponseDetails Details { get; init; }
+        public required CreditCardPaymentResponseDetails Details { get; set; }
     }
 
     public record CreditCardPaymentResponseDetails {

--- a/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/EpsPaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/EpsPaymentResponse.cs
@@ -3,7 +3,7 @@
         /// <summary>
         /// An object with the consumer bank account details.
         /// </summary>
-        public required EpsPaymentResponseDetails Details { get; init; }
+        public required EpsPaymentResponseDetails Details { get; set; }
     }
 
     public record EpsPaymentResponseDetails {

--- a/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/GiftcardPaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/GiftcardPaymentResponse.cs
@@ -5,7 +5,7 @@ namespace Mollie.Api.Models.Payment.Response.PaymentSpecificParameters {
         /// <summary>
         /// An object with payment details.
         /// </summary>
-        public required GiftcardPaymentResponseDetails Details { get; init; }
+        public required GiftcardPaymentResponseDetails Details { get; set; }
     }
 
     public record GiftcardPaymentResponseDetails {
@@ -37,16 +37,16 @@ namespace Mollie.Api.Models.Payment.Response.PaymentSpecificParameters {
         /// <summary>
         /// The ID of the gift card brand that was used during the payment.
         /// </summary>
-        public required string Issuer { get; init; }
+        public required string Issuer { get; set; }
 
         /// <summary>
         /// The amount in EUR that was paid with this gift card.
         /// </summary>
-        public required Amount Amount { get; init; }
+        public required Amount Amount { get; set; }
 
         /// <summary>
         /// The voucher number, with the last four digits masked. Example: 606436353088147****
         /// </summary>
-        public required string VoucherNumber { get; init; }
+        public required string VoucherNumber { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/GiropayPaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/GiropayPaymentResponse.cs
@@ -3,7 +3,7 @@
         /// <summary>
         /// An object with the consumer bank account details.
         /// </summary>
-        public required GiropayPaymentResponseDetails Details { get; init; }
+        public required GiropayPaymentResponseDetails Details { get; set; }
     }
 
     public record GiropayPaymentResponseDetails {

--- a/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/IdealPaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/IdealPaymentResponse.cs
@@ -3,7 +3,7 @@
         /// <summary>
         /// An object with the consumer bank account details.
         /// </summary>
-        public required IdealPaymentResponseDetails Details { get; init; }
+        public required IdealPaymentResponseDetails Details { get; set; }
     }
 
     public record IdealPaymentResponseDetails {

--- a/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/IngHomePayPaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/IngHomePayPaymentResponse.cs
@@ -3,7 +3,7 @@
         /// <summary>
         /// An object with payment details.
         /// </summary>
-        public required IngHomePayPaymentResponseDetails Details { get; init; }
+        public required IngHomePayPaymentResponseDetails Details { get; set; }
     }
 
     public record IngHomePayPaymentResponseDetails {

--- a/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/KbcPaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/KbcPaymentResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace Mollie.Api.Models.Payment.Response.PaymentSpecificParameters {
     public record KbcPaymentResponse : PaymentResponse {
-        public required KbcPaymentResponseDetails Details { get; init; }
+        public required KbcPaymentResponseDetails Details { get; set; }
     }
 
     public record KbcPaymentResponseDetails {

--- a/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/PaySafeCardPaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/PaySafeCardPaymentResponse.cs
@@ -1,6 +1,6 @@
 namespace Mollie.Api.Models.Payment.Response.PaymentSpecificParameters {
     public record PaySafeCardPaymentResponse : PaymentResponse {
-        public required PaySafeCardPaymentResponseDetails Details { get; init; }
+        public required PaySafeCardPaymentResponseDetails Details { get; set; }
     }
 
     public record PaySafeCardPaymentResponseDetails {

--- a/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/SepaDirectDebitResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/SepaDirectDebitResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace Mollie.Api.Models.Payment.Response.PaymentSpecificParameters {
     public record SepaDirectDebitResponse : PaymentResponse {
-        public required SepaDirectDebitResponseDetails Details { get; init; }
+        public required SepaDirectDebitResponseDetails Details { get; set; }
     }
 
     public record SepaDirectDebitResponseDetails {

--- a/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/SofortPaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/SofortPaymentResponse.cs
@@ -1,6 +1,6 @@
 namespace Mollie.Api.Models.Payment.Response.PaymentSpecificParameters {
     public record SofortPaymentResponse : PaymentResponse {
-        public required SofortPaymentResponseDetails Details { get; init; }
+        public required SofortPaymentResponseDetails Details { get; set; }
     }
 
     public record SofortPaymentResponseDetails {

--- a/src/Mollie.Api/Models/Payment/Response/QrCode.cs
+++ b/src/Mollie.Api/Models/Payment/Response/QrCode.cs
@@ -3,17 +3,17 @@
         /// <summary>
         ///     Height of the image in pixels.
         /// </summary>
-        public required int Height { get; init; }
+        public required int Height { get; set; }
 
         /// <summary>
         ///     Width of the image in pixels.
         /// </summary>
-        public required int Width { get; init; }
+        public required int Width { get; set; }
 
         /// <summary>
         ///     The URI you can use to display the QR code. Note that we can send both data URIs as well as links to HTTPS images.
         ///     You should support both.
         /// </summary>
-        public required string Src { get; init; }
+        public required string Src { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Payment/RoutingDestination.cs
+++ b/src/Mollie.Api/Models/Payment/RoutingDestination.cs
@@ -5,7 +5,7 @@
         /// <summary>
         /// The type of destination. Currently only the destination type organization is supported.
         /// </summary>
-        public required string Type { get; init; }
+        public required string Type { get; set; }
 
         /// <summary>
         /// Required for destination type organization.The ID of the connected organization the funds should be routed

--- a/src/Mollie.Api/Models/PaymentLink/Request/PaymentLinkRequest.cs
+++ b/src/Mollie.Api/Models/PaymentLink/Request/PaymentLinkRequest.cs
@@ -8,13 +8,13 @@ namespace Mollie.Api.Models.PaymentLink.Request {
         /// <summary>
         /// The amount that you want to charge, e.g. {"currency":"EUR", "value":"1000.00"} if you would want to charge €1000.00.
         /// </summary>
-        public Amount? Amount { get; init; }
+        public Amount? Amount { get; set; }
 
         /// <summary>
         /// This description will also be used as the payment description and will be shown to your customer on their card or bank
         /// statement when possible.
         /// </summary>
-        public required string Description { get; init; }
+        public required string Description { get; set; }
 
         /// <summary>
         /// Optional - The URL your customer will be redirected to after completing the payment process.

--- a/src/Mollie.Api/Models/PaymentLink/Response/PaymentLinkResponse.cs
+++ b/src/Mollie.Api/Models/PaymentLink/Response/PaymentLinkResponse.cs
@@ -8,19 +8,19 @@ namespace Mollie.Api.Models.PaymentLink.Response
         /// <summary>
         /// Indicates the response contains a payment object. Will always contain payment-link for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
-        /// The identifier uniquely referring to this payment link. Mollie assigns this identifier at creation time. 
+        /// The identifier uniquely referring to this payment link. Mollie assigns this identifier at creation time.
         /// For example pl_4Y0eZitmBnQ6IDoMqZQKh. Its ID will always be used by Mollie to refer to a certain payment link.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
-        ///A short description of the payment link. The description is visible in the Dashboard and will be shown on the 
+        ///A short description of the payment link. The description is visible in the Dashboard and will be shown on the
         ///customer’s bank or card statement when possible. This description will eventual been used as payment description.
         /// </summary>
-        public required string Description { get; init; }
+        public required string Description { get; set; }
 
         /// <summary>
         /// The mode used to create this payment link. Mode determines whether a payment link is real (live mode) or a test payment link.
@@ -35,7 +35,7 @@ namespace Mollie.Api.Models.PaymentLink.Response
         /// <summary>
         /// The amount of the payment link, e.g. {"currency":"EUR", "value":"100.00"} for a €100.00 payment link.
         /// </summary>
-        public required Amount Amount { get; init; }
+        public required Amount Amount { get; set; }
 
         /// <summary>
         /// The URL your customer will be redirected to after completing the payment process.
@@ -71,8 +71,8 @@ namespace Mollie.Api.Models.PaymentLink.Response
         /// An object with several URL objects relevant to the payment. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required PaymentLinkResponseLinks Links { get; init; }
-         
+        public required PaymentLinkResponseLinks Links { get; set; }
+
         public override string ToString()
         {
             return $"Id: {Id} - Description: {Description} - Amount: {Amount}";

--- a/src/Mollie.Api/Models/PaymentLink/Response/PaymentLinkResponseLinks.cs
+++ b/src/Mollie.Api/Models/PaymentLink/Response/PaymentLinkResponseLinks.cs
@@ -5,16 +5,16 @@ namespace Mollie.Api.Models.PaymentLink.Response {
         /// <summary>
         /// The API resource URL of the payment link itself.
         /// </summary>
-        public required UrlObjectLink<PaymentLinkResponse> Self { get; init; }
+        public required UrlObjectLink<PaymentLinkResponse> Self { get; set; }
 
         /// <summary>
         /// Direct link to the payment link.
         /// </summary>
-        public required UrlLink PaymentLink { get; init; } 
+        public required UrlLink PaymentLink { get; set; }
 
         /// <summary>
         ///The URL to the payment link retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/PaymentMethod/Response/FixedPricingResponse.cs
+++ b/src/Mollie.Api/Models/PaymentMethod/Response/FixedPricingResponse.cs
@@ -4,11 +4,11 @@
         /// <summary>
         /// The ISO 4217 currency code.
         /// </summary>
-        public required string Currency { get; init; }
+        public required string Currency { get; set; }
 
         /// <summary>
         /// A string containing the exact amount in the given currency.
         /// </summary>
-        public required decimal Value { get; init; }
+        public required decimal Value { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/PaymentMethod/Response/PaymentMethodResponse.cs
+++ b/src/Mollie.Api/Models/PaymentMethod/Response/PaymentMethodResponse.cs
@@ -7,32 +7,32 @@ namespace Mollie.Api.Models.PaymentMethod.Response {
         /// <summary>
         /// Indicates the response contains a method object. Will always contain method for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         /// The unique identifier of the payment method. When used during payment creation, the payment method selection screen will be skipped.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// The full name of the payment method.
         /// </summary>
-        public required string Description { get; init; }
+        public required string Description { get; set; }
 
         /// <summary>
         /// Minimum payment amount required to use this payment method.
         /// </summary>
-        public required Amount MinimumAmount { get; init; }
+        public required Amount MinimumAmount { get; set; }
 
         /// <summary>
         /// Maximum payment amount allowed when using this payment method. (Could be null)
         /// </summary>
-        public required Amount MaximumAmount { get; init; }
+        public required Amount MaximumAmount { get; set; }
 
         /// <summary>
         /// URLs of images representing the payment method.
         /// </summary>
-        public required PaymentMethodResponseImage Image { get; init; }
+        public required PaymentMethodResponseImage Image { get; set; }
 
 		/// <summary>
 		///	List of Issuers
@@ -48,7 +48,7 @@ namespace Mollie.Api.Models.PaymentMethod.Response {
 		/// An object with several URL objects relevant to the payment method. Every URL object will contain an href and a type field.
 		/// </summary>
 		[JsonProperty("_links")]
-        public required PaymentMethodResponseLinks Links { get; init; }
+        public required PaymentMethodResponseLinks Links { get; set; }
 
         public override string ToString() {
             return Description;

--- a/src/Mollie.Api/Models/PaymentMethod/Response/PaymentMethodResponseImage.cs
+++ b/src/Mollie.Api/Models/PaymentMethod/Response/PaymentMethodResponseImage.cs
@@ -6,17 +6,17 @@
         /// <summary>
         /// The URL for a payment method icon of 55x37 pixels.
         /// </summary>
-        public required string Size1x { get; init; }
+        public required string Size1x { get; set; }
 
         /// <summary>
         /// The URL for a payment method icon of 110x74 pixels. Use this for high resolution screens.
         /// </summary>
-        public required string Size2x { get; init; }
+        public required string Size2x { get; set; }
 
         /// <summary>
         /// The URL for a payment method icon in vector format. Usage of this format is preferred since it can scale to any desired size.
         /// </summary>
-        public required string Svg { get; init; }
+        public required string Svg { get; set; }
 
         public override string ToString() {
             return Size1x;

--- a/src/Mollie.Api/Models/PaymentMethod/Response/PaymentMethodResponseLinks.cs
+++ b/src/Mollie.Api/Models/PaymentMethod/Response/PaymentMethodResponseLinks.cs
@@ -5,11 +5,11 @@ namespace Mollie.Api.Models.PaymentMethod.Response {
         /// <summary>
         /// The API resource URL of the payment method itself.
         /// </summary>
-        public required UrlObjectLink<PaymentMethodResponse> Self { get; init; }
+        public required UrlObjectLink<PaymentMethodResponse> Self { get; set; }
 
         /// <summary>
         /// The URL to the payment method retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/PaymentMethod/Response/PricingResponse.cs
+++ b/src/Mollie.Api/Models/PaymentMethod/Response/PricingResponse.cs
@@ -4,17 +4,17 @@
         /// <summary>
         /// The area or product-type where the pricing is applied for, translated in the optional locale passed.
         /// </summary>
-        public required string Description { get; init; }
+        public required string Description { get; set; }
 
         /// <summary>
         /// The fixed price per transaction
         /// </summary>
-        public required FixedPricingResponse Fixed { get; init; }
+        public required FixedPricingResponse Fixed { get; set; }
 
         /// <summary>
         /// A string containing the percentage what will be charged over the payment amount besides the fixed price.
         /// </summary>
-        public required decimal Variable { get; init; }
+        public required decimal Variable { get; set; }
 
         /// <summary>
         /// This value is only available for credit card rates. It will correspond with the regions as documented in

--- a/src/Mollie.Api/Models/Permission/Response/PermissionResponse.cs
+++ b/src/Mollie.Api/Models/Permission/Response/PermissionResponse.cs
@@ -6,17 +6,17 @@ namespace Mollie.Api.Models.Permission.Response {
         /// Indicates the response contains a permission object.
         /// Possible values: permission
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         /// The permission's identifier. See OAuth: Permissions for more details about the available permissions.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// A short description of what the permission allows.
         /// </summary>
-        public required string Description { get; init; }
+        public required string Description { get; set; }
 
         /// <summary>
         /// Whether this permission is granted to the app by the organization or not.
@@ -27,6 +27,6 @@ namespace Mollie.Api.Models.Permission.Response {
         /// An object with several URL objects relevant to the permission. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required PermissionResponseLinks Links { get; init; }
+        public required PermissionResponseLinks Links { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Permission/Response/PermissionResponseLInks.cs
+++ b/src/Mollie.Api/Models/Permission/Response/PermissionResponseLInks.cs
@@ -5,11 +5,11 @@ namespace Mollie.Api.Models.Permission.Response {
         /// <summary>
         /// The API resource URL of the permission itself.
         /// </summary>
-        public required UrlObjectLink<PermissionResponse> Self { get; init; }
+        public required UrlObjectLink<PermissionResponse> Self { get; set; }
 
         /// <summary>
         /// The URL to the permission retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Profile/Request/ProfileRequest.cs
+++ b/src/Mollie.Api/Models/Profile/Request/ProfileRequest.cs
@@ -5,28 +5,28 @@ namespace Mollie.Api.Models.Profile.Request {
         /// <summary>
         /// The profile's name should reflect the tradename or brand name of the profile's website or application.
         /// </summary>
-        public required string Name { get; init; }
+        public required string Name { get; set; }
 
         /// <summary>
         /// The URL to the profile's website or application. The URL should start with http:// or https://.
         /// </summary>
-        public required string Website { get; init; }
+        public required string Website { get; set; }
 
         /// <summary>
         /// The email address associated with the profile's tradename or brand.
         /// </summary>
-        public required string Email { get; init; }
+        public required string Email { get; set; }
 
         /// <summary>
         /// The phone number associated with the profile's tradename or brand.
         /// </summary>
-        public required string Phone { get; init; }
-        
+        public required string Phone { get; set; }
+
         /// <summary>
         /// The products or services that the profile’s website offers.
         /// </summary>
         public string? Description { get; set; }
-        
+
         /// <summary>
         /// The list of countries where you expect that the majority of the profile’s customers will live, in ISO 3166-1 alpha-2 format.
         /// </summary>
@@ -37,7 +37,7 @@ namespace Mollie.Api.Models.Profile.Request {
         /// for more information on which values are accepted.
         /// </summary>
         public string? BusinessCategory { get; set; }
-        
+
         /// <summary>
         /// Optional – Creating a test profile by setting this parameter to test, enables you to start using the API without
         /// having to provide all your business info just yet. Defaults to live.

--- a/src/Mollie.Api/Models/Profile/Response/ApiKey.cs
+++ b/src/Mollie.Api/Models/Profile/Response/ApiKey.cs
@@ -5,18 +5,18 @@ namespace Mollie.Api.Models.Profile.Response {
         /// <summary>
         ///     Indicates the response contains an API key object.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         ///     The API key's identifier.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         ///     The actual API key, which you'll use when creating payments or when otherwise communicating with the API. Never
         ///     share the API key with anyone.
         /// </summary>
-        public required string Key { get; init; }
+        public required string Key { get; set; }
 
         /// <summary>
         ///     The API key's date and time of creation.

--- a/src/Mollie.Api/Models/Profile/Response/EnableGiftCardIssuerResponse.cs
+++ b/src/Mollie.Api/Models/Profile/Response/EnableGiftCardIssuerResponse.cs
@@ -5,27 +5,27 @@ namespace Mollie.Api.Models.Profile.Response {
         /// <summary>
         /// Indicates the response contains an issuer object. Will always contain issuer for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         /// The unique identifier of the gift card issuer.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// The full name of the gift card issuer.
         /// </summary>
-        public required string Description { get; init; }
+        public required string Description { get; set; }
 
         /// <summary>
         /// The status that the issuer is in. Possible values: pending-issuer or activated.
         /// </summary>
-        public required string Status { get; init; }
+        public required string Status { get; set; }
 
         /// <summary>
         /// An object with several URL objects relevant to the order. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required EnableGiftCardIssuerResponseLinks Links { get; init; }
+        public required EnableGiftCardIssuerResponseLinks Links { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Profile/Response/EnableGiftCardIssuerResponseLinks.cs
+++ b/src/Mollie.Api/Models/Profile/Response/EnableGiftCardIssuerResponseLinks.cs
@@ -5,11 +5,11 @@ namespace Mollie.Api.Models.Profile.Response {
         /// <summary>
         /// The API resource URL of the gift card issuer itself.
         /// </summary>
-        public required UrlLink Self { get; init; }
+        public required UrlLink Self { get; set; }
 
         /// <summary>
         /// The URL to the gift card issuer retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Profile/Response/ProfileResponse.cs
+++ b/src/Mollie.Api/Models/Profile/Response/ProfileResponse.cs
@@ -7,12 +7,12 @@ namespace Mollie.Api.Models.Profile.Response {
         /// <summary>
         /// Indicates the response contains a profile object. Will always contain profile for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         /// The identifier uniquely referring to this profile, for example pfl_v9hTwCvYqw.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// Indicates whether the payment profile is in test or production mode.
@@ -24,18 +24,18 @@ namespace Mollie.Api.Models.Profile.Response {
         /// The payment profile's name, this will usually reflect the tradename or brand name of the profile's website or
         /// application.
         /// </summary>
-        public required string Name { get; init; }
+        public required string Name { get; set; }
 
         /// <summary>
         /// The URL to the profile's website or application.
         /// </summary>
-        public required string Website { get; init; }
-        
+        public required string Website { get; set; }
+
         /// <summary>
         /// The products or services that the profile’s website offers.
         /// </summary>
         public string? Description { get; set; }
-        
+
         /// <summary>
         /// The list of countries where you expect that the majority of the profile’s customers will live, in ISO 3166-1 alpha-2 format.
         /// </summary>
@@ -44,30 +44,30 @@ namespace Mollie.Api.Models.Profile.Response {
         /// <summary>
         /// The email address associated with the profile's tradename or brand.
         /// </summary>
-        public required string Email { get; init; }
+        public required string Email { get; set; }
 
         /// <summary>
         /// The phone number associated with the profile's tradename or brand.
         /// </summary>
-        public required string Phone { get; init; }
+        public required string Phone { get; set; }
 
         /// <summary>
         /// The industry associated with the profile’s trade name or brand. Please refer to the documentation of the business category
         /// for more information on which values are accepted.
         /// </summary>
         public string? BusinessCategory { get; set; }
-        
+
         /// <summary>
-        /// The industry associated with the profile's tradename or brand. 
+        /// The industry associated with the profile's tradename or brand.
         /// </summary>
         [Obsolete("This parameter is deprecated and will be removed in 2022. Please use the businessCategory parameter instead.")]
         public int CategoryCode { get; set; }
 
         /// <summary>
-        /// The profile status determines whether the payment profile is able to receive live payments. See the 
+        /// The profile status determines whether the payment profile is able to receive live payments. See the
         /// Mollie.Api.Models.Profile.ProfileStatus class for a full list of known values.
         /// </summary>
-        public required string Status { get; init; }
+        public required string Status { get; set; }
 
         /// <summary>
         /// The presence of a review object indicates changes have been made that have not yet been approved by Mollie.
@@ -79,20 +79,20 @@ namespace Mollie.Api.Models.Profile.Response {
         /// <summary>
         /// The payment profile's date and time of creation.
         /// </summary>
-        public required DateTime CreatedAt { get; init; }
+        public required DateTime CreatedAt { get; set; }
 
         /// <summary>
         /// Useful URLs to related resources.
         /// </summary>
         [JsonProperty("_links")]
-        public required ProfileResponseLinks Links { get; init; }
+        public required ProfileResponseLinks Links { get; set; }
     }
 
     public record Review {
         /// <summary>
-        /// The status of the requested profile changes. See the Mollie.Api.Models.Profile.ReviewStatus 
+        /// The status of the requested profile changes. See the Mollie.Api.Models.Profile.ReviewStatus
         /// class for a full list of known values.
         /// </summary>
-        public required string Status { get; init; }
+        public required string Status { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Profile/Response/ProfileResponseLinks.cs
+++ b/src/Mollie.Api/Models/Profile/Response/ProfileResponseLinks.cs
@@ -7,13 +7,13 @@ using Mollie.Api.Models.Url;
 
 namespace Mollie.Api.Models.Profile.Response {
     public record ProfileResponseLinks {
-        public required UrlObjectLink<ProfileResponse> Self { get; init; }
-        public required UrlLink Dashboard { get; init; }
+        public required UrlObjectLink<ProfileResponse> Self { get; set; }
+        public required UrlLink Dashboard { get; set; }
         public UrlObjectLink<ListResponse<ChargebackResponse>>? Chargebacks { get; set; }
         public UrlObjectLink<ListResponse<PaymentResponse>>? Methods { get; set; }
         public UrlObjectLink<ListResponse<PaymentMethodResponse>>? Payments { get; set; }
         public UrlObjectLink<ListResponse<RefundResponse>>? Refunds { get; set; }
         public UrlLink? CheckoutPreviewUrl { get; set; }
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Refund/Request/RefundRequest.cs
+++ b/src/Mollie.Api/Models/Refund/Request/RefundRequest.cs
@@ -6,7 +6,7 @@ namespace Mollie.Api.Models.Refund.Request {
         /// <summary>
         /// The amount to refund. For some payments, it can be up to €25.00 more than the original transaction amount.
         /// </summary>
-        public required Amount Amount { get; init; }
+        public required Amount Amount { get; set; }
 
         /// <summary>
         /// Optional – The description of the refund you are creating. This will be shown to the consumer on their card or bank

--- a/src/Mollie.Api/Models/Refund/Response/RefundResponse.cs
+++ b/src/Mollie.Api/Models/Refund/Response/RefundResponse.cs
@@ -7,17 +7,17 @@ namespace Mollie.Api.Models.Refund.Response {
         /// <summary>
         /// Indicates the response contains a refund object. Will always contain refund for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         /// The refund's unique identifier, for example re_4qqhO89gsT.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// The amount refunded to the consumer with this refund.
         /// </summary>
-        public required Amount Amount { get; init; }
+        public required Amount Amount { get; set; }
 
         /// <summary>
         /// The identifier referring to the settlement this payment was settled with. For example, stl_BkEjN2eBb.
@@ -42,7 +42,7 @@ namespace Mollie.Api.Models.Refund.Response {
         /// Since refunds may be delayed for certain payment methods, the refund carries a status field. See the
         /// Mollie.Api.Models.Refund.RefundStatus class for a full list of known values.
         /// </summary>
-        public required string Status { get; init; }
+        public required string Status { get; set; }
 
         /// <summary>
         /// The date and time the refund was issued, in ISO 8601 format.
@@ -53,7 +53,7 @@ namespace Mollie.Api.Models.Refund.Response {
         /// The unique identifier of the payment this refund was created for. For example: tr_7UhSN1zuXS. The full
         /// payment object can be retrieved via the payment URL in the _links object.
         /// </summary>
-        public required string PaymentId { get; init; }
+        public required string PaymentId { get; set; }
 
         /// <summary>
         /// Provide any data you like, for example a string or a JSON object. We will save the data alongside the refund. Whenever
@@ -66,7 +66,7 @@ namespace Mollie.Api.Models.Refund.Response {
         /// An object with several URL objects relevant to the refund. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required RefundResponseLinks Links { get; init; }
+        public required RefundResponseLinks Links { get; set; }
 
         public T? GetMetadata<T>(JsonSerializerSettings? jsonSerializerSettings = null) {
             return Metadata != null ? JsonConvert.DeserializeObject<T>(Metadata, jsonSerializerSettings) : default;

--- a/src/Mollie.Api/Models/Refund/Response/RefundResponseLinks.cs
+++ b/src/Mollie.Api/Models/Refund/Response/RefundResponseLinks.cs
@@ -7,12 +7,12 @@ namespace Mollie.Api.Models.Refund.Response {
         /// <summary>
         /// The API resource URL of the refund itself.
         /// </summary>
-        public required UrlObjectLink<RefundResponse> Self { get; init; }
+        public required UrlObjectLink<RefundResponse> Self { get; set; }
 
         /// <summary>
         /// The API resource URL of the payment the refund belongs to.
         /// </summary>
-        public required UrlObjectLink<PaymentResponse> Payment { get; init; }
+        public required UrlObjectLink<PaymentResponse> Payment { get; set; }
 
         /// <summary>
         /// The API resource URL of the settlement this payment has been settled with. Not present if not yet settled.
@@ -22,6 +22,6 @@ namespace Mollie.Api.Models.Refund.Response {
         /// <summary>
         /// The URL to the refund retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Settlement/Response/SettlementPeriod.cs
+++ b/src/Mollie.Api/Models/Settlement/Response/SettlementPeriod.cs
@@ -5,12 +5,12 @@ namespace Mollie.Api.Models.Settlement.Response {
 		/// <summary>
 		/// The total revenue for each payment method during this period.
 		/// </summary>
-		public required List<SettlementPeriodRevenue> Revenue { get; init; }
+		public required List<SettlementPeriodRevenue> Revenue { get; set; }
 
 		/// <summary>
 		/// The fees withheld for each payment method during this period.
 		/// </summary>
-		public required List<SettlementPeriodCosts> Costs { get; init; }
+		public required List<SettlementPeriodCosts> Costs { get; set; }
 
 		/// <summary>
 		/// The ID of the invoice that was created to invoice specifically the costs in this month/period.

--- a/src/Mollie.Api/Models/Settlement/Response/SettlementPeriodCosts.cs
+++ b/src/Mollie.Api/Models/Settlement/Response/SettlementPeriodCosts.cs
@@ -3,32 +3,32 @@
 		/// <summary>
 		/// A description of the subtotal.
 		/// </summary>
-		public required string Description { get; init; }
+		public required string Description { get; set; }
 
 	    /// <summary>
 	    /// The net total of received funds for this payment method (excludes VAT).
 	    /// </summary>
-	    public required Amount AmountNet { get; init; }
+	    public required Amount AmountNet { get; set; }
 
 	    /// <summary>
 	    /// The VAT amount applicable to the revenue.
 	    /// </summary>
-	    public required Amount AmountVat { get; init; }
+	    public required Amount AmountVat { get; set; }
 
 	    /// <summary>
 	    /// The gross total of received funds for this payment method (includes VAT).
 	    /// </summary>
-	    public required Amount AmountGross { get; init; }
+	    public required Amount AmountGross { get; set; }
 
         /// <summary>
         /// The number of payments received for this payment method.
         /// </summary>
-        public required int Count { get; init; }
+        public required int Count { get; set; }
 
 		/// <summary>
 		/// The service rates, further divided into fixed and variable costs.
 		/// </summary>
-		public required SettlementPeriodCostsRate Rate { get; init; }
+		public required SettlementPeriodCostsRate Rate { get; set; }
 
 		/// <summary>
 		/// The payment method ID, if applicable - See the Mollie.Api.Models.Payment.PaymentMethod

--- a/src/Mollie.Api/Models/Settlement/Response/SettlementPeriodCostsRate.cs
+++ b/src/Mollie.Api/Models/Settlement/Response/SettlementPeriodCostsRate.cs
@@ -4,11 +4,11 @@
         /// <summary>
         /// An amount object describing the fixed costs.
         /// </summary>
-		public required Amount Fixed { get; init; }
+		public required Amount Fixed { get; set; }
 
         /// <summary>
         /// A string describing the variable costs as a percentage.
         /// </summary>
-		public required string Percentage { get; init; }
+		public required string Percentage { get; set; }
 	}
 }

--- a/src/Mollie.Api/Models/Settlement/Response/SettlementPeriodRevenue.cs
+++ b/src/Mollie.Api/Models/Settlement/Response/SettlementPeriodRevenue.cs
@@ -5,22 +5,22 @@
 		/// <summary>
 		/// A description of the subtotal.
 		/// </summary>
-		public required string Description { get; init; }
+		public required string Description { get; set; }
 
         /// <summary>
         /// The net total of received funds for this payment method (excludes VAT).
         /// </summary>
-        public required Amount AmountNet { get; init; }
+        public required Amount AmountNet { get; set; }
 
         /// <summary>
         /// The VAT amount applicable to the revenue.
         /// </summary>
-        public required Amount AmountVat { get; init; }
+        public required Amount AmountVat { get; set; }
 
         /// <summary>
         /// The gross total of received funds for this payment method (includes VAT).
         /// </summary>
-        public required Amount AmountGross { get; init; }
+        public required Amount AmountGross { get; set; }
 
 		/// <summary>
 		/// The number of times costs were made for this payment method.

--- a/src/Mollie.Api/Models/Settlement/Response/SettlementResponse.cs
+++ b/src/Mollie.Api/Models/Settlement/Response/SettlementResponse.cs
@@ -8,23 +8,23 @@ namespace Mollie.Api.Models.Settlement.Response {
         /// <summary>
         /// Indicates the response contains a settlement object. Will always contain settlement for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
 		/// <summary>
 		/// The settlement's identifier, for example stl_jDk30akdN.
 		/// </summary>
-		public required string Id { get; init; }
+		public required string Id { get; set; }
 
 		/// <summary>
 		/// The settlement's bank reference, as found on your invoice and in your Mollie account.
 		/// </summary>
-		public required string Reference { get; init; }
+		public required string Reference { get; set; }
 
 		/// <summary>
 		/// The date on which the settlement was created.
 		/// When requesting the next settlement the returned date signifies the expected settlement date.
 		/// </summary>
-		public required DateTime CreatedAt { get; init; }
+		public required DateTime CreatedAt { get; set; }
 
 		/// <summary>
 		/// The date on which the settlement was settled.
@@ -36,24 +36,24 @@ namespace Mollie.Api.Models.Settlement.Response {
 		/// The status of the settlement - See the Mollie.Api.Models.Settlement.SettlementStatus
 		/// class for a full list of known values.
 		/// </summary>
-		public required string Status { get; init; }
+		public required string Status { get; set; }
 
 		/// <summary>
 		/// The total amount paid out with this settlement.
 		/// </summary>
-		public required Amount Amount { get; init; }
+		public required Amount Amount { get; set; }
 
 		/// <summary>
 		/// This object is a collection of Period objects, which describe the settlement by month in full detail.
 		/// Please refer to the Period object section below.
 		/// </summary>
 		[JsonConverter(typeof(SettlementPeriodConverter))]
-		public required Dictionary<int, Dictionary<int, SettlementPeriod>> Periods { get; init; }
+		public required Dictionary<int, Dictionary<int, SettlementPeriod>> Periods { get; set; }
 
         /// <summary>
         /// An object with several URL objects relevant to the settlement. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required SettlementResponseLinks Links { get; init; }
+        public required SettlementResponseLinks Links { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Settlement/Response/SettlementResponseLinks.cs
+++ b/src/Mollie.Api/Models/Settlement/Response/SettlementResponseLinks.cs
@@ -9,26 +9,26 @@ namespace Mollie.Api.Models.Settlement.Response {
         /// <summary>
         /// The API resource URL of the settlement itself.
         /// </summary>
-        public required UrlObjectLink<SettlementResponse> Self { get; init; }
+        public required UrlObjectLink<SettlementResponse> Self { get; set; }
 
         /// <summary>
         /// The API resource URL of the payments that are included in this settlement.
         /// </summary>
-        public required UrlObjectLink<ListResponse<PaymentResponse>> Payments { get; init; }
+        public required UrlObjectLink<ListResponse<PaymentResponse>> Payments { get; set; }
 
         /// <summary>
         /// The API resource URL of the refunds that are included in this settlement.
         /// </summary>
-        public required UrlObjectLink<ListResponse<RefundResponse>> Refunds { get; init; }
+        public required UrlObjectLink<ListResponse<RefundResponse>> Refunds { get; set; }
 
         /// <summary>
         /// The API resource URL of the chargebacks that are included in this settlement.
         /// </summary>
-        public required UrlObjectLink<ListResponse<ChargebackResponse>> Chargebacks { get; init; }
+        public required UrlObjectLink<ListResponse<ChargebackResponse>> Chargebacks { get; set; }
 
         /// <summary>
         /// The URL to the settlement retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Shipment/Request/ShipmentLineRequest.cs
+++ b/src/Mollie.Api/Models/Shipment/Request/ShipmentLineRequest.cs
@@ -3,7 +3,7 @@
         /// <summary>
         /// The API resource token of the order line, for example: odl_jp31jz.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// The number of items that should be shipped for this order line.

--- a/src/Mollie.Api/Models/Shipment/Request/ShipmentUpdateRequest.cs
+++ b/src/Mollie.Api/Models/Shipment/Request/ShipmentUpdateRequest.cs
@@ -1,7 +1,7 @@
 namespace Mollie.Api.Models.Shipment.Request
 {
     public record ShipmentUpdateRequest {
-        public required TrackingObject Tracking { get; init; }
+        public required TrackingObject Tracking { get; set; }
 
         /// <summary>
         ///	Oauth only - Optional – Set this to true to make this shipment a test shipment.

--- a/src/Mollie.Api/Models/Shipment/Response/ShipmentResponse.cs
+++ b/src/Mollie.Api/Models/Shipment/Response/ShipmentResponse.cs
@@ -11,22 +11,22 @@ namespace Mollie.Api.Models.Shipment.Response
         /// <summary>
         /// Indicates the response contains a shipment object. Will always contain shipment for this endpoint.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         /// The shipment’s unique identifier, for example shp_3wmsgCJN4U.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// The order this shipment was created on, for example ord_8wmqcHMN4U.
         /// </summary>
-        public required string OrderId { get; init; }
+        public required string OrderId { get; set; }
 
         /// <summary>
         /// The shipment’s date and time of creation, in ISO 8601 format.
         /// </summary>
-        public required DateTime CreatedAt { get; init; }
+        public required DateTime CreatedAt { get; set; }
 
         /// <summary>
         /// An object containing shipment tracking details. Will be omitted when no tracking details are available.
@@ -43,13 +43,13 @@ namespace Mollie.Api.Models.Shipment.Response
         /// <summary>
         /// An array of order line objects
         /// </summary>
-        public required IEnumerable<OrderLineResponse> Lines { get; init; }
+        public required IEnumerable<OrderLineResponse> Lines { get; set; }
 
         /// <summary>
         /// An object with several URL objects relevant to the order. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required ShipmentResponseLinks Links { get; init; }
+        public required ShipmentResponseLinks Links { get; set; }
 
         public T? GetMetadata<T>(JsonSerializerSettings? jsonSerializerSettings = null) {
             return Metadata != null ? JsonConvert.DeserializeObject<T>(Metadata, jsonSerializerSettings) : default;

--- a/src/Mollie.Api/Models/Shipment/Response/ShipmentResponseLinks.cs
+++ b/src/Mollie.Api/Models/Shipment/Response/ShipmentResponseLinks.cs
@@ -5,17 +5,17 @@ namespace Mollie.Api.Models.Shipment.Response {
         /// <summary>
         /// The API resource URL of the order itself.
         /// </summary>
-        public required UrlObjectLink<ShipmentResponse> Self { get; init; }
+        public required UrlObjectLink<ShipmentResponse> Self { get; set; }
 
         /// <summary>
         /// The URL your customer should visit to make the payment for the order.
         /// This is where you should redirect the customer to after creating the order.
         /// </summary>
-        public required UrlLink Checkout { get; init; }
+        public required UrlLink Checkout { get; set; }
 
         /// <summary>
         /// The URL to the order retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Shipment/TrackingObject.cs
+++ b/src/Mollie.Api/Models/Shipment/TrackingObject.cs
@@ -3,12 +3,12 @@
         /// <summary>
         /// Name of the postal carrier (as specific as possible). For example PostNL.
         /// </summary>
-        public required string Carrier { get; init; }
+        public required string Carrier { get; set; }
 
         /// <summary>
         /// The track and trace code of the shipment. For example 3SKABA000000000.
         /// </summary>
-        public required string Code { get; init; }
+        public required string Code { get; set; }
 
         /// <summary>
         /// The URL where your customer can track the shipment

--- a/src/Mollie.Api/Models/Subscription/Request/SubscriptionRequest.cs
+++ b/src/Mollie.Api/Models/Subscription/Request/SubscriptionRequest.cs
@@ -8,7 +8,7 @@ namespace Mollie.Api.Models.Subscription.Request {
         /// The constant amount in EURO that you want to charge with each subscription payment, e.g. 100.00 if you would want
         /// to charge € 100,00.
         /// </summary>
-        public required Amount Amount { get; init; }
+        public required Amount Amount { get; set; }
 
         /// <summary>
         /// Optional – Total number of charges for the subscription to complete. Leave empty for an on-going subscription.
@@ -18,7 +18,7 @@ namespace Mollie.Api.Models.Subscription.Request {
         /// <summary>
         /// Interval to wait between charges, for example 1 month or 14 days.
         /// </summary>
-        public required string Interval { get; init; }
+        public required string Interval { get; set; }
 
         /// <summary>
         /// Optional – The start date of the subscription in yyyy-mm-dd format. This is the first day on which your customer
@@ -31,7 +31,7 @@ namespace Mollie.Api.Models.Subscription.Request {
         /// A description unique per customer. This will be included in the payment description along with the charge date in
         /// Y-m-d format.
         /// </summary>
-        public required string Description { get; init; }
+        public required string Description { get; set; }
 
         /// <summary>
         /// Optional – The payment method used for this subscription, either forced on creation or null if any of the

--- a/src/Mollie.Api/Models/Subscription/Response/SubscriptionResponse.cs
+++ b/src/Mollie.Api/Models/Subscription/Response/SubscriptionResponse.cs
@@ -8,12 +8,12 @@ namespace Mollie.Api.Models.Subscription.Response {
         /// <summary>
         /// Indicates the response contains a subscription object.
         /// </summary>
-        public required string Resource { get; init; }
+        public required string Resource { get; set; }
 
         /// <summary>
         /// The subscription's unique identifier, for example sub_rVKGtNd6s3.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// The mode used to create this subscription. Mode determines whether the payments are real or test payments.
@@ -24,18 +24,18 @@ namespace Mollie.Api.Models.Subscription.Response {
         /// <summary>
         ///  The subscription's date and time of creation, in ISO 8601 format.
         /// </summary>
-        public required DateTime CreatedAt { get; init; }
+        public required DateTime CreatedAt { get; set; }
 
         /// <summary>
         /// The subscription's current status, depends on whether the customer has a pending, valid or invalid mandate.
         /// See the Mollie.Api.Models.Subscription.SubscriptionStatus class for a full list of known values.
         /// </summary>
-        public required string Status { get; init; }
+        public required string Status { get; set; }
 
         /// <summary>
         /// The constant amount that is charged with each subscription payment.
         /// </summary>
-        public required Amount Amount { get; init; }
+        public required Amount Amount { get; set; }
 
         /// <summary>
         /// Total number of charges for the subscription to complete.
@@ -50,7 +50,7 @@ namespace Mollie.Api.Models.Subscription.Response {
         /// <summary>
         /// Interval to wait between charges like 1 month(s) or 14 days.
         /// </summary>
-        public required string Interval { get; init; }
+        public required string Interval { get; set; }
 
         /// <summary>
         /// The start date of the subscription in yyyy-mm-dd format.
@@ -67,7 +67,7 @@ namespace Mollie.Api.Models.Subscription.Response {
         /// A description unique per customer. This will be included in the payment description along with the charge date in
         /// Y-m-d format.
         /// </summary>
-        public required string Description { get; init; }
+        public required string Description { get; set; }
 
         /// <summary>
         /// The payment method used for this subscription, either forced on creation by specifying the method parameter, or
@@ -102,7 +102,7 @@ namespace Mollie.Api.Models.Subscription.Response {
         /// An object with several URL objects relevant to the subscription. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required SubscriptionResponseLinks Links { get; init; }
+        public required SubscriptionResponseLinks Links { get; set; }
 
         /// <summary>
         /// Adding an application fee allows you to charge the merchant for each payment in the subscription and

--- a/src/Mollie.Api/Models/Subscription/Response/SubscriptionResponseLinks.cs
+++ b/src/Mollie.Api/Models/Subscription/Response/SubscriptionResponseLinks.cs
@@ -9,12 +9,12 @@ namespace Mollie.Api.Models.Subscription.Response {
         /// <summary>
         ///     The API resource URL of the subscription itself.
         /// </summary>
-        public required UrlObjectLink<SubscriptionResponse> Self { get; init; }
+        public required UrlObjectLink<SubscriptionResponse> Self { get; set; }
 
         /// <summary>
         /// The API resource URL of the customer the subscription is for.
         /// </summary>
-        public required UrlObjectLink<CustomerResponse> Customer { get; init; }
+        public required UrlObjectLink<CustomerResponse> Customer { get; set; }
 
         /// <summary>
         /// The API resource URL of the payments that are created by this subscription. Not present
@@ -25,11 +25,11 @@ namespace Mollie.Api.Models.Subscription.Response {
         /// <summary>
         /// The API resource URL of the website profile on which this subscription was created.
         /// </summary>
-        public required UrlObjectLink<ProfileResponse> Profile { get; init; }
+        public required UrlObjectLink<ProfileResponse> Profile { get; set; }
 
         /// <summary>
         /// The URL to the subscription retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Terminal/Response/TerminalResponse.cs
+++ b/src/Mollie.Api/Models/Terminal/Response/TerminalResponse.cs
@@ -12,44 +12,44 @@ namespace Mollie.Api.Models.Terminal.Response
         /// The unique identifier used for referring to a terminal. Mollie assigns this identifier at terminal creation time.
         /// For example term_7MgL4wea46qkRcoTZjWEH. This ID will be used by Mollie to refer to a certain terminal and will be used for assigning a payment to a specific terminal.
         /// </summary>
-        public required string Id { get; init; }
+        public required string Id { get; set; }
 
         /// <summary>
         /// The identifier used for referring to the profile the terminal was created on. For example, pfl_QkEhN94Ba.
         /// </summary>
-        public required string ProfileId { get; init; }
+        public required string ProfileId { get; set; }
 
         /// <summary>
         /// The status of the terminal, which is a read-only value determined by Mollie, according to the actions performed for that terminal.
         /// Its values can be pending, active, inactive. pending means that the terminal has been created but not yet active.
         /// active means that the terminal is active and can take payments. inactive means that the terminal has been deactivated.
         /// </summary>
-        public required string Status { get; init; }
+        public required string Status { get; set; }
 
         /// <summary>
         /// The brand of the terminal.
         /// </summary>
-        public required string Brand { get; init; }
+        public required string Brand { get; set; }
 
         /// <summary>
         /// The model of the terminal.
         /// </summary>
-        public required string Model { get; init; }
+        public required string Model { get; set; }
 
         /// <summary>
         /// The serial number of the terminal. The serial number is provided at terminal creation time.
         /// </summary>
-        public required string SerialNumber { get; init; }
+        public required string SerialNumber { get; set; }
 
         /// <summary>
         /// An ISO 4217 currency code. The currencies supported depend on the payment methods that are enabled on your account.
         /// </summary>
-        public required string Currency { get; init; }
+        public required string Currency { get; set; }
 
         /// <summary>
         /// The full name of the payment terminal.
         /// </summary>
-        public required string Description { get; init; }
+        public required string Description { get; set; }
 
         /// <summary>
         /// The Terminal's date and time of creation, in ISO 8601 format.
@@ -65,6 +65,6 @@ namespace Mollie.Api.Models.Terminal.Response
         /// An object with several URL objects relevant to the payment method. Every URL object will contain an href and a type field.
         /// </summary>
         [JsonProperty("_links")]
-        public required TerminalResponseLinks Links { get; init; }
+        public required TerminalResponseLinks Links { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Terminal/Response/TerminalResponseLinks.cs
+++ b/src/Mollie.Api/Models/Terminal/Response/TerminalResponseLinks.cs
@@ -10,11 +10,11 @@ namespace Mollie.Api.Models.Terminal.Response
         /// <summary>
         /// The API resource URL of the payment method itself.
         /// </summary>
-        public required UrlObjectLink<TerminalResponse> Self { get; init; }
+        public required UrlObjectLink<TerminalResponse> Self { get; set; }
 
         /// <summary>
         /// The URL to the payment method retrieval endpoint documentation.
         /// </summary>
-        public required UrlLink Documentation { get; init; }
+        public required UrlLink Documentation { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Url/UrlLink.cs
+++ b/src/Mollie.Api/Models/Url/UrlLink.cs
@@ -1,7 +1,7 @@
 ﻿namespace Mollie.Api.Models.Url {
     public record UrlLink {
-        public required string Href { get; init; }
-        public required string Type { get; init; }
+        public required string Href { get; set; }
+        public required string Type { get; set; }
 
         public override string ToString() {
             return $"{Type} - {Href}";

--- a/src/Mollie.Api/Models/Wallet/Request/ApplePayPaymentSessionRequest.cs
+++ b/src/Mollie.Api/Models/Wallet/Request/ApplePayPaymentSessionRequest.cs
@@ -5,11 +5,11 @@
         /// A list of all valid host names for merchant validation is available. You should white list these in your
         /// application and reject any validationUrl that have a host name not in the list.
         /// </summary>
-        public required string ValidationUrl { get; init; }
-        
+        public required string ValidationUrl { get; set; }
+
         /// <summary>
         /// The domain of your web shop, that is visible in the browser’s location bar. For example pay.myshop.com.
         /// </summary>
-        public required string Domain { get; init; }
+        public required string Domain { get; set; }
     }
 }

--- a/src/Mollie.Api/Models/Wallet/Response/ApplePayPaymentSessionResponse.cs
+++ b/src/Mollie.Api/Models/Wallet/Response/ApplePayPaymentSessionResponse.cs
@@ -5,14 +5,14 @@ using Newtonsoft.Json;
 namespace Mollie.Api.Models.Wallet.Response {
     public record ApplePayPaymentSessionResponse {
         [JsonConverter(typeof(MicrosecondEpochConverter))]
-        public required DateTime EpochTimestamp { get; init; }
+        public required DateTime EpochTimestamp { get; set; }
         [JsonConverter(typeof(MicrosecondEpochConverter))]
-        public required DateTime ExpiresAt { get; init; }
-        public required string MerchantSessionIdentifier { get; init; }
-        public required string Nonce { get; init; }
-        public required string MerchantIdentifier { get; init; }
-        public required string DomainName { get; init; }
-        public required string DisplayName { get; init; }
-        public required string Signature { get; init; }
+        public required DateTime ExpiresAt { get; set; }
+        public required string MerchantSessionIdentifier { get; set; }
+        public required string Nonce { get; set; }
+        public required string MerchantIdentifier { get; set; }
+        public required string DomainName { get; set; }
+        public required string DisplayName { get; set; }
+        public required string Signature { get; set; }
     }
 }

--- a/tests/Mollie.Tests.Integration/Api/PaymentMethodTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/PaymentMethodTests.cs
@@ -133,7 +133,6 @@ public class PaymentMethodTests : BaseMollieApiTestClass, IDisposable {
 
     [DefaultRetryTheory]
     [InlineData("JPY", 249)]
-    [InlineData("ISK", 50)]
     [InlineData("EUR", 50.25)]
     public async Task GetPaymentMethodListAsync_WithVariousCurrencies_ReturnsAvailablePaymentMethods(string currency, decimal value) {
         // When: Retrieving the payment methods for a currency and amount


### PR DESCRIPTION
Use { get; set; } everywhere instead of { get; init; } so we can continue to support lower C# language versions