### PR TITLE
Improve support for multi tenant setups

### DIFF
--- a/src/Mollie.Api/Client/BalanceClient.cs
+++ b/src/Mollie.Api/Client/BalanceClient.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.Balance.Response;
 using Mollie.Api.Models.Balance.Response.BalanceReport;
 using Mollie.Api.Models.Balance.Response.BalanceTransaction;
@@ -14,6 +15,9 @@ using Mollie.Api.Models.Url;
 namespace Mollie.Api.Client {
     public class BalanceClient : BaseMollieClient, IBalanceClient {
         public BalanceClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
+        }
+
+        public BalanceClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<BalanceResponse> GetBalanceAsync(string balanceId) {

--- a/src/Mollie.Api/Client/BalanceClient.cs
+++ b/src/Mollie.Api/Client/BalanceClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
@@ -17,7 +18,7 @@ namespace Mollie.Api.Client {
         public BalanceClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public BalanceClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public BalanceClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<BalanceResponse> GetBalanceAsync(string balanceId) {

--- a/src/Mollie.Api/Client/BaseMollieClient.cs
+++ b/src/Mollie.Api/Client/BaseMollieClient.cs
@@ -8,6 +8,8 @@ using System.Text;
 using System.Threading.Tasks;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework;
+using Mollie.Api.Framework.Authentication;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Framework.Idempotency;
 using Mollie.Api.Models.Error;
 using Mollie.Api.Models.Url;
@@ -17,7 +19,7 @@ namespace Mollie.Api.Client {
     public abstract class BaseMollieClient : IDisposable {
         public const string ApiEndPoint = "https://api.mollie.com/v2/";
         private readonly string _apiEndpoint = ApiEndPoint;
-        private readonly string _apiKey;
+        private readonly IBearerTokenRetriever _bearerTokenRetriever;
         private readonly HttpClient _httpClient;
         private readonly JsonConverterService _jsonConverterService;
 
@@ -33,7 +35,14 @@ namespace Mollie.Api.Client {
             _jsonConverterService = new JsonConverterService();
             _createdHttpClient = httpClient == null;
             _httpClient = httpClient ?? new HttpClient();
-            _apiKey = apiKey;
+            _bearerTokenRetriever = new DefaultBearerTokenRetriever(apiKey);
+        }
+
+        protected BaseMollieClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) {
+            _jsonConverterService = new JsonConverterService();
+            _createdHttpClient = httpClient == null;
+            _httpClient = httpClient ?? new HttpClient();
+            _bearerTokenRetriever = bearerTokenRetriever;
         }
 
         protected BaseMollieClient(HttpClient? httpClient = null, string apiEndpoint = ApiEndPoint) {
@@ -41,7 +50,7 @@ namespace Mollie.Api.Client {
             _jsonConverterService = new JsonConverterService();
             _createdHttpClient = httpClient == null;
             _httpClient = httpClient ?? new HttpClient();
-            _apiKey = string.Empty;
+            _bearerTokenRetriever = new DefaultBearerTokenRetriever(string.Empty);
         }
 
         public IDisposable WithIdempotencyKey(string value) {
@@ -99,7 +108,8 @@ namespace Mollie.Api.Client {
         }
 
         protected void ValidateApiKeyIsOauthAccesstoken(bool isConstructor = false) {
-            if (!_apiKey.StartsWith("access_")) {
+            string apiKey = _bearerTokenRetriever.GetBearerToken();
+            if (!apiKey.StartsWith("access_")) {
                 if (isConstructor) {
                     throw new InvalidOperationException(
                         "The provided token isn't an oauth token. You have invoked the method with oauth parameters thus an oauth accesstoken is required.");
@@ -124,7 +134,7 @@ namespace Mollie.Api.Client {
         protected virtual HttpRequestMessage CreateHttpRequest(HttpMethod method, string relativeUri, HttpContent? content = null) {
             HttpRequestMessage httpRequest = new HttpRequestMessage(method, new Uri(new Uri(_apiEndpoint), relativeUri));
             httpRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+            httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _bearerTokenRetriever.GetBearerToken());
             httpRequest.Headers.Add("User-Agent", GetUserAgent());
             var idemPotencyKey = _idempotencyKey.Value ?? Guid.NewGuid().ToString();
             httpRequest.Headers.Add("Idempotency-Key", idemPotencyKey);

--- a/src/Mollie.Api/Client/CaptureClient.cs
+++ b/src/Mollie.Api/Client/CaptureClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
@@ -15,7 +16,7 @@ namespace Mollie.Api.Client
         public CaptureClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public CaptureClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public CaptureClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<CaptureResponse> GetCaptureAsync(string paymentId, string captureId, bool testmode = false) {

--- a/src/Mollie.Api/Client/CaptureClient.cs
+++ b/src/Mollie.Api/Client/CaptureClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.Capture.Request;
 using Mollie.Api.Models.Capture.Response;
 using Mollie.Api.Models.List.Response;
@@ -12,6 +13,9 @@ namespace Mollie.Api.Client
 {
     public class CaptureClient : BaseMollieClient, ICaptureClient {
         public CaptureClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
+        }
+
+        public CaptureClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<CaptureResponse> GetCaptureAsync(string paymentId, string captureId, bool testmode = false) {

--- a/src/Mollie.Api/Client/ChargebackClient.cs
+++ b/src/Mollie.Api/Client/ChargebackClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.Chargeback.Response;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Url;
@@ -10,6 +11,9 @@ using Mollie.Api.Models.Url;
 namespace Mollie.Api.Client {
     public class ChargebackClient : BaseMollieClient, IChargebackClient {
         public ChargebackClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
+        }
+
+        public ChargebackClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<ChargebackResponse> GetChargebackAsync(string paymentId, string chargebackId, bool testmode = false) {

--- a/src/Mollie.Api/Client/ChargebackClient.cs
+++ b/src/Mollie.Api/Client/ChargebackClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
@@ -13,7 +14,7 @@ namespace Mollie.Api.Client {
         public ChargebackClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public ChargebackClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public ChargebackClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<ChargebackResponse> GetChargebackAsync(string paymentId, string chargebackId, bool testmode = false) {

--- a/src/Mollie.Api/Client/ClientLinkClient.cs
+++ b/src/Mollie.Api/Client/ClientLinkClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
@@ -18,8 +19,8 @@ namespace Mollie.Api.Client {
             _clientId = clientId;
         }
 
-        public ClientLinkClient(string clientId, IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null)
-            : base(bearerTokenRetriever, httpClient) {
+        public ClientLinkClient(string clientId, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(mollieSecretManager, httpClient) {
             _clientId = clientId;
         }
 

--- a/src/Mollie.Api/Client/ClientLinkClient.cs
+++ b/src/Mollie.Api/Client/ClientLinkClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.ClientLink.Request;
 using Mollie.Api.Models.ClientLink.Response;
 
@@ -14,6 +15,11 @@ namespace Mollie.Api.Client {
         public ClientLinkClient(string clientId, string oauthAccessToken, HttpClient? httpClient = null)
             : base(oauthAccessToken, httpClient)
         {
+            _clientId = clientId;
+        }
+
+        public ClientLinkClient(string clientId, IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null)
+            : base(bearerTokenRetriever, httpClient) {
             _clientId = clientId;
         }
 

--- a/src/Mollie.Api/Client/CustomerClient.cs
+++ b/src/Mollie.Api/Client/CustomerClient.cs
@@ -17,7 +17,7 @@ namespace Mollie.Api.Client {
         public CustomerClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public CustomerClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public CustomerClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<CustomerResponse> CreateCustomerAsync(CustomerRequest request) {

--- a/src/Mollie.Api/Client/CustomerClient.cs
+++ b/src/Mollie.Api/Client/CustomerClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models;
 using Mollie.Api.Models.Customer.Request;
 using Mollie.Api.Models.Customer.Response;
@@ -14,6 +15,9 @@ using Mollie.Api.Models.Url;
 namespace Mollie.Api.Client {
     public class CustomerClient : BaseMollieClient, ICustomerClient {
         public CustomerClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
+        }
+
+        public CustomerClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<CustomerResponse> CreateCustomerAsync(CustomerRequest request) {

--- a/src/Mollie.Api/Client/InvoiceClient.cs
+++ b/src/Mollie.Api/Client/InvoiceClient.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.Invoice.Response;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Url;
@@ -11,6 +12,9 @@ using Mollie.Api.Models.Url;
 namespace Mollie.Api.Client {
     public class InvoiceClient : OauthBaseMollieClient, IInvoiceClient {
         public InvoiceClient(string oauthAccessToken, HttpClient? httpClient = null) : base(oauthAccessToken, httpClient) {
+        }
+
+        public InvoiceClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<InvoiceResponse> GetInvoiceAsync(string invoiceId) {

--- a/src/Mollie.Api/Client/InvoiceClient.cs
+++ b/src/Mollie.Api/Client/InvoiceClient.cs
@@ -14,7 +14,7 @@ namespace Mollie.Api.Client {
         public InvoiceClient(string oauthAccessToken, HttpClient? httpClient = null) : base(oauthAccessToken, httpClient) {
         }
 
-        public InvoiceClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public InvoiceClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<InvoiceResponse> GetInvoiceAsync(string invoiceId) {

--- a/src/Mollie.Api/Client/MandateClient.cs
+++ b/src/Mollie.Api/Client/MandateClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Mandate.Request;
@@ -12,6 +13,9 @@ using Mollie.Api.Models.Url;
 namespace Mollie.Api.Client {
     public class MandateClient : BaseMollieClient, IMandateClient {
         public MandateClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
+        }
+
+        public MandateClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<MandateResponse> GetMandateAsync(string customerId, string mandateId, bool testmode = false) {

--- a/src/Mollie.Api/Client/MandateClient.cs
+++ b/src/Mollie.Api/Client/MandateClient.cs
@@ -15,7 +15,7 @@ namespace Mollie.Api.Client {
         public MandateClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public MandateClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public MandateClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<MandateResponse> GetMandateAsync(string customerId, string mandateId, bool testmode = false) {

--- a/src/Mollie.Api/Client/OauthBaseMollieClient.cs
+++ b/src/Mollie.Api/Client/OauthBaseMollieClient.cs
@@ -1,9 +1,20 @@
 ﻿using System;
 using System.Net.Http;
+using Mollie.Api.Framework.Authentication.Abstract;
 
 namespace Mollie.Api.Client {
     public class OauthBaseMollieClient : BaseMollieClient {
-        public OauthBaseMollieClient(string oauthAccessToken, HttpClient? httpClient = null) : base(oauthAccessToken, httpClient) {
+        protected OauthBaseMollieClient(string oauthAccessToken, HttpClient? httpClient = null)
+            : base(oauthAccessToken, httpClient) {
+            ValidateApiKeyIsOauthAccesstoken(oauthAccessToken);
+        }
+
+        protected OauthBaseMollieClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null)
+            : base(bearerTokenRetriever, httpClient) {
+            ValidateApiKeyIsOauthAccesstoken(bearerTokenRetriever.GetBearerToken());
+        }
+
+        private void ValidateApiKeyIsOauthAccesstoken(string oauthAccessToken) {
             if (string.IsNullOrWhiteSpace(oauthAccessToken)) {
                 throw new ArgumentNullException(nameof(oauthAccessToken), "Mollie API key cannot be empty");
             }

--- a/src/Mollie.Api/Client/OauthBaseMollieClient.cs
+++ b/src/Mollie.Api/Client/OauthBaseMollieClient.cs
@@ -9,9 +9,9 @@ namespace Mollie.Api.Client {
             ValidateApiKeyIsOauthAccesstoken(oauthAccessToken);
         }
 
-        protected OauthBaseMollieClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null)
-            : base(bearerTokenRetriever, httpClient) {
-            ValidateApiKeyIsOauthAccesstoken(bearerTokenRetriever.GetBearerToken());
+        protected OauthBaseMollieClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(mollieSecretManager, httpClient) {
+            ValidateApiKeyIsOauthAccesstoken(mollieSecretManager.GetBearerToken());
         }
 
         private void ValidateApiKeyIsOauthAccesstoken(string oauthAccessToken) {

--- a/src/Mollie.Api/Client/OnboardingClient.cs
+++ b/src/Mollie.Api/Client/OnboardingClient.cs
@@ -3,10 +3,14 @@ using Mollie.Api.Models.Onboarding.Request;
 using Mollie.Api.Models.Onboarding.Response;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Mollie.Api.Framework.Authentication.Abstract;
 
 namespace Mollie.Api.Client {
     public class OnboardingClient : BaseMollieClient, IOnboardingClient {
         public OnboardingClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
+        }
+
+        public OnboardingClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<OnboardingStatusResponse> GetOnboardingStatusAsync() {

--- a/src/Mollie.Api/Client/OnboardingClient.cs
+++ b/src/Mollie.Api/Client/OnboardingClient.cs
@@ -10,7 +10,7 @@ namespace Mollie.Api.Client {
         public OnboardingClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public OnboardingClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public OnboardingClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<OnboardingStatusResponse> GetOnboardingStatusAsync() {

--- a/src/Mollie.Api/Client/OrderClient.cs
+++ b/src/Mollie.Api/Client/OrderClient.cs
@@ -17,7 +17,7 @@ namespace Mollie.Api.Client {
         public OrderClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public OrderClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public OrderClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<OrderResponse> CreateOrderAsync(OrderRequest orderRequest) {

--- a/src/Mollie.Api/Client/OrderClient.cs
+++ b/src/Mollie.Api/Client/OrderClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Order.Request;
@@ -14,6 +15,9 @@ using Mollie.Api.Models.Url;
 namespace Mollie.Api.Client {
     public class OrderClient : BaseMollieClient, IOrderClient {
         public OrderClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
+        }
+
+        public OrderClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<OrderResponse> CreateOrderAsync(OrderRequest orderRequest) {

--- a/src/Mollie.Api/Client/OrganizationClient.cs
+++ b/src/Mollie.Api/Client/OrganizationClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Organization;
 using Mollie.Api.Models.Url;
@@ -8,6 +9,9 @@ using Mollie.Api.Models.Url;
 namespace Mollie.Api.Client {
     public class OrganizationClient : OauthBaseMollieClient, IOrganizationClient {
         public OrganizationClient(string oauthAccessToken, HttpClient? httpClient = null) : base(oauthAccessToken, httpClient) {
+        }
+
+        public OrganizationClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<OrganizationResponse> GetCurrentOrganizationAsync() {

--- a/src/Mollie.Api/Client/OrganizationClient.cs
+++ b/src/Mollie.Api/Client/OrganizationClient.cs
@@ -11,7 +11,7 @@ namespace Mollie.Api.Client {
         public OrganizationClient(string oauthAccessToken, HttpClient? httpClient = null) : base(oauthAccessToken, httpClient) {
         }
 
-        public OrganizationClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public OrganizationClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<OrganizationResponse> GetCurrentOrganizationAsync() {

--- a/src/Mollie.Api/Client/PaymentClient.cs
+++ b/src/Mollie.Api/Client/PaymentClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Payment.Request;
@@ -13,6 +14,9 @@ namespace Mollie.Api.Client {
     public class PaymentClient : BaseMollieClient, IPaymentClient {
 
 	    public PaymentClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) { }
+
+        public PaymentClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        }
 
         public async Task<PaymentResponse> CreatePaymentAsync(PaymentRequest paymentRequest, bool includeQrCode = false) {
             if (!string.IsNullOrWhiteSpace(paymentRequest.ProfileId) || paymentRequest.Testmode.HasValue || paymentRequest.ApplicationFee != null) {

--- a/src/Mollie.Api/Client/PaymentClient.cs
+++ b/src/Mollie.Api/Client/PaymentClient.cs
@@ -15,7 +15,7 @@ namespace Mollie.Api.Client {
 
 	    public PaymentClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) { }
 
-        public PaymentClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public PaymentClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<PaymentResponse> CreatePaymentAsync(PaymentRequest paymentRequest, bool includeQrCode = false) {

--- a/src/Mollie.Api/Client/PaymentLinkClient.cs
+++ b/src/Mollie.Api/Client/PaymentLinkClient.cs
@@ -17,7 +17,7 @@ namespace Mollie.Api.Client
     {
         public PaymentLinkClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) { }
 
-        public PaymentLinkClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public PaymentLinkClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<PaymentLinkResponse> CreatePaymentLinkAsync(PaymentLinkRequest paymentLinkRequest)

--- a/src/Mollie.Api/Client/PaymentLinkClient.cs
+++ b/src/Mollie.Api/Client/PaymentLinkClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Payment.Response;
@@ -15,6 +16,9 @@ namespace Mollie.Api.Client
     public class PaymentLinkClient : BaseMollieClient, IPaymentLinkClient
     {
         public PaymentLinkClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) { }
+
+        public PaymentLinkClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        }
 
         public async Task<PaymentLinkResponse> CreatePaymentLinkAsync(PaymentLinkRequest paymentLinkRequest)
         {

--- a/src/Mollie.Api/Client/PaymentMethodClient.cs
+++ b/src/Mollie.Api/Client/PaymentMethodClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Payment;
@@ -14,6 +15,9 @@ namespace Mollie.Api.Client
     public class PaymentMethodClient : BaseMollieClient, IPaymentMethodClient
     {
         public PaymentMethodClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
+        }
+
+        public PaymentMethodClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<PaymentMethodResponse> GetPaymentMethodAsync(

--- a/src/Mollie.Api/Client/PaymentMethodClient.cs
+++ b/src/Mollie.Api/Client/PaymentMethodClient.cs
@@ -17,7 +17,7 @@ namespace Mollie.Api.Client
         public PaymentMethodClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public PaymentMethodClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public PaymentMethodClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<PaymentMethodResponse> GetPaymentMethodAsync(

--- a/src/Mollie.Api/Client/PermissionClient.cs
+++ b/src/Mollie.Api/Client/PermissionClient.cs
@@ -11,7 +11,7 @@ namespace Mollie.Api.Client {
         public PermissionClient(string oauthAccessToken, HttpClient? httpClient = null) : base(oauthAccessToken, httpClient) {
         }
 
-        public PermissionClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public PermissionClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<PermissionResponse> GetPermissionAsync(string permissionId) {

--- a/src/Mollie.Api/Client/PermissionClient.cs
+++ b/src/Mollie.Api/Client/PermissionClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Permission.Response;
 using Mollie.Api.Models.Url;
@@ -8,6 +9,9 @@ using Mollie.Api.Models.Url;
 namespace Mollie.Api.Client {
     public class PermissionClient : OauthBaseMollieClient, IPermissionClient {
         public PermissionClient(string oauthAccessToken, HttpClient? httpClient = null) : base(oauthAccessToken, httpClient) {
+        }
+
+        public PermissionClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<PermissionResponse> GetPermissionAsync(string permissionId) {

--- a/src/Mollie.Api/Client/ProfileClient.cs
+++ b/src/Mollie.Api/Client/ProfileClient.cs
@@ -13,7 +13,7 @@ namespace Mollie.Api.Client {
         public ProfileClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public ProfileClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public ProfileClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<ProfileResponse> CreateProfileAsync(ProfileRequest request) {

--- a/src/Mollie.Api/Client/ProfileClient.cs
+++ b/src/Mollie.Api/Client/ProfileClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.PaymentMethod.Response;
 using Mollie.Api.Models.Profile.Request;
@@ -10,6 +11,9 @@ using Mollie.Api.Models.Url;
 namespace Mollie.Api.Client {
     public class ProfileClient : BaseMollieClient, IProfileClient {
         public ProfileClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
+        }
+
+        public ProfileClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<ProfileResponse> CreateProfileAsync(ProfileRequest request) {

--- a/src/Mollie.Api/Client/RefundClient.cs
+++ b/src/Mollie.Api/Client/RefundClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Order.Request;
 using Mollie.Api.Models.Order.Response;
@@ -13,6 +14,9 @@ using Mollie.Api.Models.Url;
 namespace Mollie.Api.Client {
     public class RefundClient : BaseMollieClient, IRefundClient {
         public RefundClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
+        }
+
+        public RefundClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<RefundResponse> CreatePaymentRefundAsync(string paymentId, RefundRequest refundRequest) {

--- a/src/Mollie.Api/Client/RefundClient.cs
+++ b/src/Mollie.Api/Client/RefundClient.cs
@@ -16,7 +16,7 @@ namespace Mollie.Api.Client {
         public RefundClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public RefundClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public RefundClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<RefundResponse> CreatePaymentRefundAsync(string paymentId, RefundRequest refundRequest) {

--- a/src/Mollie.Api/Client/SettlementClient.cs
+++ b/src/Mollie.Api/Client/SettlementClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.Capture.Response;
 using Mollie.Api.Models.Chargeback.Response;
 using Mollie.Api.Models.List.Response;
@@ -12,6 +13,9 @@ using Mollie.Api.Models.Url;
 namespace Mollie.Api.Client {
     public class SettlementClient : BaseMollieClient, ISettlementClient {
         public SettlementClient(string oauthAccessToken, HttpClient? httpClient = null) : base(oauthAccessToken, httpClient) {
+        }
+
+        public SettlementClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<SettlementResponse> GetSettlementAsync(string settlementId) {

--- a/src/Mollie.Api/Client/SettlementClient.cs
+++ b/src/Mollie.Api/Client/SettlementClient.cs
@@ -15,7 +15,7 @@ namespace Mollie.Api.Client {
         public SettlementClient(string oauthAccessToken, HttpClient? httpClient = null) : base(oauthAccessToken, httpClient) {
         }
 
-        public SettlementClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public SettlementClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<SettlementResponse> GetSettlementAsync(string settlementId) {

--- a/src/Mollie.Api/Client/ShipmentClient.cs
+++ b/src/Mollie.Api/Client/ShipmentClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Shipment.Request;
 using Mollie.Api.Models.Shipment.Response;
@@ -12,6 +13,9 @@ namespace Mollie.Api.Client
 {
     public class ShipmentClient : BaseMollieClient, IShipmentClient {
         public ShipmentClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
+        }
+
+        public ShipmentClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<ShipmentResponse> CreateShipmentAsync(string orderId, ShipmentRequest shipmentRequest) {

--- a/src/Mollie.Api/Client/ShipmentClient.cs
+++ b/src/Mollie.Api/Client/ShipmentClient.cs
@@ -15,7 +15,7 @@ namespace Mollie.Api.Client
         public ShipmentClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public ShipmentClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public ShipmentClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<ShipmentResponse> CreateShipmentAsync(string orderId, ShipmentRequest shipmentRequest) {

--- a/src/Mollie.Api/Client/SubscriptionClient.cs
+++ b/src/Mollie.Api/Client/SubscriptionClient.cs
@@ -16,7 +16,7 @@ namespace Mollie.Api.Client {
         public SubscriptionClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public SubscriptionClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public SubscriptionClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<ListResponse<SubscriptionResponse>> GetSubscriptionListAsync(string customerId, string? from = null, int? limit = null, string? profileId = null, bool testmode = false) {

--- a/src/Mollie.Api/Client/SubscriptionClient.cs
+++ b/src/Mollie.Api/Client/SubscriptionClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Payment.Response;
@@ -13,6 +14,9 @@ using Mollie.Api.Models.Url;
 namespace Mollie.Api.Client {
     public class SubscriptionClient : BaseMollieClient, ISubscriptionClient {
         public SubscriptionClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
+        }
+
+        public SubscriptionClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<ListResponse<SubscriptionResponse>> GetSubscriptionListAsync(string customerId, string? from = null, int? limit = null, string? profileId = null, bool testmode = false) {

--- a/src/Mollie.Api/Client/TerminalClient.cs
+++ b/src/Mollie.Api/Client/TerminalClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Terminal.Response;
 using Mollie.Api.Models.Url;
@@ -11,6 +12,9 @@ namespace Mollie.Api.Client {
     public class TerminalClient : BaseMollieClient, ITerminalClient
     {
         public TerminalClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) { }
+
+        public TerminalClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        }
 
         public async Task<TerminalResponse> GetTerminalAsync(string terminalId) {
             ValidateRequiredUrlParameter(nameof(terminalId), terminalId);

--- a/src/Mollie.Api/Client/TerminalClient.cs
+++ b/src/Mollie.Api/Client/TerminalClient.cs
@@ -13,7 +13,7 @@ namespace Mollie.Api.Client {
     {
         public TerminalClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) { }
 
-        public TerminalClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public TerminalClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<TerminalResponse> GetTerminalAsync(string terminalId) {

--- a/src/Mollie.Api/Client/WalletClient.cs
+++ b/src/Mollie.Api/Client/WalletClient.cs
@@ -10,7 +10,7 @@ namespace Mollie.Api.Client {
         public WalletClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public WalletClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
+        public WalletClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
         }
 
         public async Task<ApplePayPaymentSessionResponse> RequestApplePayPaymentSessionAsync(ApplePayPaymentSessionRequest request) {

--- a/src/Mollie.Api/Client/WalletClient.cs
+++ b/src/Mollie.Api/Client/WalletClient.cs
@@ -1,12 +1,16 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.Wallet.Request;
 using Mollie.Api.Models.Wallet.Response;
 
 namespace Mollie.Api.Client {
     public class WalletClient : BaseMollieClient, IWalletClient {
         public WalletClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
+        }
+
+        public WalletClient(IBearerTokenRetriever bearerTokenRetriever, HttpClient? httpClient = null) : base(bearerTokenRetriever, httpClient) {
         }
 
         public async Task<ApplePayPaymentSessionResponse> RequestApplePayPaymentSessionAsync(ApplePayPaymentSessionRequest request) {

--- a/src/Mollie.Api/DependencyInjection.cs
+++ b/src/Mollie.Api/DependencyInjection.cs
@@ -17,8 +17,13 @@ namespace Mollie.Api {
             MollieOptions mollieOptions = new();
             mollieOptionsDelegate.Invoke(mollieOptions);
 
-            services.AddScoped<IMollieSecretManager, DefaultMollieSecretManager>(_ =>
-                new DefaultMollieSecretManager(mollieOptions.ApiKey));
+            if (mollieOptions.CustomMollieSecretManager != null) {
+                services.AddScoped(typeof(IMollieSecretManager), mollieOptions.CustomMollieSecretManager);
+            }
+            else {
+                services.AddScoped<IMollieSecretManager, DefaultMollieSecretManager>(_ =>
+                    new DefaultMollieSecretManager(mollieOptions.ApiKey));
+            }
 
             RegisterMollieApiClient<IBalanceClient, BalanceClient>(services, (httpClient, provider) =>
                 new BalanceClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);

--- a/src/Mollie.Api/DependencyInjection.cs
+++ b/src/Mollie.Api/DependencyInjection.cs
@@ -3,6 +3,8 @@ using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client;
 using Mollie.Api.Client.Abstract;
+using Mollie.Api.Framework.Authentication;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Options;
 using Polly;
 
@@ -12,53 +14,56 @@ namespace Mollie.Api {
             this IServiceCollection services,
             Action<MollieOptions> mollieOptionsDelegate) {
 
-            MollieOptions mollieOptions = new MollieOptions();
+            MollieOptions mollieOptions = new();
             mollieOptionsDelegate.Invoke(mollieOptions);
 
+            IBearerTokenRetriever bearerTokenRetriever = mollieOptions.BearerTokenRetriever ??
+                                                         new DefaultBearerTokenRetriever(mollieOptions.ApiKey);
+
             RegisterMollieApiClient<IBalanceClient, BalanceClient>(services, httpClient =>
-                new BalanceClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new BalanceClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<ICaptureClient, CaptureClient>(services, httpClient =>
-                new CaptureClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new CaptureClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IChargebackClient, ChargebackClient>(services, httpClient =>
-                new ChargebackClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new ChargebackClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IConnectClient, ConnectClient>(services, httpClient =>
                 new ConnectClient(mollieOptions.ClientId, mollieOptions.ClientSecret, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<ICustomerClient, CustomerClient>(services, httpClient =>
-                new CustomerClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new CustomerClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IInvoiceClient, InvoiceClient>(services, httpClient =>
-                new InvoiceClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new InvoiceClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IMandateClient, MandateClient>(services, httpClient =>
-                new MandateClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new MandateClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IOnboardingClient, OnboardingClient>(services, httpClient =>
-                new OnboardingClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new OnboardingClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IOrderClient, OrderClient>(services, httpClient =>
-                new OrderClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new OrderClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IOrganizationClient, OrganizationClient>(services, httpClient =>
-                new OrganizationClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new OrganizationClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IPaymentClient, PaymentClient>(services, httpClient =>
-                new PaymentClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new PaymentClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IPaymentLinkClient, PaymentLinkClient>(services, httpClient =>
-                new PaymentLinkClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new PaymentLinkClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IPaymentMethodClient, PaymentMethodClient>(services, httpClient =>
-                new PaymentMethodClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new PaymentMethodClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IPermissionClient, PermissionClient>(services, httpClient =>
-                new PermissionClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new PermissionClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IProfileClient, ProfileClient>(services, httpClient =>
-                new ProfileClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new ProfileClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IRefundClient, RefundClient>(services, httpClient =>
-                new RefundClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new RefundClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<ISettlementClient, SettlementClient>(services, httpClient =>
-                new SettlementClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new SettlementClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IShipmentClient, ShipmentClient>(services, httpClient =>
-                new ShipmentClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new ShipmentClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<ISubscriptionClient, SubscriptionClient>(services, httpClient =>
-                new SubscriptionClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new SubscriptionClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<ITerminalClient, TerminalClient>(services, httpClient =>
-                new TerminalClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new TerminalClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IClientLinkClient, ClientLinkClient>(services, httpClient =>
-                new ClientLinkClient(mollieOptions.ClientId, mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new ClientLinkClient(mollieOptions.ClientId, bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IWalletClient, WalletClient>(services, httpClient =>
-                new WalletClient(mollieOptions.ApiKey, httpClient), mollieOptions.RetryPolicy);
+                new WalletClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
 
             return services;
         }

--- a/src/Mollie.Api/DependencyInjection.cs
+++ b/src/Mollie.Api/DependencyInjection.cs
@@ -17,60 +17,60 @@ namespace Mollie.Api {
             MollieOptions mollieOptions = new();
             mollieOptionsDelegate.Invoke(mollieOptions);
 
-            IBearerTokenRetriever bearerTokenRetriever = mollieOptions.BearerTokenRetriever ??
-                                                         new DefaultBearerTokenRetriever(mollieOptions.ApiKey);
+            services.AddScoped<IMollieSecretManager, DefaultMollieSecretManager>(_ =>
+                new DefaultMollieSecretManager(mollieOptions.ApiKey));
 
-            RegisterMollieApiClient<IBalanceClient, BalanceClient>(services, httpClient =>
-                new BalanceClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<ICaptureClient, CaptureClient>(services, httpClient =>
-                new CaptureClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IChargebackClient, ChargebackClient>(services, httpClient =>
-                new ChargebackClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IConnectClient, ConnectClient>(services, httpClient =>
+            RegisterMollieApiClient<IBalanceClient, BalanceClient>(services, (httpClient, provider) =>
+                new BalanceClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<ICaptureClient, CaptureClient>(services, (httpClient, provider) =>
+                new CaptureClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IChargebackClient, ChargebackClient>(services, (httpClient, provider) =>
+                new ChargebackClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IConnectClient, ConnectClient>(services, (httpClient, _) =>
                 new ConnectClient(mollieOptions.ClientId, mollieOptions.ClientSecret, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<ICustomerClient, CustomerClient>(services, httpClient =>
-                new CustomerClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IInvoiceClient, InvoiceClient>(services, httpClient =>
-                new InvoiceClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IMandateClient, MandateClient>(services, httpClient =>
-                new MandateClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IOnboardingClient, OnboardingClient>(services, httpClient =>
-                new OnboardingClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IOrderClient, OrderClient>(services, httpClient =>
-                new OrderClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IOrganizationClient, OrganizationClient>(services, httpClient =>
-                new OrganizationClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IPaymentClient, PaymentClient>(services, httpClient =>
-                new PaymentClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IPaymentLinkClient, PaymentLinkClient>(services, httpClient =>
-                new PaymentLinkClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IPaymentMethodClient, PaymentMethodClient>(services, httpClient =>
-                new PaymentMethodClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IPermissionClient, PermissionClient>(services, httpClient =>
-                new PermissionClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IProfileClient, ProfileClient>(services, httpClient =>
-                new ProfileClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IRefundClient, RefundClient>(services, httpClient =>
-                new RefundClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<ISettlementClient, SettlementClient>(services, httpClient =>
-                new SettlementClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IShipmentClient, ShipmentClient>(services, httpClient =>
-                new ShipmentClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<ISubscriptionClient, SubscriptionClient>(services, httpClient =>
-                new SubscriptionClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<ITerminalClient, TerminalClient>(services, httpClient =>
-                new TerminalClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IClientLinkClient, ClientLinkClient>(services, httpClient =>
-                new ClientLinkClient(mollieOptions.ClientId, bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IWalletClient, WalletClient>(services, httpClient =>
-                new WalletClient(bearerTokenRetriever, httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<ICustomerClient, CustomerClient>(services, (httpClient, provider) =>
+                new CustomerClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IInvoiceClient, InvoiceClient>(services, (httpClient, provider) =>
+                new InvoiceClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IMandateClient, MandateClient>(services, (httpClient, provider) =>
+                new MandateClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IOnboardingClient, OnboardingClient>(services, (httpClient, provider) =>
+                new OnboardingClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IOrderClient, OrderClient>(services,(httpClient, provider) =>
+                new OrderClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IOrganizationClient, OrganizationClient>(services, (httpClient, provider) =>
+                new OrganizationClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IPaymentClient, PaymentClient>(services, (httpClient, provider) =>
+                new PaymentClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IPaymentLinkClient, PaymentLinkClient>(services, (httpClient, provider) =>
+                new PaymentLinkClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IPaymentMethodClient, PaymentMethodClient>(services, (httpClient, provider) =>
+                new PaymentMethodClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IPermissionClient, PermissionClient>(services, (httpClient, provider) =>
+                new PermissionClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IProfileClient, ProfileClient>(services, (httpClient, provider) =>
+                new ProfileClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IRefundClient, RefundClient>(services, (httpClient, provider) =>
+                new RefundClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<ISettlementClient, SettlementClient>(services, (httpClient, provider) =>
+                new SettlementClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IShipmentClient, ShipmentClient>(services, (httpClient, provider) =>
+                new ShipmentClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<ISubscriptionClient, SubscriptionClient>(services, (httpClient, provider) =>
+                new SubscriptionClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<ITerminalClient, TerminalClient>(services, (httpClient, provider) =>
+                new TerminalClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IClientLinkClient, ClientLinkClient>(services, (httpClient, provider) =>
+                new ClientLinkClient(mollieOptions.ClientId, provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IWalletClient, WalletClient>(services, (httpClient, provider) =>
+                new WalletClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
 
             return services;
         }
 
         static void RegisterMollieApiClient<TInterface, TImplementation>(
             IServiceCollection services,
-            Func<HttpClient, TImplementation> factory,
+            Func<HttpClient, IServiceProvider, TImplementation> factory,
             IAsyncPolicy<HttpResponseMessage>? retryPolicy = null)
             where TInterface : class
             where TImplementation : class, TInterface {

--- a/src/Mollie.Api/Framework/Authentication/Abstract/IBearerTokenRetriever.cs
+++ b/src/Mollie.Api/Framework/Authentication/Abstract/IBearerTokenRetriever.cs
@@ -1,0 +1,5 @@
+﻿namespace Mollie.Api.Framework.Authentication.Abstract;
+
+public interface IBearerTokenRetriever {
+    public string GetBearerToken();
+}

--- a/src/Mollie.Api/Framework/Authentication/Abstract/IMollieSecretManager.cs
+++ b/src/Mollie.Api/Framework/Authentication/Abstract/IMollieSecretManager.cs
@@ -1,5 +1,5 @@
 ﻿namespace Mollie.Api.Framework.Authentication.Abstract;
 
-public interface IBearerTokenRetriever {
+public interface IMollieSecretManager {
     public string GetBearerToken();
 }

--- a/src/Mollie.Api/Framework/Authentication/DefaultBearerTokenRetriever.cs
+++ b/src/Mollie.Api/Framework/Authentication/DefaultBearerTokenRetriever.cs
@@ -1,0 +1,9 @@
+﻿using Mollie.Api.Framework.Authentication.Abstract;
+
+namespace Mollie.Api.Framework.Authentication;
+
+public class DefaultBearerTokenRetriever(string apiKey) : IBearerTokenRetriever {
+    public string GetBearerToken() {
+        return apiKey;
+    }
+}

--- a/src/Mollie.Api/Framework/Authentication/DefaultBearerTokenRetriever.cs
+++ b/src/Mollie.Api/Framework/Authentication/DefaultBearerTokenRetriever.cs
@@ -1,9 +1,0 @@
-﻿using Mollie.Api.Framework.Authentication.Abstract;
-
-namespace Mollie.Api.Framework.Authentication;
-
-public class DefaultBearerTokenRetriever(string apiKey) : IBearerTokenRetriever {
-    public string GetBearerToken() {
-        return apiKey;
-    }
-}

--- a/src/Mollie.Api/Framework/Authentication/DefaultMollieSecretManager.cs
+++ b/src/Mollie.Api/Framework/Authentication/DefaultMollieSecretManager.cs
@@ -1,0 +1,6 @@
+﻿using Mollie.Api.Framework.Authentication.Abstract;
+namespace Mollie.Api.Framework.Authentication;
+
+public class DefaultMollieSecretManager(string apiKey) : IMollieSecretManager {
+    public string GetBearerToken() => apiKey;
+}

--- a/src/Mollie.Api/Options/MollieOptions.cs
+++ b/src/Mollie.Api/Options/MollieOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net.Http;
-using Mollie.Api.Framework.Authentication.Abstract;
 using Polly;
 
 namespace Mollie.Api.Options {
@@ -24,10 +23,5 @@ namespace Mollie.Api.Options {
         /// (Optional) Polly retry policy for failed requests
         /// </summary>
         public IAsyncPolicy<HttpResponseMessage>? RetryPolicy { get; set; }
-
-        /// <summary>
-        /// (Optional) Set a custom bearer token retrieval, in case you have a multi-tenant setup with multiple API keys
-        /// </summary>
-        public IBearerTokenRetriever? BearerTokenRetriever { get; set; } = null;
     }
 }

--- a/src/Mollie.Api/Options/MollieOptions.cs
+++ b/src/Mollie.Api/Options/MollieOptions.cs
@@ -1,4 +1,6 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Polly;
 
 namespace Mollie.Api.Options {
@@ -23,5 +25,18 @@ namespace Mollie.Api.Options {
         /// (Optional) Polly retry policy for failed requests
         /// </summary>
         public IAsyncPolicy<HttpResponseMessage>? RetryPolicy { get; set; }
+
+        /// <summary>
+        /// A custom secret manager that you can override to implement advanced multi-tenant scenario's
+        /// </summary>
+        public Type? CustomMollieSecretManager { get; private set; }
+
+        /// <summary>
+        /// Set a custom secret manager that you can override to implement advanced multi-tenant scenario's
+        /// </summary>
+        public MollieOptions SetCustomMollieSecretManager<T>() where T : IMollieSecretManager {
+            CustomMollieSecretManager = typeof(T);
+            return this;
+        }
     }
 }

--- a/src/Mollie.Api/Options/MollieOptions.cs
+++ b/src/Mollie.Api/Options/MollieOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using Mollie.Api.Framework.Authentication.Abstract;
 using Polly;
 
 namespace Mollie.Api.Options {
@@ -12,16 +13,21 @@ namespace Mollie.Api.Options {
         /// (Optional) ClientId used by Connect API
         /// </summary>
         public string ClientId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// (Optional) ClientSecret used by Connect API
         /// </summary>
         /// <returns></returns>
         public string ClientSecret { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// (Optional) Polly retry policy for failed requests
         /// </summary>
         public IAsyncPolicy<HttpResponseMessage>? RetryPolicy { get; set; }
+
+        /// <summary>
+        /// (Optional) Set a custom bearer token retrieval, in case you have a multi-tenant setup with multiple API keys
+        /// </summary>
+        public IBearerTokenRetriever? BearerTokenRetriever { get; set; } = null;
     }
 }


### PR DESCRIPTION
Allow library consumers to configure a custom implementation to retrieve the API key. This can be usefull in case they are running a multi-tenant setup with multiple API keys.

Usage:
When registering dependencies:
```C#
builder.Services.AddMollieApi(options => {
    //options.ApiKey = builder.Configuration["MySecretManagerMollie:ApiKey"]!;
    options.SetCustomMollieSecretManager<TenantSecretManager>();
    options.RetryPolicy = MollieHttpRetryPolicies.TransientHttpErrorRetryPolicy();
});
```

Custom secret manager for multi-tenant setup:
```C#
public class TenantSecretManager : IMollieSecretManager {
    private readonly ITenantService _tenantService;

    public string GetBearerToken() => _tenantService.GetCurrentTenant().ApiKey;
}
```