### PR TITLE
IMP-610: Use correct authorize URL

### DIFF
--- a/src/Mollie.Api/Client/ConnectClient.cs
+++ b/src/Mollie.Api/Client/ConnectClient.cs
@@ -11,7 +11,7 @@ using Mollie.Api.Models.Connect.Response;
 
 namespace Mollie.Api.Client {
     public class ConnectClient : BaseMollieClient, IConnectClient {
-        private const string AuthorizeEndPoint = "https://www.mollie.com/oauth2/authorize";
+        private const string AuthorizeEndPoint = "https://my.mollie.com/oauth2/authorize";
         private const string TokenEndPoint = "https://api.mollie.nl/oauth2/";
 
         private readonly string _clientId;

--- a/tests/Mollie.Tests.Integration/Api/ConnectTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/ConnectTests.cs
@@ -18,7 +18,7 @@ public class ConnectTests : BaseMollieApiTestClass {
         string authorizationUrl = connectClient.GetAuthorizationUrl("abcde", new List<string>() { AppPermissions.PaymentsRead });
 
         // Then:
-        string expectedUrl = $"https://www.mollie.com/oauth2/authorize?client_id={ClientId}&state=abcde&scope=payments.read&response_type=code&approval_prompt=auto";
+        string expectedUrl = $"https://my.mollie.com/oauth2/authorize?client_id={ClientId}&state=abcde&scope=payments.read&response_type=code&approval_prompt=auto";
         authorizationUrl.Should().Be(expectedUrl);
     }
 
@@ -36,7 +36,7 @@ public class ConnectTests : BaseMollieApiTestClass {
         });
 
         // Then:
-        string expectedUrl = $"https://www.mollie.com/oauth2/authorize?client_id={ClientId}" +
+        string expectedUrl = $"https://my.mollie.com/oauth2/authorize?client_id={ClientId}" +
                              $"&state=abcdef&scope=payments.read+payments.write+profiles.read+profiles.write&response_type=code&approval_prompt=auto";
         authorizationUrl.Should().Be(expectedUrl);
     }

--- a/tests/Mollie.Tests.Unit/Client/ConnectClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/ConnectClientTests.cs
@@ -28,7 +28,7 @@ public class ConnectClientTests : BaseClientTests
         string authorizationUrl = connectClient.GetAuthorizationUrl("abcde", scopes);
 
         // Assert
-        string expectedUrl = $"https://www.mollie.com/oauth2/authorize?client_id={ClientId}&state=abcde&scope=payments.read&response_type=code&approval_prompt=auto";
+        string expectedUrl = $"https://my.mollie.com/oauth2/authorize?client_id={ClientId}&state=abcde&scope=payments.read&response_type=code&approval_prompt=auto";
         authorizationUrl.Should().Be(expectedUrl);
     }
 


### PR DESCRIPTION
The OAuth authorize URL changed from www.mollie.com to my.mollie.com