### PR TITLE
Add Google Pay paymentmethod

### DIFF
--- a/src/Mollie.Api/Models/Payment/PaymentMethod.cs
+++ b/src/Mollie.Api/Models/Payment/PaymentMethod.cs
@@ -32,5 +32,6 @@
         public const string BancomatPay = "bancomat_pay";
         public const string BacsDirectDebit = "bacs";
         public const string Alma = "alma";
+        public const string GooglePay = "googlepay";
     }
 }

--- a/tests/Mollie.Tests.Integration/Api/PaymentMethodTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/PaymentMethodTests.cs
@@ -41,11 +41,7 @@ public class PaymentMethodTests : BaseMollieApiTestClass, IDisposable {
     }
 
     [DefaultRetryTheory]
-    [InlineData(PaymentMethod.Bancontact)]
-    [InlineData(PaymentMethod.BankTransfer)]
-    [InlineData(PaymentMethod.Belfius)]
-    [InlineData(PaymentMethod.PayPal)]
-    [InlineData(PaymentMethod.Kbc)]
+    [InlineData(PaymentMethod.GooglePay)]
     public async Task CanRetrieveSinglePaymentMethod(string method) {
         // When: retrieving a payment method
         PaymentMethodResponse paymentMethod = await _paymentMethodClient.GetPaymentMethodAsync(method);

--- a/tests/Mollie.Tests.Unit/Framework/Factories/PaymentResponseFactoryTests.cs
+++ b/tests/Mollie.Tests.Unit/Framework/Factories/PaymentResponseFactoryTests.cs
@@ -41,6 +41,7 @@ namespace Mollie.Tests.Unit.Framework.Factories {
         [InlineData(PaymentMethod.BancomatPay, typeof(PaymentResponse))]
         [InlineData(PaymentMethod.BacsDirectDebit, typeof(PaymentResponse))]
         [InlineData(PaymentMethod.Alma, typeof(PaymentResponse))]
+        [InlineData(PaymentMethod.GooglePay, typeof(PaymentResponse))]
         [InlineData("UnknownPaymentMethod", typeof(PaymentResponse))]
         public void Create_CreatesTypeBasedOnPaymentMethod(string paymentMethod, Type expectedType) {
             // Given


### PR DESCRIPTION
Added Google Pay to the list of constant string values of payment methods.

Solves #408 