### PR TITLE
Add support for new PaymentLink update and delete methods

### DIFF
--- a/src/Mollie.Api/Client/Abstract/IPaymentLinkClient.cs
+++ b/src/Mollie.Api/Client/Abstract/IPaymentLinkClient.cs
@@ -14,6 +14,31 @@ namespace Mollie.Api.Client.Abstract {
         Task<PaymentLinkResponse> CreatePaymentLinkAsync(PaymentLinkRequest paymentLinkRequest);
 
         /// <summary>
+        /// Update a payment link
+        /// </summary>
+        /// <param name="paymentLinkId">Provide the ID of the item you want to perform this operation on.</param>
+        /// <param name="paymentLinkUpdateRequest">The request body</param>
+        /// <param name="testmode">Most API credentials are specifically created for either live mode or test mode.
+        /// In those cases the testmode query parameter can be omitted. For organization-level credentials such as
+        /// OAuth access tokens, you can enable test mode by setting the testmode query parameter to true.</param>
+        /// <returns>The updated payment link response</returns>
+        Task<PaymentLinkResponse> UpdatePaymentLinkAsync(
+            string paymentLinkId,
+            PaymentLinkUpdateRequest paymentLinkUpdateRequest,
+            bool testmode = false);
+
+        /// <summary>
+        /// Payment links for which no payments have been made yet can be deleted entirely. This can be useful for
+        /// removing payment links that have been incorrectly configured or that are no longer relevant.
+        /// </summary>
+        /// <param name="paymentLinkId">Provide the ID of the item you want to perform this operation on.</param>
+        /// <param name="testmode">Most API credentials are specifically created for either live mode or test mode.
+        /// In those cases the testmode query parameter can be omitted. For organization-level credentials such as
+        /// OAuth access tokens, you can enable test mode by setting the testmode query parameter to true.</param>
+        /// <returns></returns>
+        Task DeletePaymentLinkAsync(string paymentLinkId, bool testmode = false);
+
+        /// <summary>
         ///	Retrieve a single payment link object by its token.
         /// </summary>
         /// <param name="paymentLinkId">The payment link to retrieve</param>

--- a/src/Mollie.Api/Client/PaymentLinkClient.cs
+++ b/src/Mollie.Api/Client/PaymentLinkClient.cs
@@ -23,6 +23,24 @@ namespace Mollie.Api.Client
             return await PostAsync<PaymentLinkResponse>($"payment-links", paymentLinkRequest).ConfigureAwait(false);
         }
 
+        public async Task<PaymentLinkResponse> UpdatePaymentLinkAsync(
+            string paymentLinkId,
+            PaymentLinkUpdateRequest paymentLinkUpdateRequest,
+            bool testmode = false) {
+
+            ValidateRequiredUrlParameter(nameof(paymentLinkId), paymentLinkId);
+            var queryParameters = BuildQueryParameters(testmode);
+            string relativeUri = $"payment-links/{paymentLinkId}{queryParameters.ToQueryString()}";
+            return await PatchAsync<PaymentLinkResponse>(relativeUri, paymentLinkUpdateRequest).ConfigureAwait(false);
+        }
+
+        public async Task DeletePaymentLinkAsync(string paymentLinkId, bool testmode = false) {
+            ValidateRequiredUrlParameter(nameof(paymentLinkId), paymentLinkId);
+            var queryParameters = BuildQueryParameters(testmode);
+            string relativeUri = $"payment-links/{paymentLinkId}{queryParameters.ToQueryString()}";
+            await DeleteAsync(relativeUri).ConfigureAwait(false);
+        }
+
         public async Task<PaymentLinkResponse> GetPaymentLinkAsync(string paymentLinkId, bool testmode = false)
         {
             ValidateRequiredUrlParameter(nameof(paymentLinkId), paymentLinkId);
@@ -42,7 +60,6 @@ namespace Mollie.Api.Client
             return await GetAsync(url).ConfigureAwait(false);
         }
 
-
         public async Task<ListResponse<PaymentLinkResponse>> GetPaymentLinkListAsync(UrlObjectLink<ListResponse<PaymentLinkResponse>> url)
         {
             return await GetAsync(url).ConfigureAwait(false);
@@ -60,6 +77,12 @@ namespace Mollie.Api.Client
                testmode: testmode);
 
             return await GetListAsync<ListResponse<PaymentLinkResponse>>("payment-links", from, limit, queryParameters).ConfigureAwait(false);
+        }
+
+        private Dictionary<string, string> BuildQueryParameters(bool testmode = false) {
+            var result = new Dictionary<string, string>();
+            result.AddValueIfTrue("testmode", testmode);
+            return result;
         }
 
         private Dictionary<string, string> BuildQueryParameters(string? profileId = null, bool testmode = false)

--- a/src/Mollie.Api/Models/PaymentLink/Request/PaymentLinkUpdateRequest.cs
+++ b/src/Mollie.Api/Models/PaymentLink/Request/PaymentLinkUpdateRequest.cs
@@ -1,0 +1,16 @@
+﻿namespace Mollie.Api.Models.PaymentLink.Request;
+
+public record PaymentLinkUpdateRequest {
+    /// <summary>
+    /// A short description of the payment link. The description is visible in the Dashboard and will be shown on the
+    /// customer's bank or card statement when possible.
+    ///
+    /// Updating the description does not affect any previously existing payments created for this payment link.
+    /// </summary>
+    public required string Description { get; init; }
+
+    /// <summary>
+    /// Whether the payment link is archived. Customers will not be able to complete payments on archived payment links.
+    /// </summary>
+    public required bool Archived { get; init; }
+}

--- a/src/Mollie.Api/Models/PaymentLink/Response/PaymentLinkResponse.cs
+++ b/src/Mollie.Api/Models/PaymentLink/Response/PaymentLinkResponse.cs
@@ -38,6 +38,11 @@ namespace Mollie.Api.Models.PaymentLink.Response
         public required Amount Amount { get; set; }
 
         /// <summary>
+        /// Whether the payment link is archived. Customers will not be able to complete payments on archived payment links.
+        /// </summary>
+        public required bool Archived { get; set; }
+
+        /// <summary>
         /// The URL your customer will be redirected to after completing the payment process.
         /// </summary>
         public string? RedirectUrl { get; set; }


### PR DESCRIPTION
New PaymentLink API methods have been added to update a PaymentLink or delete a PaymentLink:
https://docs.mollie.com/reference/update-payment-link
https://docs.mollie.com/reference/delete-payment-link

Also added support for the `PaymentLinkResponse.Archived` property.