### PR TITLE
Improve the way we can use payment method specific payment requests

### DIFF
--- a/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/ApplePayPaymentRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/ApplePayPaymentRequest.cs
@@ -1,7 +1,14 @@
-﻿namespace Mollie.Api.Models.Payment.Request.PaymentSpecificParameters {
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Mollie.Api.Models.Payment.Request.PaymentSpecificParameters {
     public record ApplePayPaymentRequest : PaymentRequest {
         public ApplePayPaymentRequest()
         {
+            Method = PaymentMethod.ApplePay;
+        }
+
+        [SetsRequiredMembers]
+        public ApplePayPaymentRequest(PaymentRequest paymentRequest) : base(paymentRequest) {
             Method = PaymentMethod.ApplePay;
         }
 

--- a/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/BankTransferPaymentRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/BankTransferPaymentRequest.cs
@@ -1,6 +1,13 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Mollie.Api.Models.Payment.Request.PaymentSpecificParameters {
     public record BankTransferPaymentRequest : PaymentRequest {
         public BankTransferPaymentRequest() {
+            Method = PaymentMethod.BankTransfer;
+        }
+
+        [SetsRequiredMembers]
+        public BankTransferPaymentRequest(PaymentRequest paymentRequest) : base(paymentRequest) {
             Method = PaymentMethod.BankTransfer;
         }
 

--- a/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/CreditCardPaymentRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/CreditCardPaymentRequest.cs
@@ -1,6 +1,13 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Mollie.Api.Models.Payment.Request.PaymentSpecificParameters {
     public record CreditCardPaymentRequest : PaymentRequest {
         public CreditCardPaymentRequest() {
+            Method = PaymentMethod.CreditCard;
+        }
+
+        [SetsRequiredMembers]
+        public CreditCardPaymentRequest(PaymentRequest paymentRequest) : base(paymentRequest) {
             Method = PaymentMethod.CreditCard;
         }
 

--- a/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/GiftcardPaymentRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/GiftcardPaymentRequest.cs
@@ -1,6 +1,13 @@
-﻿namespace Mollie.Api.Models.Payment.Request.PaymentSpecificParameters {
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Mollie.Api.Models.Payment.Request.PaymentSpecificParameters {
     public record GiftcardPaymentRequest : PaymentRequest {
         public GiftcardPaymentRequest() {
+            Method = PaymentMethod.GiftCard;
+        }
+
+        [SetsRequiredMembers]
+        public GiftcardPaymentRequest(PaymentRequest paymentRequest) : base(paymentRequest) {
             Method = PaymentMethod.GiftCard;
         }
 

--- a/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/IDealPaymentRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/IDealPaymentRequest.cs
@@ -1,6 +1,13 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Mollie.Api.Models.Payment.Request.PaymentSpecificParameters {
     public record IdealPaymentRequest : PaymentRequest {
         public IdealPaymentRequest() {
+            Method = PaymentMethod.Ideal;
+        }
+
+        [SetsRequiredMembers]
+        public IdealPaymentRequest(PaymentRequest paymentRequest) : base(paymentRequest) {
             Method = PaymentMethod.Ideal;
         }
 

--- a/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/KbcPaymentRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/KbcPaymentRequest.cs
@@ -1,6 +1,13 @@
-﻿namespace Mollie.Api.Models.Payment.Request.PaymentSpecificParameters {
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Mollie.Api.Models.Payment.Request.PaymentSpecificParameters {
     public record KbcPaymentRequest : PaymentRequest {
         public KbcPaymentRequest() {
+            Method = PaymentMethod.Kbc;
+        }
+
+        [SetsRequiredMembers]
+        public KbcPaymentRequest(PaymentRequest paymentRequest) : base(paymentRequest) {
             Method = PaymentMethod.Kbc;
         }
 

--- a/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/PayPalPaymentRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/PayPalPaymentRequest.cs
@@ -1,6 +1,13 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Mollie.Api.Models.Payment.Request.PaymentSpecificParameters {
     public record PayPalPaymentRequest : PaymentRequest {
         public PayPalPaymentRequest() {
+            Method = PaymentMethod.PayPal;
+        }
+
+        [SetsRequiredMembers]
+        public PayPalPaymentRequest(PaymentRequest paymentRequest) : base(paymentRequest) {
             Method = PaymentMethod.PayPal;
         }
 

--- a/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/PaySafeCardPaymentRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/PaySafeCardPaymentRequest.cs
@@ -1,6 +1,13 @@
-﻿namespace Mollie.Api.Models.Payment.Request.PaymentSpecificParameters {
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Mollie.Api.Models.Payment.Request.PaymentSpecificParameters {
     public record PaySafeCardPaymentRequest : PaymentRequest {
         public PaySafeCardPaymentRequest() {
+            Method = PaymentMethod.PaySafeCard;
+        }
+
+        [SetsRequiredMembers]
+        public PaySafeCardPaymentRequest(PaymentRequest paymentRequest) : base(paymentRequest) {
             Method = PaymentMethod.PaySafeCard;
         }
 

--- a/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/Przelewy24PaymentRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/Przelewy24PaymentRequest.cs
@@ -1,9 +1,16 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Mollie.Api.Models.Payment.Request.PaymentSpecificParameters
 {
     public record Przelewy24PaymentRequest : PaymentRequest
     {
         public Przelewy24PaymentRequest()
         {
+            Method = PaymentMethod.Przelewy24;
+        }
+
+        [SetsRequiredMembers]
+        public Przelewy24PaymentRequest(PaymentRequest paymentRequest) : base(paymentRequest) {
             Method = PaymentMethod.Przelewy24;
         }
 

--- a/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/SepaDirectDebitRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/SepaDirectDebitRequest.cs
@@ -1,6 +1,13 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Mollie.Api.Models.Payment.Request.PaymentSpecificParameters {
     public record SepaDirectDebitRequest : PaymentRequest {
         public SepaDirectDebitRequest() {
+            Method = PaymentMethod.DirectDebit;
+        }
+
+        [SetsRequiredMembers]
+        public SepaDirectDebitRequest(PaymentRequest paymentRequest) : base(paymentRequest) {
             Method = PaymentMethod.DirectDebit;
         }
 

--- a/tests/Mollie.Tests.Unit/Models/Payment/Request/PaymentRequestTests.cs
+++ b/tests/Mollie.Tests.Unit/Models/Payment/Request/PaymentRequestTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using FluentAssertions;
+using Mollie.Api.Models;
+using Mollie.Api.Models.Payment;
+using Mollie.Api.Models.Payment.Request;
+using Mollie.Api.Models.Payment.Request.PaymentSpecificParameters;
+using Xunit;
+
+namespace Mollie.Tests.Unit.Models.Payment.Request;
+
+public class PaymentRequestTests {
+    [Theory]
+    [InlineData(PaymentMethod.CreditCard, typeof(CreditCardPaymentRequest))]
+    [InlineData(PaymentMethod.Ideal, typeof(IdealPaymentRequest))]
+    public void CreatePaymentRequest(string paymentMethod, Type expectedType) {
+        var amount = new Amount(Currency.EUR, 50m);
+        var description = "my-description";
+        var paymentRequest = new PaymentRequest() {
+            Amount = amount,
+            Description = description
+        };
+        switch (paymentMethod) {
+            case PaymentMethod.CreditCard:
+                paymentRequest = new CreditCardPaymentRequest(paymentRequest) {
+                    CardToken = "card-token"
+                };
+                break;
+            case PaymentMethod.Ideal:
+                paymentRequest = new IdealPaymentRequest(paymentRequest) {
+                    Issuer = "ideal_issuer"
+                };
+                break;
+        }
+
+        paymentRequest.Should().BeOfType(expectedType);
+        paymentRequest.Amount.Should().Be(amount);
+        paymentRequest.Description.Should().Be(description);
+    }
+}


### PR DESCRIPTION
Suggestion to improve issue mentioned in #380 

Example code:
```C#
public void CreatePaymentRequest(string paymentMethod, Type expectedType) {
        var amount = new Amount(Currency.EUR, 50m);
        var description = "my-description";
        var paymentRequest = new PaymentRequest() {
            Amount = amount,
            Description = description
        };
        switch (paymentMethod) {
            case PaymentMethod.CreditCard:
                paymentRequest = new CreditCardPaymentRequest(paymentRequest) {
                    CardToken = "card-token"
                };
                break;
            case PaymentMethod.Ideal:
                paymentRequest = new IdealPaymentRequest(paymentRequest) {
                    Issuer = "ideal_issuer"
                };
                break;
        }
```