### PR TITLE
Add support for voucher related fields in PaymentRequest

### DIFF
--- a/src/Mollie.Api/Models/Order/Request/OrderLineDetailsCategory.cs
+++ b/src/Mollie.Api/Models/Order/Request/OrderLineDetailsCategory.cs
@@ -1,7 +1,0 @@
-﻿namespace Mollie.Api.Models.Order.Request {
-    public static class OrderLineDetailsCategory {
-        public const string Meal = "meal";
-        public const string Eco = "eco";
-        public const string Gift = "gift";
-    }
-}

--- a/src/Mollie.Api/Models/Payment/PaymentLine.cs
+++ b/src/Mollie.Api/Models/Payment/PaymentLine.cs
@@ -1,4 +1,6 @@
-﻿namespace Mollie.Api.Models.Payment;
+﻿using System.Collections.Generic;
+
+namespace Mollie.Api.Models.Payment;
 
 public record PaymentLine {
     /// <summary>
@@ -48,6 +50,12 @@ public record PaymentLine {
     /// calculated with the formula totalAmount × (vatRate / (100 + vatRate)).
     /// </summary>
     public Amount? VatAmount { get; set; }
+
+    /// <summary>
+    /// An array with the voucher categories, in case of a line eligible for a voucher. See the Integrating
+    /// Vouchers guide for more information. Use the Mollie.Api.Models.VoucherCategory class for a full list of known values.
+    /// </summary>
+    public IEnumerable<string>? Categories { get; set; }
 
     /// <summary>
     /// The SKU, EAN, ISBN or UPC of the product sold.

--- a/src/Mollie.Api/Models/Payment/PaymentMethod.cs
+++ b/src/Mollie.Api/Models/Payment/PaymentMethod.cs
@@ -33,5 +33,6 @@
         public const string BacsDirectDebit = "bacs";
         public const string Alma = "alma";
         public const string GooglePay = "googlepay";
+        public const string Voucher = "voucher";
     }
 }

--- a/src/Mollie.Api/Models/Payment/Request/PaymentRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentRequest.cs
@@ -89,6 +89,13 @@ namespace Mollie.Api.Models.Payment.Request {
         }
 
         /// <summary>
+        /// Only relevant for iDEAL, KBC/CBC, gift card, and voucher payments.
+        /// Some payment methods are a network of connected banks or card issuers. In these cases, after selecting the payment method,
+        /// the customer may still need to select the appropriate issuer before the payment can proceed.
+        /// </summary>
+        public string? Issuer { get; set; }
+
+        /// <summary>
         /// Normally, a payment method screen is shown. However, when using this parameter, you can choose a specific payment method
         /// and your customer will skip the selection screen and is sent directly to the chosen payment method. The parameter
         /// enables you to fully integrate the payment method selection into your website.

--- a/src/Mollie.Api/Models/VoucherCategory.cs
+++ b/src/Mollie.Api/Models/VoucherCategory.cs
@@ -1,0 +1,8 @@
+﻿namespace Mollie.Api.Models;
+
+public static class VoucherCategory {
+    public const string Gift = "gift";
+    public const string Eco = "eco";
+    public const string Meal = "meal";
+    public const string SportCulture = "sport_culture";
+}

--- a/tests/Mollie.Tests.Integration/Api/OrderTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/OrderTests.cs
@@ -301,7 +301,7 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         ManageOrderLinesAddOperationData newOrderLineRequest = new ManageOrderLinesAddOperationData {
             Name = "LEGO Batman mobile",
             Type = OrderLineDetailsType.Physical,
-            Category = OrderLineDetailsCategory.Gift,
+            Category = VoucherCategory.Gift,
             Quantity = 1,
             UnitPrice = new Amount(Currency.EUR, 100.00m),
             TotalAmount = new Amount(Currency.EUR, 100.00m),
@@ -434,10 +434,10 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
             Amount = new Amount(Currency.EUR, "100.00"),
             OrderNumber = "16738",
             Lines = new List<OrderLineRequest>() {
-                new OrderLineRequest() {
+                new() {
                     Name = "A box of chocolates",
                     Type = OrderLineDetailsType.Physical,
-                    Category = OrderLineDetailsCategory.Gift,
+                    Category = VoucherCategory.Gift,
                     Quantity = 1,
                     UnitPrice = new Amount(Currency.EUR, "100.00"),
                     TotalAmount = new Amount(Currency.EUR, "100.00"),

--- a/tests/Mollie.Tests.Integration/Api/PaymentTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/PaymentTests.cs
@@ -253,47 +253,6 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         result.Method.Should().Be(paymentRequest.Method);
     }
 
-    [Fact]
-    public async Task CanCreateVoucherPaymentAndRetrieveIt() {
-        // When: we create a voucher payment
-        PaymentRequest paymentRequest = new PaymentRequest() {
-            Amount = new Amount(Currency.EUR, "100.00"),
-            Description = "Description",
-            RedirectUrl = DefaultRedirectUrl,
-            Method = PaymentMethod.Voucher,
-            Lines = [
-                new() {
-                    Type = OrderLineDetailsType.Digital,
-                    Categories = [
-                        "gift"
-                    ],
-                    Description = "Star wars lego",
-                    Quantity = 1,
-                    QuantityUnit = "pcs",
-                    UnitPrice = new Amount(Currency.EUR, 100m),
-                    TotalAmount = new Amount(Currency.EUR, 100m),
-                    ProductUrl = "http://www.lego.com/starwars",
-                    ImageUrl = "http://www.lego.com/starwars.jpg",
-                    Sku = "my-sku",
-                    VatAmount = new Amount(Currency.EUR, 17.36m),
-                    VatRate = "21.00"
-                }
-            ]
-        };
-
-        // When: We send the payment request to Mollie and attempt to retrieve it
-        PaymentResponse paymentResponse = await _paymentClient.CreatePaymentAsync(paymentRequest);
-        PaymentResponse result = await _paymentClient.GetPaymentAsync(paymentResponse.Id);
-
-        // Then
-        result.Should().NotBeNull();
-        result.Id.Should().Be(paymentResponse.Id);
-        result.Amount.Should().Be(paymentRequest.Amount);
-        result.Description.Should().Be(paymentRequest.Description);
-        result.RedirectUrl.Should().Be(paymentRequest.RedirectUrl);
-        result.Method.Should().Be(paymentRequest.Method);
-    }
-
     [DefaultRetryFact]
     public async Task CanCreatePaymentAndRetrieveIt() {
         // When: we create a new payment request

--- a/tests/Mollie.Tests.Integration/Api/PaymentTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/PaymentTests.cs
@@ -253,6 +253,47 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         result.Method.Should().Be(paymentRequest.Method);
     }
 
+    [Fact]
+    public async Task CanCreateVoucherPaymentAndRetrieveIt() {
+        // When: we create a voucher payment
+        PaymentRequest paymentRequest = new PaymentRequest() {
+            Amount = new Amount(Currency.EUR, "100.00"),
+            Description = "Description",
+            RedirectUrl = DefaultRedirectUrl,
+            Method = PaymentMethod.Voucher,
+            Lines = [
+                new() {
+                    Type = OrderLineDetailsType.Digital,
+                    Categories = [
+                        "gift"
+                    ],
+                    Description = "Star wars lego",
+                    Quantity = 1,
+                    QuantityUnit = "pcs",
+                    UnitPrice = new Amount(Currency.EUR, 100m),
+                    TotalAmount = new Amount(Currency.EUR, 100m),
+                    ProductUrl = "http://www.lego.com/starwars",
+                    ImageUrl = "http://www.lego.com/starwars.jpg",
+                    Sku = "my-sku",
+                    VatAmount = new Amount(Currency.EUR, 17.36m),
+                    VatRate = "21.00"
+                }
+            ]
+        };
+
+        // When: We send the payment request to Mollie and attempt to retrieve it
+        PaymentResponse paymentResponse = await _paymentClient.CreatePaymentAsync(paymentRequest);
+        PaymentResponse result = await _paymentClient.GetPaymentAsync(paymentResponse.Id);
+
+        // Then
+        result.Should().NotBeNull();
+        result.Id.Should().Be(paymentResponse.Id);
+        result.Amount.Should().Be(paymentRequest.Amount);
+        result.Description.Should().Be(paymentRequest.Description);
+        result.RedirectUrl.Should().Be(paymentRequest.RedirectUrl);
+        result.Method.Should().Be(paymentRequest.Method);
+    }
+
     [DefaultRetryFact]
     public async Task CanCreatePaymentAndRetrieveIt() {
         // When: we create a new payment request

--- a/tests/Mollie.Tests.Unit/Framework/Factories/PaymentResponseFactoryTests.cs
+++ b/tests/Mollie.Tests.Unit/Framework/Factories/PaymentResponseFactoryTests.cs
@@ -42,6 +42,7 @@ namespace Mollie.Tests.Unit.Framework.Factories {
         [InlineData(PaymentMethod.BacsDirectDebit, typeof(PaymentResponse))]
         [InlineData(PaymentMethod.Alma, typeof(PaymentResponse))]
         [InlineData(PaymentMethod.GooglePay, typeof(PaymentResponse))]
+        [InlineData(PaymentMethod.Voucher, typeof(PaymentResponse))]
         [InlineData("UnknownPaymentMethod", typeof(PaymentResponse))]
         public void Create_CreatesTypeBasedOnPaymentMethod(string paymentMethod, Type expectedType) {
             // Given


### PR DESCRIPTION
- Add support for the `Categories` field on the `PaymentLine` class.
- Add the `Voucher` payment method to the list of available paymentmethods.
- Add support for the `Issuer` property on the `PaymentRequest` class.
- Replace the `OrderLineDetailsCategory` class with the `VoucherCategory` class, which can now be used in both the Order and Payment API clients.