### PR TITLE
Update PaymentMethod constant list with new payment methods

### DIFF
--- a/src/Mollie.Api/Models/Payment/PaymentMethod.cs
+++ b/src/Mollie.Api/Models/Payment/PaymentMethod.cs
@@ -24,5 +24,13 @@
         public const string In3 = "in3";
         public const string PointOfSale = "pointofsale";
         public const string Billie = "billie";
+        public const string Trustly = "trustly";
+        public const string Twint = "twint";
+        public const string Satispay = "satispay";
+        public const string Riverty = "riverty";
+        public const string Blik = "blik";
+        public const string BancomatPay = "bancomat_pay";
+        public const string BacsDirectDebit = "bacs";
+        public const string Alma = "alma";
     }
 }

--- a/tests/Mollie.Tests.Unit/Framework/Factories/PaymentResponseFactoryTests.cs
+++ b/tests/Mollie.Tests.Unit/Framework/Factories/PaymentResponseFactoryTests.cs
@@ -32,11 +32,20 @@ namespace Mollie.Tests.Unit.Framework.Factories {
         [InlineData(PaymentMethod.MealVoucher, typeof(PaymentResponse))]
         [InlineData(PaymentMethod.In3, typeof(PaymentResponse))]
         [InlineData(PaymentMethod.PointOfSale, typeof(PointOfSalePaymentResponse))]
+        [InlineData(PaymentMethod.Billie, typeof(PaymentResponse))]
+        [InlineData(PaymentMethod.Trustly, typeof(PaymentResponse))]
+        [InlineData(PaymentMethod.Twint, typeof(PaymentResponse))]
+        [InlineData(PaymentMethod.Satispay, typeof(PaymentResponse))]
+        [InlineData(PaymentMethod.Riverty, typeof(PaymentResponse))]
+        [InlineData(PaymentMethod.Blik, typeof(PaymentResponse))]
+        [InlineData(PaymentMethod.BancomatPay, typeof(PaymentResponse))]
+        [InlineData(PaymentMethod.BacsDirectDebit, typeof(PaymentResponse))]
+        [InlineData(PaymentMethod.Alma, typeof(PaymentResponse))]
         [InlineData("UnknownPaymentMethod", typeof(PaymentResponse))]
         public void Create_CreatesTypeBasedOnPaymentMethod(string paymentMethod, Type expectedType) {
             // Given
             var sut = new PaymentResponseFactory();
-            
+
             // When
             var result = sut.Create(paymentMethod);
 


### PR DESCRIPTION
Expanded the list of PaymentMethods with: Trustly, Twint, Satispay, Riverty, Bli, BancomayPay, BacsDirectDirect and Alma