### PR TITLE
#372: Throw a MollieApiException for all types of unsuccesfull API response codes

### DIFF
--- a/src/Mollie.Api/Client/BaseMollieClient.cs
+++ b/src/Mollie.Api/Client/BaseMollieClient.cs
@@ -92,20 +92,7 @@ namespace Mollie.Api.Client {
                 return _jsonConverterService.Deserialize<T>(resultContent)!;
             }
 
-            switch (response.StatusCode) {
-                case HttpStatusCode.BadRequest:
-                case HttpStatusCode.Unauthorized:
-                case HttpStatusCode.Forbidden:
-                case HttpStatusCode.NotFound:
-                case HttpStatusCode.MethodNotAllowed:
-                case HttpStatusCode.UnsupportedMediaType:
-                case HttpStatusCode.Gone:
-                case (HttpStatusCode) 422: // Unprocessable entity
-                    throw new MollieApiException(resultContent);
-                default:
-                    throw new HttpRequestException(
-                        $"Unknown http exception occured with status code: {(int) response.StatusCode}.");
-            }
+            throw new MollieApiException(response.StatusCode, resultContent);
         }
 
         protected void ValidateApiKeyIsOauthAccesstoken(bool isConstructor = false) {

--- a/src/Mollie.Api/Client/BaseMollieClient.cs
+++ b/src/Mollie.Api/Client/BaseMollieClient.cs
@@ -9,7 +9,9 @@ using System.Threading.Tasks;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework;
 using Mollie.Api.Framework.Idempotency;
+using Mollie.Api.Models.Error;
 using Mollie.Api.Models.Url;
+using Newtonsoft.Json;
 
 namespace Mollie.Api.Client {
     public abstract class BaseMollieClient : IDisposable {
@@ -92,7 +94,8 @@ namespace Mollie.Api.Client {
                 return _jsonConverterService.Deserialize<T>(resultContent)!;
             }
 
-            throw new MollieApiException(response.StatusCode, resultContent);
+            MollieErrorMessage errorDetails = ParseMollieErrorMessage(response.StatusCode, resultContent);
+            throw new MollieApiException(errorDetails);
         }
 
         protected void ValidateApiKeyIsOauthAccesstoken(bool isConstructor = false) {
@@ -148,6 +151,19 @@ namespace Mollie.Api.Client {
             const string packageName = "Mollie.Api.NET";
             string versionNumber = typeof(BaseMollieClient).GetTypeInfo().Assembly.GetName().Version.ToString();
             return $"{packageName}/{versionNumber}";
+        }
+
+        private MollieErrorMessage ParseMollieErrorMessage(HttpStatusCode responseStatusCode, string responseBody) {
+            try {
+                return _jsonConverterService.Deserialize<MollieErrorMessage>(responseBody)!;
+            }
+            catch (JsonReaderException) {
+                return new MollieErrorMessage {
+                    Title = "Unknown error",
+                    Status = (int)responseStatusCode,
+                    Detail = responseBody
+                };
+            }
         }
 
         protected void ValidateRequiredUrlParameter(string parameterName, string parameterValue) {

--- a/src/Mollie.Api/Client/MollieApiException.cs
+++ b/src/Mollie.Api/Client/MollieApiException.cs
@@ -1,28 +1,12 @@
 ﻿using System;
-using System.Net;
 using Mollie.Api.Models.Error;
-using Newtonsoft.Json;
 
 namespace Mollie.Api.Client {
     public class MollieApiException : Exception {
         public MollieErrorMessage Details { get; set; }
 
-        public MollieApiException(HttpStatusCode httpStatusCode, string responseBody)
-            : base(ParseErrorMessage(httpStatusCode, responseBody).ToString()){
-            Details = ParseErrorMessage(httpStatusCode, responseBody);
-        }
-
-        private static MollieErrorMessage ParseErrorMessage(HttpStatusCode httpStatusCode, string responseBody) {
-            try {
-                return JsonConvert.DeserializeObject<MollieErrorMessage>(responseBody)!;
-            }
-            catch (JsonReaderException) {
-                return new MollieErrorMessage {
-                    Title = "Unknown error",
-                    Status = (int)httpStatusCode,
-                    Detail = responseBody
-                };
-            }
+        public MollieApiException(MollieErrorMessage details) : base(details.ToString()) {
+            Details = details;
         }
     }
 }

--- a/tests/Mollie.Tests.Unit/Client/BaseClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/BaseClientTests.cs
@@ -1,14 +1,23 @@
-﻿using RichardSzalay.MockHttp;
+﻿using System.Net;
+using RichardSzalay.MockHttp;
 using System.Net.Http;
+using System.Net.Mime;
 
 namespace Mollie.Tests.Unit.Client {
     public abstract class BaseClientTests {
         protected const string DefaultRedirectUrl = "https://www.mollie.com";
 
-        protected MockHttpMessageHandler CreateMockHttpMessageHandler(HttpMethod httpMethod, string url, string response, string expectedPartialContent = null) {
-            MockHttpMessageHandler mockHttp = new MockHttpMessageHandler();
+        protected MockHttpMessageHandler CreateMockHttpMessageHandler(
+            HttpMethod httpMethod,
+            string url,
+            string response,
+            string expectedPartialContent = null,
+            string responseContentType =  MediaTypeNames.Application.Json,
+            HttpStatusCode responseStatusCode = HttpStatusCode.OK) {
+
+            MockHttpMessageHandler mockHttp = new();
             MockedRequest mockedRequest = mockHttp.Expect(httpMethod, url)
-                .Respond("application/json", response);
+                .Respond(responseStatusCode, responseContentType, response);
 
             if (!string.IsNullOrEmpty(expectedPartialContent))
             {

--- a/tests/Mollie.Tests.Unit/Client/BaseMollieClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/BaseMollieClientTests.cs
@@ -1,0 +1,77 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Net.Mime;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Mollie.Api.Client;
+using Mollie.Api.Models;
+using Mollie.Api.Models.Payment.Request;
+using Xunit;
+
+namespace Mollie.Tests.Unit.Client;
+
+public class BaseMollieClientTests : BaseClientTests {
+    [Fact]
+    public async Task HttpResponseStatusCodeIsNotSuccesfull_ResponseBodyContainsMollieErrorDetails_MollieApiExceptionIsThrown() {
+
+        // Arrange
+        const string errorMessage = "A validation error occured";
+        const int errorStatus = (int)HttpStatusCode.UnprocessableEntity;
+        string responseBody = @$"{{
+    ""_links"": {{
+        ""documentation"": {{
+            ""href"": ""https://docs.mollie.com/overview/handling-errors"",
+            ""type"": ""text/html""
+        }}
+    }},
+    ""detail"": ""{errorMessage}"",
+    ""status"": {errorStatus},
+    ""title"": ""Error""
+}}";
+        const string expectedUrl = $"{BaseMollieClient.ApiEndPoint}payments";
+        var mockHttp = CreateMockHttpMessageHandler(
+            HttpMethod.Post,
+            expectedUrl,
+            responseBody,
+            responseStatusCode: HttpStatusCode.UnprocessableEntity);
+        HttpClient httpClient = mockHttp.ToHttpClient();
+        PaymentClient paymentClient = new("api-key", httpClient);
+        PaymentRequest paymentRequest = new() {
+            Amount = new Amount(Currency.EUR, 50m),
+            Description = "description"
+        };
+
+        // Act
+        var exception = await Assert.ThrowsAsync<MollieApiException>(() => paymentClient.CreatePaymentAsync(paymentRequest));
+
+        // Assert
+        exception.Details.Detail.Should().Be(errorMessage);
+        exception.Details.Status.Should().Be(errorStatus);
+    }
+
+    [Fact]
+    public async Task HttpResponseStatusCodeIsNotSuccesfull_ResponseBodyContainsHtml_MollieApiExceptionIsThrown() {
+        // Arrange
+        string responseBody = "<html><body>Whoops!</body></html>";
+        const string expectedUrl = $"{BaseMollieClient.ApiEndPoint}payments";
+        var mockHttp = CreateMockHttpMessageHandler(
+            HttpMethod.Post,
+            expectedUrl,
+            responseBody,
+            responseContentType: MediaTypeNames.Text.Html,
+            responseStatusCode: HttpStatusCode.UnprocessableEntity);
+        HttpClient httpClient = mockHttp.ToHttpClient();
+        PaymentClient paymentClient = new("api-key", httpClient);
+        PaymentRequest paymentRequest = new() {
+            Amount = new Amount(Currency.EUR, 50m),
+            Description = "description"
+        };
+
+        // Act
+        var exception = await Assert.ThrowsAsync<MollieApiException>(() => paymentClient.CreatePaymentAsync(paymentRequest));
+
+        // Assert
+        exception.Details.Detail.Should().Be(responseBody);
+        exception.Details.Status.Should().Be((int)HttpStatusCode.UnprocessableEntity);
+    }
+}


### PR DESCRIPTION
Fix for #372 

BaseMollieClient now throws a `MollieApiException` for every type of failed HTTP status code. Previously, this was only done for a specific set of HTTP status codes. In all other cases, the old implementation raised a `HttpRequestException`. This made it more difficult for consumers to catch exceptions, since they had to catch both the `MollieApiException` and the `HttpRequestException` types. 