### PR TITLE
Replace FluentAssertions library with Shouldly

### DIFF
--- a/tests/Mollie.Tests.Integration/Api/ApiExceptionTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/ApiExceptionTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Models;
@@ -22,10 +22,10 @@ public class ApiExceptionTests : BaseMollieApiTestClass {
 
         // Then: Send the payment request to the Mollie Api, this should throw a mollie api exception
         MollieApiException apiException = await Assert.ThrowsAsync<MollieApiException>(() => paymentClient.CreatePaymentAsync(paymentRequest));
-        apiException.Should().NotBeNull();
-        apiException.Details.Should().NotBeNull();
-        apiException.Details.Status.Should().Be(422);
-        apiException.Details.Title.Should().Be("Unprocessable Entity");
-        apiException.Details.Detail.Should().Be("The description is invalid");
+        apiException.ShouldNotBeNull();
+        apiException.Details.ShouldNotBeNull();
+        apiException.Details.Status.ShouldBe(422);
+        apiException.Details.Title.ShouldBe("Unprocessable Entity");
+        apiException.Details.Detail.ShouldBe("The description is invalid");
     }
 }

--- a/tests/Mollie.Tests.Integration/Api/BalanceTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/BalanceTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Models.Balance.Response.BalanceReport;
@@ -26,16 +26,16 @@ public class BalanceTests : BaseMollieApiTestClass, IDisposable {
         var result = await _balanceClient.GetPrimaryBalanceAsync();
 
         // Then: Make sure we can parse the result
-        result.Should().NotBeNull();
-        result.Resource.Should().Be("balance");
-        result.Currency.Should().NotBeNull();
-        result.Id.Should().NotBeNull();
-        result.Links.Documentation.Href.Should().Be("https://docs.mollie.com/reference/v2/balances-api/get-primary-balance");
-        result.Links.Self.Href.Should().Be("https://api.mollie.com/v2/balances/{result.Id}");
-        result.TransferFrequency.Should().NotBeNull();
-        result.AvailableAmount.Should().NotBeNull();
-        result.PendingAmount.Should().NotBeNull();
-        result.TransferThreshold.Should().NotBeNull();
+        result.ShouldNotBeNull();
+        result.Resource.ShouldBe("balance");
+        result.Currency.ShouldNotBeNull();
+        result.Id.ShouldNotBeNull();
+        result.Links.Documentation.Href.ShouldBe("https://docs.mollie.com/reference/v2/balances-api/get-primary-balance");
+        result.Links.Self.Href.ShouldBe("https://api.mollie.com/v2/balances/{result.Id}");
+        result.TransferFrequency.ShouldNotBeNull();
+        result.AvailableAmount.ShouldNotBeNull();
+        result.PendingAmount.ShouldNotBeNull();
+        result.TransferThreshold.ShouldNotBeNull();
     }
 
     [DefaultRetryFact]
@@ -51,17 +51,17 @@ public class BalanceTests : BaseMollieApiTestClass, IDisposable {
         var result = await _balanceClient.GetBalanceAsync(firstBalance.Id);
 
         // Then: Make sure we can parse the result
-        result.Should().NotBeNull();
-        result.Resource.Should().Be("balance");
-        result.AvailableAmount.Should().Be(firstBalance.AvailableAmount);
-        result.Id.Should().Be(firstBalance.Id);
-        result.Links.Documentation.Href.Should().Be("https://docs.mollie.com/reference/v2/balances-api/get-balance");
-        result.Links.Self.Href.Should().Be($"https://api.mollie.com/v2/balances/{result.Id}");
-        result.Currency.Should().Be(firstBalance.Currency);
-        result.TransferFrequency.Should().Be(firstBalance.TransferFrequency);
-        result.AvailableAmount.Should().Be(firstBalance.AvailableAmount);
-        result.PendingAmount.Should().Be(firstBalance.PendingAmount);
-        result.TransferThreshold.Should().Be(firstBalance.TransferThreshold);
+        result.ShouldNotBeNull();
+        result.Resource.ShouldBe("balance");
+        result.AvailableAmount.ShouldBe(firstBalance.AvailableAmount);
+        result.Id.ShouldBe(firstBalance.Id);
+        result.Links.Documentation.Href.ShouldBe("https://docs.mollie.com/reference/v2/balances-api/get-balance");
+        result.Links.Self.Href.ShouldBe($"https://api.mollie.com/v2/balances/{result.Id}");
+        result.Currency.ShouldBe(firstBalance.Currency);
+        result.TransferFrequency.ShouldBe(firstBalance.TransferFrequency);
+        result.AvailableAmount.ShouldBe(firstBalance.AvailableAmount);
+        result.PendingAmount.ShouldBe(firstBalance.PendingAmount);
+        result.TransferThreshold.ShouldBe(firstBalance.TransferThreshold);
     }
 
     [DefaultRetryFact]
@@ -70,8 +70,8 @@ public class BalanceTests : BaseMollieApiTestClass, IDisposable {
         var result = await _balanceClient.GetBalanceListAsync();
 
         // Then: Make sure we can parse the result
-        result.Should().NotBeNull();
-        result.Items.Count.Should().Be(result.Count);
+        result.ShouldNotBeNull();
+        result.Items.Count.ShouldBe(result.Count);
     }
 
     [DefaultRetryTheory]
@@ -91,13 +91,13 @@ public class BalanceTests : BaseMollieApiTestClass, IDisposable {
             grouping: grouping);
 
         // Then: Make sure we can parse the result
-        result.Should().NotBeNull();
-        result.Should().BeOfType(expectedObjectType);
-        result.Resource.Should().Be("balance-report");
-        result.BalanceId.Should().Be(primaryBalance.Id);
-        result.From.Should().Be(from);
-        result.Until.Should().Be(until);
-        result.Grouping.Should().Be(grouping);
+        result.ShouldNotBeNull();
+        result.ShouldBeOfType(expectedObjectType);
+        result.Resource.ShouldBe("balance-report");
+        result.BalanceId.ShouldBe(primaryBalance.Id);
+        result.From.ShouldBe(from);
+        result.Until.ShouldBe(until);
+        result.Grouping.ShouldBe(grouping);
     }
 
     [DefaultRetryFact]
@@ -111,10 +111,10 @@ public class BalanceTests : BaseMollieApiTestClass, IDisposable {
         var result = await _balanceClient.GetBalanceTransactionListAsync(balanceId, from, limit);
 
         // Then: Make sure we can parse the result
-        result.Should().NotBeNull();
-        result.Items.Should().NotBeNull();
-        result.Links.Should().NotBeNull();
-        result.Links.Self.Href.Should().Be($"https://api.mollie.com/v2/balances/{balanceId}/transactions?from={from}&limit={limit}");
+        result.ShouldNotBeNull();
+        result.Items.ShouldNotBeNull();
+        result.Links.ShouldNotBeNull();
+        result.Links.Self.Href.ShouldBe($"https://api.mollie.com/v2/balances/{balanceId}/transactions?from={from}&limit={limit}");
     }
 
     [DefaultRetryFact]
@@ -127,8 +127,8 @@ public class BalanceTests : BaseMollieApiTestClass, IDisposable {
         var result = await _balanceClient.GetPrimaryBalanceTransactionListAsync(from, limit);
 
         // Then: Make sure we can parse the result
-        result.Should().NotBeNull();
-        result.Items.Should().NotBeNull();
+        result.ShouldNotBeNull();
+        result.Items.ShouldNotBeNull();
     }
 
     public void Dispose()

--- a/tests/Mollie.Tests.Integration/Api/CaptureTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/CaptureTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Models;
@@ -45,10 +45,10 @@ public class CaptureTests : BaseMollieApiTestClass, IDisposable {
         var capture = await _captureClient.CreateCapture(payment.Id, captureRequest);
 
         // Then: The capture should be created
-        capture.Status.Should().Be("pending");
-        capture.PaymentId.Should().Be(payment.Id);
-        capture.Resource.Should().Be("capture");
-        capture.Metadata.Should().Be(captureRequest.Metadata);
+        capture.Status.ShouldBe("pending");
+        capture.PaymentId.ShouldBe(payment.Id);
+        capture.Resource.ShouldBe("capture");
+        capture.Metadata.ShouldBe(captureRequest.Metadata);
     }
 
     [DefaultRetryFact(Skip = "We can only test this in debug mode, because we actually have to use the PaymentUrl" +
@@ -76,12 +76,12 @@ public class CaptureTests : BaseMollieApiTestClass, IDisposable {
         var captureList = await _captureClient.GetCaptureListAsync(payment.Id);
 
         // Then
-        captureList.Count.Should().Be(1);
+        captureList.Count.ShouldBe(1);
         var capture = captureList.Items.Single();
-        capture.Status.Should().Be("succeeded");
-        capture.PaymentId.Should().Be(payment.Id);
-        capture.Resource.Should().Be("capture");
-        capture.Metadata.Should().Be(captureRequest.Metadata);
+        capture.Status.ShouldBe("succeeded");
+        capture.PaymentId.ShouldBe(payment.Id);
+        capture.Resource.ShouldBe("capture");
+        capture.Metadata.ShouldBe(captureRequest.Metadata);
     }
 
     public void Dispose()

--- a/tests/Mollie.Tests.Integration/Api/ConnectTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/ConnectTests.cs
@@ -2,7 +2,7 @@
 using Mollie.Tests.Integration.Framework;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Models.Connect.Request;
 using Mollie.Api.Models.Connect.Response;
 
@@ -19,7 +19,7 @@ public class ConnectTests : BaseMollieApiTestClass {
 
         // Then:
         string expectedUrl = $"https://my.mollie.com/oauth2/authorize?client_id={ClientId}&state=abcde&scope=payments.read&response_type=code&approval_prompt=auto";
-        authorizationUrl.Should().Be(expectedUrl);
+        authorizationUrl.ShouldBe(expectedUrl);
     }
 
     [DefaultRetryFact]
@@ -38,7 +38,7 @@ public class ConnectTests : BaseMollieApiTestClass {
         // Then:
         string expectedUrl = $"https://my.mollie.com/oauth2/authorize?client_id={ClientId}" +
                              $"&state=abcdef&scope=payments.read+payments.write+profiles.read+profiles.write&response_type=code&approval_prompt=auto";
-        authorizationUrl.Should().Be(expectedUrl);
+        authorizationUrl.ShouldBe(expectedUrl);
     }
 
     [DefaultRetryFact(Skip = "We can only test this in debug mode, because we login to the mollie dashboard and login to get the auth token")]
@@ -52,7 +52,7 @@ public class ConnectTests : BaseMollieApiTestClass {
         TokenResponse tokenResponse = await connectClient.GetAccessTokenAsync(tokenRequest);
 
         // Then: The access token should not be null
-        tokenResponse.AccessToken.Should().NotBeNullOrEmpty();
+        tokenResponse.AccessToken.ShouldNotBeNullOrEmpty();
     }
 
     [DefaultRetryFact(Skip = "We can only test this in debug mode, because we need a valid access token")]

--- a/tests/Mollie.Tests.Integration/Api/CustomerTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/CustomerTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Models;
@@ -30,8 +30,8 @@ public class CustomerTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<CustomerResponse> response = await _customerClient.GetCustomerListAsync();
 
         // Then
-        response.Should().NotBeNull();
-        response.Items.Should().NotBeNull();
+        response.ShouldNotBeNull();
+        response.Items.ShouldNotBeNull();
     }
 
     [DefaultRetryFact]
@@ -43,7 +43,7 @@ public class CustomerTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<CustomerResponse> response = await _customerClient.GetCustomerListAsync(null, numberOfCustomers);
 
         // Then
-        numberOfCustomers.Should().Be(response.Items.Count);
+        numberOfCustomers.ShouldBe(response.Items.Count);
     }
 
     [DefaultRetryFact]
@@ -56,9 +56,9 @@ public class CustomerTests : BaseMollieApiTestClass, IDisposable {
         CustomerResponse result = await CreateCustomer(name, email);
 
         // Then: Make sure the requested parameters match the response parameter values
-        result.Should().NotBeNull();
-        result.Name.Should().Be(name);
-        result.Email.Should().Be(email);
+        result.ShouldNotBeNull();
+        result.Name.ShouldBe(name);
+        result.Email.ShouldBe(email);
     }
 
     [DefaultRetryFact]
@@ -75,8 +75,8 @@ public class CustomerTests : BaseMollieApiTestClass, IDisposable {
         CustomerResponse result = await _customerClient.UpdateCustomerAsync(customerIdToUpdate, updateParameters);
 
         // Then: Make sure the new name is updated
-        result.Should().NotBeNull();
-        result.Name.Should().Be(newCustomerName);
+        result.ShouldNotBeNull();
+        result.Name.ShouldBe(newCustomerName);
     }
 
     [DefaultRetryFact]
@@ -90,7 +90,7 @@ public class CustomerTests : BaseMollieApiTestClass, IDisposable {
 
         // Then: Make sure its deleted
         MollieApiException apiException = await Assert.ThrowsAsync<MollieApiException>(() => _customerClient.GetCustomerAsync(customerIdToDelete));
-        apiException.Details.Status.Should().Be((int)HttpStatusCode.Gone);
+        apiException.Details.Status.ShouldBe((int)HttpStatusCode.Gone);
     }
 
     [DefaultRetryFact]
@@ -104,8 +104,8 @@ public class CustomerTests : BaseMollieApiTestClass, IDisposable {
         CustomerResponse retrievedCustomer = await _customerClient.GetCustomerAsync(createdCustomer.Links.Self);
 
         // Then: Make sure it's retrieved
-        retrievedCustomer.Name.Should().Be(createdCustomer.Name);
-        retrievedCustomer.Email.Should().Be(createdCustomer.Email);
+        retrievedCustomer.Name.ShouldBe(createdCustomer.Name);
+        retrievedCustomer.Email.ShouldBe(createdCustomer.Email);
     }
 
     [DefaultRetryFact]
@@ -122,7 +122,7 @@ public class CustomerTests : BaseMollieApiTestClass, IDisposable {
         CustomerResponse retrievedCustomer = await _customerClient.CreateCustomerAsync(customerRequest);
 
         // Then: Make sure it's retrieved
-        IsJsonResultEqual(customerRequest.Metadata, retrievedCustomer.Metadata).Should().BeTrue();
+        IsJsonResultEqual(customerRequest.Metadata, retrievedCustomer.Metadata).ShouldBeTrue();
     }
 
     [DefaultRetryFact]
@@ -139,7 +139,7 @@ public class CustomerTests : BaseMollieApiTestClass, IDisposable {
         CustomerResponse retrievedCustomer = await _customerClient.CreateCustomerAsync(customerRequest);
 
         // Then: Make sure it's retrieved
-        retrievedCustomer.Metadata.Should().Be(customerRequest.Metadata);
+        retrievedCustomer.Metadata.ShouldBe(customerRequest.Metadata);
     }
 
     [DefaultRetryFact]
@@ -158,8 +158,8 @@ public class CustomerTests : BaseMollieApiTestClass, IDisposable {
         PaymentResponse paymentResponse = await _customerClient.CreateCustomerPayment(customer.Id, paymentRequest);
 
         // Then: Make sure the requested parameters match the response parameter values
-        paymentResponse.Should().NotBeNull();
-        paymentResponse.CustomerId.Should().Be(customer.Id);
+        paymentResponse.ShouldNotBeNull();
+        paymentResponse.CustomerId.ShouldBe(customer.Id);
     }
 
     private async Task<CustomerResponse> CreateCustomer(string name, string email) {

--- a/tests/Mollie.Tests.Integration/Api/MandateTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/MandateTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Models.Customer.Response;
@@ -35,8 +35,8 @@ public class MandateTests : BaseMollieApiTestClass, IDisposable {
             ListResponse<MandateResponse> response = await _mandateClient.GetMandateListAsync(customers.Items.First().Id);
 
             // Then
-            response.Should().NotBeNull();
-            response.Items.Should().NotBeNull();
+            response.ShouldNotBeNull();
+            response.Items.ShouldNotBeNull();
         }
     }
 
@@ -53,7 +53,7 @@ public class MandateTests : BaseMollieApiTestClass, IDisposable {
             ListResponse<MandateResponse> response = await _mandateClient.GetMandateListAsync(customers.Items.First().Id, null, numberOfMandates);
 
             // Then
-            numberOfMandates.Should().BeGreaterOrEqualTo(response.Items.Count);
+            numberOfMandates.ShouldBeGreaterThanOrEqualTo(response.Items.Count);
         }
     }
 
@@ -73,10 +73,10 @@ public class MandateTests : BaseMollieApiTestClass, IDisposable {
             MandateResponse mandateResponse = await _mandateClient.CreateMandateAsync(customers.Items.First().Id, mandateRequest);
 
             // Then: Make sure we created a new mandate
-            mandateResponse.Should().BeOfType<SepaDirectDebitMandateResponse>();
+            mandateResponse.ShouldBeOfType<SepaDirectDebitMandateResponse>();
             var sepaDirectDebitResponse = (SepaDirectDebitMandateResponse)mandateResponse;
-            sepaDirectDebitResponse.Details.ConsumerAccount.Should().Be(mandateRequest.ConsumerAccount);
-            sepaDirectDebitResponse.Details.ConsumerName.Should().Be(mandateRequest.ConsumerName);
+            sepaDirectDebitResponse.Details.ConsumerAccount.ShouldBe(mandateRequest.ConsumerAccount);
+            sepaDirectDebitResponse.Details.ConsumerName.ShouldBe(mandateRequest.ConsumerName);
         }
     }
 

--- a/tests/Mollie.Tests.Integration/Api/OrderTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/OrderTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Models;
@@ -15,6 +15,7 @@ using Mollie.Api.Models.Order.Response;
 using Mollie.Api.Models.Payment;
 using Mollie.Tests.Integration.Framework;
 using Xunit;
+using SortDirection = Mollie.Api.Models.SortDirection;
 
 namespace Mollie.Tests.Integration.Api;
 
@@ -34,7 +35,7 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         // Assert
         if (orders.Items.Any())
         {
-            orders.Items.Should().BeInDescendingOrder(x => x.CreatedAt);
+            orders.Items.Select(x => x.CreatedAt).ShouldBeInOrder(Shouldly.SortDirection.Descending);
         }
     }
 
@@ -47,7 +48,7 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         // Assert
         if (orders.Items.Any())
         {
-            orders.Items.Should().BeInDescendingOrder(x => x.CreatedAt);
+            orders.Items.Select(x => x.CreatedAt).ShouldBeInOrder(Shouldly.SortDirection.Descending);
         }
     }
 
@@ -60,7 +61,7 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         // Assert
         if (orders.Items.Any())
         {
-            orders.Items.Should().BeInAscendingOrder(x => x.CreatedAt);
+            orders.Items.Select(x => x.CreatedAt).ShouldBeInOrder(Shouldly.SortDirection.Ascending);
         }
     }
 
@@ -73,18 +74,18 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         OrderResponse result = await _orderClient.CreateOrderAsync(orderRequest);
 
         // Then: Make sure we get a valid response
-        result.Should().NotBeNull();
-        result.Amount.Should().Be(orderRequest.Amount);
-        result.OrderNumber.Should().Be(orderRequest.OrderNumber);
-        result.Lines.Should().HaveCount(orderRequest.Lines.Count());
-        result.Links.Should().NotBeNull();
+        result.ShouldNotBeNull();
+        result.Amount.ShouldBe(orderRequest.Amount);
+        result.OrderNumber.ShouldBe(orderRequest.OrderNumber);
+        result.Lines.Count().ShouldBe(orderRequest.Lines.Count());
+        result.Links.ShouldNotBeNull();
         OrderLineRequest orderLineRequest = orderRequest.Lines.First();
         OrderLineResponse orderResponseLine = result.Lines.First();
-        orderResponseLine.Type.Should().Be(orderLineRequest.Type);
-        orderResponseLine.Links.ImageUrl!.Href.Should().Be(orderLineRequest.ImageUrl);
-        orderResponseLine.Links.ProductUrl!.Href.Should().Be(orderLineRequest.ProductUrl);
+        orderResponseLine.Type.ShouldBe(orderLineRequest.Type);
+        orderResponseLine.Links.ImageUrl!.Href.ShouldBe(orderLineRequest.ImageUrl);
+        orderResponseLine.Links.ProductUrl!.Href.ShouldBe(orderLineRequest.ProductUrl);
         var expectedMetadataString = result.Lines.First().Metadata;
-        orderResponseLine.Metadata.Should().Be(expectedMetadataString);
+        orderResponseLine.Metadata.ShouldBe(expectedMetadataString);
     }
 
     [DefaultRetryFact]
@@ -103,18 +104,18 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         OrderResponse result = await _orderClient.CreateOrderAsync(orderRequest);
 
         // Then: Make sure we get a valid response
-        result.Should().NotBeNull();
-        result.Amount.Should().Be(orderRequest.Amount);
-        result.OrderNumber.Should().Be(orderRequest.OrderNumber);
-        result.Lines.Should().HaveCount(orderRequest.Lines.Count());
-        result.Links.Should().NotBeNull();
+        result.ShouldNotBeNull();
+        result.Amount.ShouldBe(orderRequest.Amount);
+        result.OrderNumber.ShouldBe(orderRequest.OrderNumber);
+        result.Lines.Count().ShouldBe(orderRequest.Lines.Count());
+        result.Links.ShouldNotBeNull();
         OrderLineRequest orderLineRequest = orderRequest.Lines.First();
         OrderLineResponse orderResponseLine = result.Lines.First();
-        orderResponseLine.Type.Should().Be(orderLineRequest.Type);
-        orderResponseLine.Links.ImageUrl!.Href.Should().Be(orderLineRequest.ImageUrl);
-        orderResponseLine.Links.ProductUrl!.Href.Should().Be(orderLineRequest.ProductUrl);
+        orderResponseLine.Type.ShouldBe(orderLineRequest.Type);
+        orderResponseLine.Links.ImageUrl!.Href.ShouldBe(orderLineRequest.ImageUrl);
+        orderResponseLine.Links.ProductUrl!.Href.ShouldBe(orderLineRequest.ProductUrl);
         var expectedMetadataString = result.Lines.First().Metadata;
-        orderResponseLine.Metadata.Should().Be(expectedMetadataString);
+        orderResponseLine.Metadata.ShouldBe(expectedMetadataString);
     }
 
     [DefaultRetryFact]
@@ -131,9 +132,9 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         OrderResponse result = await _orderClient.CreateOrderAsync(orderRequest);
 
         // Then: Make sure we get a valid response
-        result.Should().NotBeNull();
-        result.Amount.Should().Be(orderRequest.Amount);
-        result.OrderNumber.Should().Be(orderRequest.OrderNumber);
+        result.ShouldNotBeNull();
+        result.Amount.ShouldBe(orderRequest.Amount);
+        result.OrderNumber.ShouldBe(orderRequest.OrderNumber);
     }
 
     [DefaultRetryFact]
@@ -146,11 +147,11 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         OrderResponse result = await _orderClient.CreateOrderAsync(orderRequest);
 
         // Then: Make sure we get a valid response
-        orderRequest.Method.Should().Be(PaymentMethod.CreditCard);
-        orderRequest.Methods!.First().Should().Be(PaymentMethod.CreditCard);
-        result.Should().NotBeNull();
-        result.Amount.Should().Be(orderRequest.Amount);
-        result.OrderNumber.Should().Be(orderRequest.OrderNumber);
+        orderRequest.Method.ShouldBe(PaymentMethod.CreditCard);
+        orderRequest.Methods!.First().ShouldBe(PaymentMethod.CreditCard);
+        result.ShouldNotBeNull();
+        result.Amount.ShouldBe(orderRequest.Amount);
+        result.OrderNumber.ShouldBe(orderRequest.OrderNumber);
     }
 
     public static IEnumerable<object[]> PaymentSpecificParameters =>
@@ -221,9 +222,9 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         OrderResponse result = await _orderClient.CreateOrderAsync(orderRequest);
 
         // Then: Make sure we get a valid response
-        result.Should().NotBeNull();
-        result.Amount.Should().Be(orderRequest.Amount);
-        result.OrderNumber.Should().Be(orderRequest.OrderNumber);
+        result.ShouldNotBeNull();
+        result.Amount.ShouldBe(orderRequest.Amount);
+        result.OrderNumber.ShouldBe(orderRequest.OrderNumber);
     }
 
     [DefaultRetryFact]
@@ -236,8 +237,8 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         OrderResponse retrievedOrder = await _orderClient.GetOrderAsync(createdOrder.Id);
 
         // Then: Make sure we get a valid response
-        retrievedOrder.Should().NotBeNull();
-        retrievedOrder.Id.Should().Be(createdOrder.Id);
+        retrievedOrder.ShouldNotBeNull();
+        retrievedOrder.Id.ShouldBe(createdOrder.Id);
     }
 
     [DefaultRetryFact]
@@ -250,12 +251,12 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         OrderResponse retrievedOrder = await _orderClient.GetOrderAsync(createdOrder.Id, embedPayments: true, embedShipments: true, embedRefunds: true);
 
         // Then: Make sure we get a valid response
-        retrievedOrder.Should().NotBeNull();
-        retrievedOrder.Id.Should().Be(createdOrder.Id);
-        retrievedOrder.Embedded.Should().NotBeNull();
-        retrievedOrder.Embedded!.Payments.Should().NotBeNull();
-        retrievedOrder.Embedded.Shipments.Should().NotBeNull();
-        retrievedOrder.Embedded.Refunds.Should().NotBeNull();
+        retrievedOrder.ShouldNotBeNull();
+        retrievedOrder.Id.ShouldBe(createdOrder.Id);
+        retrievedOrder.Embedded.ShouldNotBeNull();
+        retrievedOrder.Embedded!.Payments.ShouldNotBeNull();
+        retrievedOrder.Embedded.Shipments.ShouldNotBeNull();
+        retrievedOrder.Embedded.Refunds.ShouldNotBeNull();
     }
 
     [DefaultRetryFact]
@@ -272,7 +273,7 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         OrderResponse updatedOrder = await _orderClient.UpdateOrderAsync(createdOrder.Id, orderUpdateRequest);
 
         // Then: Make sure the order is updated
-        updatedOrder.OrderNumber.Should().Be(orderUpdateRequest.OrderNumber);
+        updatedOrder.OrderNumber.ShouldBe(orderUpdateRequest.OrderNumber);
     }
 
     [DefaultRetryFact(Skip = "Broken - Reported to Mollie: https://discordapp.com/channels/1037712581407817839/1180467187677401198/1180467187677401198")]
@@ -288,7 +289,7 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         OrderResponse updatedOrder = await _orderClient.UpdateOrderLinesAsync(createdOrder.Id, createdOrder.Lines.First().Id, updateRequest);
 
         // Then: The name of the order line should be updated
-        updatedOrder.Lines.First().Name.Should().Be(updateRequest.Name);
+        updatedOrder.Lines.First().Name.ShouldBe(updateRequest.Name);
     }
 
     [DefaultRetryFact]
@@ -321,19 +322,19 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         OrderResponse updatedOrder = await _orderClient.ManageOrderLinesAsync(createdOrder.Id, manageOrderLinesRequest);
 
         // Then: The order line should be added
-        updatedOrder.Lines.Should().HaveCount(2);
+        updatedOrder.Lines.Count().ShouldBe(2);
         var addedOrderLineRequest = updatedOrder.Lines.SingleOrDefault(line => line.Name == newOrderLineRequest.Name);
-        addedOrderLineRequest.Should().NotBeNull();
-        addedOrderLineRequest!.Type.Should().Be(newOrderLineRequest.Type);
-        addedOrderLineRequest.Quantity.Should().Be(newOrderLineRequest.Quantity);
-        addedOrderLineRequest.UnitPrice.Should().Be(newOrderLineRequest.UnitPrice);
-        addedOrderLineRequest.TotalAmount.Should().Be(newOrderLineRequest.TotalAmount);
-        addedOrderLineRequest.VatRate.Should().Be(newOrderLineRequest.VatRate);
-        addedOrderLineRequest.VatAmount.Should().Be(newOrderLineRequest.VatAmount);
+        addedOrderLineRequest.ShouldNotBeNull();
+        addedOrderLineRequest!.Type.ShouldBe(newOrderLineRequest.Type);
+        addedOrderLineRequest.Quantity.ShouldBe(newOrderLineRequest.Quantity);
+        addedOrderLineRequest.UnitPrice.ShouldBe(newOrderLineRequest.UnitPrice);
+        addedOrderLineRequest.TotalAmount.ShouldBe(newOrderLineRequest.TotalAmount);
+        addedOrderLineRequest.VatRate.ShouldBe(newOrderLineRequest.VatRate);
+        addedOrderLineRequest.VatAmount.ShouldBe(newOrderLineRequest.VatAmount);
         var newMetaData = addedOrderLineRequest.Metadata!
             .Replace(Environment.NewLine, "")
             .Replace(" ", "");
-        newMetaData.Should().Be(newOrderLineRequest.Metadata);
+        newMetaData.ShouldBe(newOrderLineRequest.Metadata);
     }
 
     [DefaultRetryFact]
@@ -367,18 +368,18 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         OrderResponse updatedOrder = await _orderClient.ManageOrderLinesAsync(createdOrder.Id, manageOrderLinesRequest);
 
         // Then: The order line should be updated
-        updatedOrder.Lines.Should().HaveCount(1);
+        updatedOrder.Lines.Count().ShouldBe(1);
         var addedOrderLineRequest = updatedOrder.Lines.SingleOrDefault(line => line.Name == orderLineUpdateRequest.Name);
-        addedOrderLineRequest.Should().NotBeNull();
-        addedOrderLineRequest!.Quantity.Should().Be(orderLineUpdateRequest.Quantity);
-        addedOrderLineRequest.UnitPrice.Should().Be(orderLineUpdateRequest.UnitPrice);
-        addedOrderLineRequest.TotalAmount.Should().Be(orderLineUpdateRequest.TotalAmount);
-        addedOrderLineRequest.VatRate.Should().Be(orderLineUpdateRequest.VatRate);
-        addedOrderLineRequest.VatAmount.Should().Be(orderLineUpdateRequest.VatAmount);
+        addedOrderLineRequest.ShouldNotBeNull();
+        addedOrderLineRequest!.Quantity.ShouldBe(orderLineUpdateRequest.Quantity.Value);
+        addedOrderLineRequest.UnitPrice.ShouldBe(orderLineUpdateRequest.UnitPrice);
+        addedOrderLineRequest.TotalAmount.ShouldBe(orderLineUpdateRequest.TotalAmount);
+        addedOrderLineRequest.VatRate.ShouldBe(orderLineUpdateRequest.VatRate);
+        addedOrderLineRequest.VatAmount.ShouldBe(orderLineUpdateRequest.VatAmount);
         addedOrderLineRequest.Metadata!
             .Replace(Environment.NewLine, "")
             .Replace(" ", "")
-            .Should().Be(orderLineUpdateRequest.Metadata);
+            .ShouldBe(orderLineUpdateRequest.Metadata);
     }
 
     [DefaultRetryFact]
@@ -402,9 +403,9 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         OrderResponse updatedOrder = await _orderClient.ManageOrderLinesAsync(createdOrder.Id, manageOrderLinesRequest);
 
         // Then: The order line should be canceled
-        updatedOrder.Lines.Should().HaveCount(1);
+        updatedOrder.Lines.Count().ShouldBe(1);
         var updatedOrderLineRequest = updatedOrder.Lines.Single();
-        updatedOrderLineRequest.Status.Should().Be(OrderStatus.Canceled);
+        updatedOrderLineRequest.Status.ShouldBe(OrderStatus.Canceled);
     }
 
     [DefaultRetryFact]
@@ -413,8 +414,8 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<OrderResponse> response = await _orderClient.GetOrderListAsync();
 
         // Then
-        response.Should().NotBeNull();
-        response.Items.Should().NotBeNull();
+        response.ShouldNotBeNull();
+        response.Items.ShouldNotBeNull();
     }
 
     [DefaultRetryFact]
@@ -426,7 +427,7 @@ public class OrderTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<OrderResponse> response = await _orderClient.GetOrderListAsync(null, numberOfOrders);
 
         // Then
-        response.Items.Should().HaveCountLessThanOrEqualTo(numberOfOrders);
+        response.Items.Count.ShouldBeLessThanOrEqualTo(numberOfOrders);
     }
 
     private OrderRequest CreateOrder() {

--- a/tests/Mollie.Tests.Integration/Api/PaymentLinkTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/PaymentLinkTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
@@ -26,8 +26,8 @@ public class PaymentLinkTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<PaymentLinkResponse> response = await _paymentLinkClient.GetPaymentLinkListAsync();
 
         // Then
-        response.Should().NotBeNull();
-        response.Items.Should().NotBeNull();
+        response.ShouldNotBeNull();
+        response.Items.ShouldNotBeNull();
     }
 
     [DefaultRetryFact]
@@ -49,11 +49,11 @@ public class PaymentLinkTests : BaseMollieApiTestClass, IDisposable {
         var verifyPaymentLinkResponse = new Action<PaymentLinkResponse>(response => {
             var expiresAtWithoutMs = paymentLinkRequest.ExpiresAt.Value.Truncate(TimeSpan.FromSeconds(1));
 
-            response.Amount.Should().Be(paymentLinkRequest.Amount);
-            response.ExpiresAt.Should().Be(expiresAtWithoutMs);
-            response.Description.Should().Be(paymentLinkRequest.Description);
-            response.RedirectUrl.Should().Be(paymentLinkRequest.RedirectUrl);
-            response.Archived.Should().BeFalse();
+            response.Amount.ShouldBe(paymentLinkRequest.Amount);
+            response.ExpiresAt.ShouldBe(expiresAtWithoutMs);
+            response.Description.ShouldBe(paymentLinkRequest.Description);
+            response.RedirectUrl.ShouldBe(paymentLinkRequest.RedirectUrl);
+            response.Archived.ShouldBeFalse();
         });
 
         verifyPaymentLinkResponse(createdPaymentLinkResponse);
@@ -79,10 +79,10 @@ public class PaymentLinkTests : BaseMollieApiTestClass, IDisposable {
         var verifyPaymentLinkResponse = new Action<PaymentLinkResponse>(response => {
             var expiresAtWithoutMs = paymentLinkRequest.ExpiresAt.Value.Truncate(TimeSpan.FromSeconds(1));
 
-            response.Amount.Should().BeNull();
-            response.ExpiresAt.Should().Be(expiresAtWithoutMs);
-            response.Description.Should().Be(paymentLinkRequest.Description);
-            response.RedirectUrl.Should().Be(paymentLinkRequest.RedirectUrl);
+            response.Amount.ShouldBeNull();
+            response.ExpiresAt.ShouldBe(expiresAtWithoutMs);
+            response.Description.ShouldBe(paymentLinkRequest.Description);
+            response.RedirectUrl.ShouldBe(paymentLinkRequest.RedirectUrl);
         });
 
         verifyPaymentLinkResponse(createdPaymentLinkResponse);
@@ -111,8 +111,8 @@ public class PaymentLinkTests : BaseMollieApiTestClass, IDisposable {
             paymentLinkUpdateRequest);
 
         // Then: We expect the payment link to be updated
-        updatedPaymentLinkResponse.Description.Should().Be(paymentLinkUpdateRequest.Description);
-        updatedPaymentLinkResponse.Archived.Should().Be(paymentLinkUpdateRequest.Archived);
+        updatedPaymentLinkResponse.Description.ShouldBe(paymentLinkUpdateRequest.Description);
+        updatedPaymentLinkResponse.Archived.ShouldBe(paymentLinkUpdateRequest.Archived);
     }
 
     [DefaultRetryFact]
@@ -133,8 +133,8 @@ public class PaymentLinkTests : BaseMollieApiTestClass, IDisposable {
         // Then: We expect the payment link to be updated
         MollieApiException exception = await Assert.ThrowsAsync<MollieApiException>(() =>
             _paymentLinkClient.GetPaymentLinkAsync(createdPaymentLinkResponse.Id));
-        exception.Details.Status.Should().Be(404);
-        exception.Details.Detail.Should().Be("Payment link does not exists.");
+        exception.Details.Status.ShouldBe(404);
+        exception.Details.Detail.ShouldBe("Payment link does not exists.");
     }
 
     [DefaultRetryFact]
@@ -153,8 +153,8 @@ public class PaymentLinkTests : BaseMollieApiTestClass, IDisposable {
         var result = await _paymentLinkClient.GetPaymentLinkPaymentListAsync(createdPaymentLinkResponse.Id);
 
         // Then: We expect the payment list to be returned
-        result.Should().NotBeNull();
-        result.Items.Should().HaveCount(0);
+        result.ShouldNotBeNull();
+        result.Items.Count.ShouldBe(0);
     }
 
     public void Dispose()

--- a/tests/Mollie.Tests.Integration/Api/PaymentMethodTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/PaymentMethodTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Models;
@@ -26,8 +26,8 @@ public class PaymentMethodTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<PaymentMethodResponse> response = await _paymentMethodClient.GetPaymentMethodListAsync();
 
         // Then: Make sure it can be retrieved
-        response.Should().NotBeNull();
-        response.Items.Should().NotBeNull();
+        response.ShouldNotBeNull();
+        response.Items.ShouldNotBeNull();
     }
 
     [DefaultRetryFact]
@@ -36,8 +36,8 @@ public class PaymentMethodTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<PaymentMethodResponse> response = await _paymentMethodClient.GetPaymentMethodListAsync(includeWallets: "applepay");
 
         // Then: Make sure it can be retrieved
-        response.Should().NotBeNull();
-        response.Items.Should().NotBeNull();
+        response.ShouldNotBeNull();
+        response.Items.ShouldNotBeNull();
     }
 
     [DefaultRetryTheory]
@@ -47,8 +47,8 @@ public class PaymentMethodTests : BaseMollieApiTestClass, IDisposable {
         PaymentMethodResponse paymentMethod = await _paymentMethodClient.GetPaymentMethodAsync(method);
 
         // Then: Make sure it can be retrieved
-        paymentMethod.Should().NotBeNull();
-        paymentMethod.Id.Should().Be(method);
+        paymentMethod.ShouldNotBeNull();
+        paymentMethod.Id.ShouldBe(method);
     }
 
     [DefaultRetryFact]
@@ -57,8 +57,8 @@ public class PaymentMethodTests : BaseMollieApiTestClass, IDisposable {
         PaymentMethodResponse paymentMethod = await _paymentMethodClient.GetPaymentMethodAsync(PaymentMethod.Kbc, true);
 
         // Then: We should have one or multiple issuers
-        paymentMethod.Should().NotBeNull();
-        paymentMethod.Issuers.Should().NotBeEmpty();
+        paymentMethod.ShouldNotBeNull();
+        paymentMethod.Issuers.ShouldNotBeEmpty();
     }
 
     [DefaultRetryFact]
@@ -67,7 +67,7 @@ public class PaymentMethodTests : BaseMollieApiTestClass, IDisposable {
         PaymentMethodResponse paymentMethod = await _paymentMethodClient.GetPaymentMethodAsync(PaymentMethod.Kbc);
 
         // Then: Issuers should not be included
-        paymentMethod.Issuers.Should().BeNull();
+        paymentMethod.Issuers.ShouldBeNull();
     }
 
     [DefaultRetryFact]
@@ -76,8 +76,8 @@ public class PaymentMethodTests : BaseMollieApiTestClass, IDisposable {
         PaymentMethodResponse paymentMethod = await _paymentMethodClient.GetPaymentMethodAsync(PaymentMethod.CreditCard, includePricing: true);
 
         // Then: We should have one or multiple issuers
-        paymentMethod.Should().NotBeNull();
-        paymentMethod.Pricing.Should().NotBeEmpty();
+        paymentMethod.ShouldNotBeNull();
+        paymentMethod.Pricing.ShouldNotBeEmpty();
     }
 
     [DefaultRetryFact]
@@ -86,7 +86,7 @@ public class PaymentMethodTests : BaseMollieApiTestClass, IDisposable {
         PaymentMethodResponse paymentMethod = await _paymentMethodClient.GetPaymentMethodAsync(PaymentMethod.CreditCard, includePricing: false);
 
         // Then: Issuers should not be included
-        paymentMethod.Pricing.Should().BeNull();
+        paymentMethod.Pricing.ShouldBeNull();
     }
 
     [DefaultRetryFact]
@@ -95,8 +95,8 @@ public class PaymentMethodTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<PaymentMethodResponse> paymentMethods = await _paymentMethodClient.GetAllPaymentMethodListAsync();
 
         // Then: We should have multiple issuers
-        paymentMethods.Should().NotBeNull();
-        paymentMethods.Items.Should().NotBeEmpty();
+        paymentMethods.ShouldNotBeNull();
+        paymentMethods.Items.ShouldNotBeEmpty();
     }
 
     [DefaultRetryFact]
@@ -105,7 +105,7 @@ public class PaymentMethodTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<PaymentMethodResponse> paymentMethods = await _paymentMethodClient.GetAllPaymentMethodListAsync(includePricing: true);
 
         // Then: We should have prices available
-        paymentMethods.Items.All(x => x.Pricing != null && x.Pricing.Any(y => y.Fixed.Value > 0)).Should().BeTrue();
+        paymentMethods.Items.All(x => x.Pricing != null && x.Pricing.Any(y => y.Fixed.Value > 0)).ShouldBeTrue();
     }
 
     [DefaultRetryFact]
@@ -114,7 +114,7 @@ public class PaymentMethodTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<PaymentMethodResponse> paymentMethods = await _paymentMethodClient.GetAllPaymentMethodListAsync(includeIssuers: true);
 
         // Then: We should have one or multiple issuers
-        paymentMethods.Items.Should().Contain(x => x.Issuers != null);
+        paymentMethods.Items.ShouldContain(x => x.Issuers != null);
     }
 
     [DefaultRetryFact]
@@ -123,8 +123,8 @@ public class PaymentMethodTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<PaymentMethodResponse> paymentMethods = await _paymentMethodClient.GetAllPaymentMethodListAsync(includeIssuers: true, includePricing: true);
 
         // Then: We should have one or multiple issuers
-        paymentMethods.Items.Should().Contain(x => x.Issuers != null);
-        paymentMethods.Items.Should().Contain(x => x.Pricing != null && x.Pricing.Any(y => y.Fixed.Value > 0));
+        paymentMethods.Items.ShouldContain(x => x.Issuers != null);
+        paymentMethods.Items.ShouldContain(x => x.Pricing != null && x.Pricing.Any(y => y.Fixed.Value > 0));
     }
 
     [DefaultRetryTheory]
@@ -136,7 +136,7 @@ public class PaymentMethodTests : BaseMollieApiTestClass, IDisposable {
         var paymentMethods = await _paymentMethodClient.GetPaymentMethodListAsync(amount: amount);
 
         // Then: We should have multiple payment methods
-        paymentMethods.Count.Should().BeGreaterThan(0);
+        paymentMethods.Count.ShouldBeGreaterThan(0);
     }
 
     public void Dispose()

--- a/tests/Mollie.Tests.Integration/Api/PaymentTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/PaymentTests.cs
@@ -12,7 +12,7 @@ using Mollie.Api.Models.Payment.Response;
 using Mollie.Tests.Integration.Framework;
 using System.Collections.Generic;
 using System.Linq;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Models.Capture.Response;
 using Mollie.Api.Models.Customer.Response;
 using Mollie.Api.Models.List.Response;
@@ -22,6 +22,7 @@ using Mollie.Api.Models.Payment.Request.PaymentSpecificParameters;
 using Mollie.Api.Models.Payment.Response.PaymentSpecificParameters;
 using Mollie.Api.Models.Terminal.Response;
 using Xunit;
+using SortDirection = Mollie.Api.Models.SortDirection;
 
 namespace Mollie.Tests.Integration.Api;
 
@@ -46,9 +47,9 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<PaymentResponse> response = await _paymentClient.GetPaymentListAsync();
 
         // Then
-        response.Should().NotBeNull();
-        response.Items.Should().NotBeNull();
-        response.Items.Should().BeInDescendingOrder(x => x.CreatedAt);
+        response.ShouldNotBeNull();
+        response.Items.ShouldNotBeNull();
+        response.Items.Select(x => x.CreatedAt).ShouldBeInOrder(Shouldly.SortDirection.Descending);
     }
 
     [DefaultRetryFact]
@@ -58,9 +59,9 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<PaymentResponse> response = await _paymentClient.GetPaymentListAsync(sort: SortDirection.Desc);
 
         // Then
-        response.Should().NotBeNull();
-        response.Items.Should().NotBeNull();
-        response.Items.Should().BeInDescendingOrder(x => x.CreatedAt);
+        response.ShouldNotBeNull();
+        response.Items.ShouldNotBeNull();
+        response.Items.Select(x => x.CreatedAt).ShouldBeInOrder(Shouldly.SortDirection.Descending);
     }
 
     [DefaultRetryFact]
@@ -70,9 +71,9 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<PaymentResponse> response = await _paymentClient.GetPaymentListAsync(sort: SortDirection.Asc);
 
         // Then
-        response.Should().NotBeNull();
-        response.Items.Should().NotBeNull();
-        response.Items.Should().BeInAscendingOrder(x => x.CreatedAt);
+        response.ShouldNotBeNull();
+        response.Items.ShouldNotBeNull();
+        response.Items.Select(x => x.CreatedAt).ShouldBeInOrder(Shouldly.SortDirection.Ascending);
     }
 
     [DefaultRetryFact]
@@ -84,7 +85,7 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<PaymentResponse> response = await _paymentClient.GetPaymentListAsync(null, numberOfPayments);
 
         // Then
-        response.Items.Count.Should().BeLessOrEqualTo(numberOfPayments);
+        response.Items.Count.ShouldBeLessThanOrEqualTo(numberOfPayments);
     }
 
     [DefaultRetryFact]
@@ -100,10 +101,10 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         PaymentResponse result = await _paymentClient.CreatePaymentAsync(paymentRequest);
 
         // Then: Make sure we get a valid response
-        result.Should().NotBeNull();
-        result.Amount.Should().Be(paymentRequest.Amount);
-        result.Description.Should().Be(paymentRequest.Description);
-        result.RedirectUrl.Should().Be(paymentRequest.RedirectUrl);
+        result.ShouldNotBeNull();
+        result.Amount.ShouldBe(paymentRequest.Amount);
+        result.Description.ShouldBe(paymentRequest.Description);
+        result.RedirectUrl.ShouldBe(paymentRequest.RedirectUrl);
     }
 
     [DefaultRetryFact]
@@ -122,7 +123,7 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
             PaymentResponse secondAttempt = await _paymentClient.CreatePaymentAsync(paymentRequest);
 
             // Then: Make sure the responses have the same payment Id
-            firstAttempt.Id.Should().Be(secondAttempt.Id);
+            firstAttempt.Id.ShouldBe(secondAttempt.Id);
         }
     }
 
@@ -143,13 +144,13 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         PaymentResponse result = await _paymentClient.CreatePaymentAsync(paymentRequest);
 
         // Then: Make sure all requested parameters match the response parameter values
-        result.Should().NotBeNull();
-        result.Amount.Should().Be(paymentRequest.Amount);
-        result.Description.Should().Be(paymentRequest.Description);
-        result.RedirectUrl.Should().Be(paymentRequest.RedirectUrl);
-        result.Locale.Should().Be(paymentRequest.Locale);
-        result.WebhookUrl.Should().Be(paymentRequest.WebhookUrl);
-        IsJsonResultEqual(result.Metadata, paymentRequest.Metadata).Should().BeTrue();
+        result.ShouldNotBeNull();
+        result.Amount.ShouldBe(paymentRequest.Amount);
+        result.Description.ShouldBe(paymentRequest.Description);
+        result.RedirectUrl.ShouldBe(paymentRequest.RedirectUrl);
+        result.Locale.ShouldBe(paymentRequest.Locale);
+        result.WebhookUrl.ShouldBe(paymentRequest.WebhookUrl);
+        IsJsonResultEqual(result.Metadata, paymentRequest.Metadata).ShouldBeTrue();
     }
 
     [DefaultRetryFact]
@@ -170,8 +171,8 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         PaymentResponse updatedPayment = await _paymentClient.UpdatePaymentAsync(result.Id, paymentUpdateRequest);
 
         // Then: Make sure the payment is updated
-        updatedPayment.Description.Should().Be(paymentUpdateRequest.Description);
-        updatedPayment.Metadata.Should().Be(paymentUpdateRequest.Metadata);
+        updatedPayment.Description.ShouldBe(paymentUpdateRequest.Description);
+        updatedPayment.Metadata.ShouldBe(paymentUpdateRequest.Metadata);
     }
 
     [DefaultRetryFact]
@@ -188,11 +189,11 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         PaymentResponse result = await _paymentClient.CreatePaymentAsync(paymentRequest);
 
         // Then: Make sure we get a valid response
-        result.Should().NotBeNull();
-        result.Amount.Should().Be(paymentRequest.Amount);
-        result.Description.Should().Be(paymentRequest.Description);
-        result.RedirectUrl.Should().Be(paymentRequest.RedirectUrl);
-        result.Method.Should().Be(paymentRequest.Method);
+        result.ShouldNotBeNull();
+        result.Amount.ShouldBe(paymentRequest.Amount);
+        result.Description.ShouldBe(paymentRequest.Description);
+        result.RedirectUrl.ShouldBe(paymentRequest.RedirectUrl);
+        result.Method.ShouldBe(paymentRequest.Method);
     }
 
     [DefaultRetryFact]
@@ -213,11 +214,11 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         PaymentResponse result = await _paymentClient.CreatePaymentAsync(paymentRequest);
 
         // Then: Make sure we get a valid response
-        result.Should().NotBeNull();
-        result.Amount.Should().Be(paymentRequest.Amount);
-        result.Description.Should().Be(paymentRequest.Description);
-        result.RedirectUrl.Should().Be(paymentRequest.RedirectUrl);
-        result.Method.Should().BeNull();
+        result.ShouldNotBeNull();
+        result.Amount.ShouldBe(paymentRequest.Amount);
+        result.Description.ShouldBe(paymentRequest.Description);
+        result.RedirectUrl.ShouldBe(paymentRequest.RedirectUrl);
+        result.Method.ShouldBeNull();
     }
 
     [DefaultRetryTheory]
@@ -245,12 +246,12 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         PaymentResponse result = await _paymentClient.CreatePaymentAsync(paymentRequest);
 
         // Then: Make sure all requested parameters match the response parameter values
-        result.Should().NotBeNull();
-        result.Should().BeOfType(expectedResponseType);
-        result.Amount.Should().Be(paymentRequest.Amount);
-        result.Description.Should().Be(paymentRequest.Description);
-        result.RedirectUrl.Should().Be(paymentRequest.RedirectUrl);
-        result.Method.Should().Be(paymentRequest.Method);
+        result.ShouldNotBeNull();
+        result.ShouldBeOfType(expectedResponseType);
+        result.Amount.ShouldBe(paymentRequest.Amount);
+        result.Description.ShouldBe(paymentRequest.Description);
+        result.RedirectUrl.ShouldBe(paymentRequest.RedirectUrl);
+        result.Method.ShouldBe(paymentRequest.Method);
     }
 
     [DefaultRetryFact]
@@ -268,12 +269,12 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         PaymentResponse result = await _paymentClient.GetPaymentAsync(paymentResponse.Id);
 
         // Then
-        result.Should().NotBeNull();
-        result.Id.Should().Be(paymentResponse.Id);
-        result.Amount.Should().Be(paymentRequest.Amount);
-        result.Description.Should().Be(paymentRequest.Description);
-        result.RedirectUrl.Should().Be(paymentRequest.RedirectUrl);
-        result.Method.Should().Be(paymentRequest.Method);
+        result.ShouldNotBeNull();
+        result.Id.ShouldBe(paymentResponse.Id);
+        result.Amount.ShouldBe(paymentRequest.Amount);
+        result.Description.ShouldBe(paymentRequest.Description);
+        result.RedirectUrl.ShouldBe(paymentRequest.RedirectUrl);
+        result.Method.ShouldBe(paymentRequest.Method);
     }
 
     [DefaultRetryFact]
@@ -295,7 +296,7 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
             PaymentResponse result = await _paymentClient.GetPaymentAsync(paymentResponse.Id);
 
             // Then: Make sure the recurringtype parameter is entered
-            result.SequenceType.Should().Be(SequenceType.First);
+            result.SequenceType.ShouldBe(SequenceType.First);
         }
     }
 
@@ -314,7 +315,7 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         PaymentResponse result = await _paymentClient.CreatePaymentAsync(paymentRequest);
 
         // Then: Make sure we get the same json result as metadata
-        result.Metadata.Should().Be(metadata);
+        result.Metadata.ShouldBe(metadata);
     }
 
     [DefaultRetryFact]
@@ -332,7 +333,7 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         PaymentResponse result = await _paymentClient.CreatePaymentAsync(paymentRequest);
 
         // Then: Make sure we get the same json result as metadata
-        IsJsonResultEqual(result.Metadata, json).Should().BeTrue();
+        IsJsonResultEqual(result.Metadata, json).ShouldBeTrue();
     }
 
     [DefaultRetryFact]
@@ -355,9 +356,9 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         CustomMetadataClass metadataResponse = result.GetMetadata<CustomMetadataClass>();
 
         // Then: Make sure we get the same json result as metadata
-        metadataResponse.Should().NotBeNull();
-        metadataResponse.OrderId.Should().Be(metadataRequest.OrderId);
-        metadataResponse.Description.Should().Be(metadataRequest.Description);
+        metadataResponse.ShouldNotBeNull();
+        metadataResponse.OrderId.ShouldBe(metadataRequest.OrderId);
+        metadataResponse.Description.ShouldBe(metadataRequest.Description);
     }
 
     [DefaultRetryFact]
@@ -404,9 +405,9 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         PaymentResponse result = await _paymentClient.CreatePaymentAsync(paymentRequest);
 
         // Assert
-        result.Lines.Should().BeEquivalentTo(paymentRequest.Lines);
-        result.BillingAddress.Should().BeEquivalentTo(paymentRequest.BillingAddress);
-        result.ShippingAddress.Should().BeEquivalentTo(paymentRequest.ShippingAddress);
+        result.Lines.ShouldBeEquivalentTo(paymentRequest.Lines);
+        result.BillingAddress.ShouldBeEquivalentTo(paymentRequest.BillingAddress);
+        result.ShippingAddress.ShouldBeEquivalentTo(paymentRequest.ShippingAddress);
     }
 
     [DefaultRetryFact]
@@ -428,9 +429,9 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
             PaymentResponse result = await _paymentClient.CreatePaymentAsync(paymentRequest);
 
             // Then: Make sure we get the mandate id back in the details
-            result.MandateId.Should().Be(validMandate.Id);
-            result.Links.Mandate!.Href.Should().EndWith(validMandate.Id);
-            result.Links.Customer!.Href.Should().EndWith(customer.Id);
+            result.MandateId.ShouldBe(validMandate.Id);
+            result.Links.Mandate!.Href.ShouldEndWith(validMandate.Id);
+            result.Links.Customer!.Href.ShouldEndWith(customer.Id);
         }
     }
 
@@ -449,10 +450,10 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         PaymentResponse result = await paymentClient.CreatePaymentAsync(paymentRequest);
 
         // Then: It should still work in the same way
-        result.Should().NotBeNull();
-        result.Amount.Should().Be(paymentRequest.Amount);
-        result.Description.Should().Be(paymentRequest.Description);
-        result.RedirectUrl.Should().Be(paymentRequest.RedirectUrl);
+        result.ShouldNotBeNull();
+        result.Amount.ShouldBe(paymentRequest.Amount);
+        result.Description.ShouldBe(paymentRequest.Description);
+        result.RedirectUrl.ShouldBe(paymentRequest.RedirectUrl);
     }
 
     [DefaultRetryFact]
@@ -470,11 +471,11 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         PaymentResponse result = await _paymentClient.GetPaymentAsync(paymentResponse.Id);
 
         // Then
-        result.Should().NotBeNull();
-        result.Id.Should().Be(paymentResponse.Id);
-        result.Amount.Should().Be(paymentRequest.Amount);
-        result.Description.Should().Be(paymentRequest.Description);
-        result.RedirectUrl.Should().Be(paymentRequest.RedirectUrl);
+        result.ShouldNotBeNull();
+        result.Id.ShouldBe(paymentResponse.Id);
+        result.Amount.ShouldBe(paymentRequest.Amount);
+        result.Description.ShouldBe(paymentRequest.Description);
+        result.RedirectUrl.ShouldBe(paymentRequest.RedirectUrl);
     }
 
     [DefaultRetryFact]
@@ -497,13 +498,13 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         decimal resultAmount = result.Amount; // Implicit cast
 
         // Then
-        result.Should().NotBeNull();
-        result.Id.Should().Be(paymentResponse.Id);
-        result.Amount.Should().Be(paymentRequest.Amount);
-        result.Description.Should().Be(paymentRequest.Description);
-        result.RedirectUrl.Should().Be(paymentRequest.RedirectUrl);
-        resultAmount.Should().Be(responseAmount);
-        resultAmount.Should().Be(initialAmount);
+        result.ShouldNotBeNull();
+        result.Id.ShouldBe(paymentResponse.Id);
+        result.Amount.ShouldBe(paymentRequest.Amount);
+        result.Description.ShouldBe(paymentRequest.Description);
+        result.RedirectUrl.ShouldBe(paymentRequest.RedirectUrl);
+        resultAmount.ShouldBe(responseAmount);
+        resultAmount.ShouldBe(initialAmount);
     }
 
     [DefaultRetryFact]
@@ -524,19 +525,19 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
             PaymentResponse response = await _paymentClient.CreatePaymentAsync(paymentRequest);
 
             // Then
-            response.Should().NotBeNull();
-            response.Amount.Should().Be(paymentRequest.Amount);
-            response.Description.Should().Be(paymentRequest.Description);
-            response.RedirectUrl.Should().Be(paymentRequest.RedirectUrl);
-            response.Should().BeOfType<PointOfSalePaymentResponse>();
+            response.ShouldNotBeNull();
+            response.Amount.ShouldBe(paymentRequest.Amount);
+            response.Description.ShouldBe(paymentRequest.Description);
+            response.RedirectUrl.ShouldBe(paymentRequest.RedirectUrl);
+            response.ShouldBeOfType<PointOfSalePaymentResponse>();
             PointOfSalePaymentResponse posResponse = (PointOfSalePaymentResponse)response;
-            posResponse.Details.TerminalId.Should().Be(paymentRequest.TerminalId);
-            posResponse.Details.CardNumber.Should().BeNull();
-            posResponse.Details.CardFingerprint.Should().BeNull();
-            posResponse.Details.CardAudience.Should().BeNull();
-            posResponse.Details.CardLabel.Should().BeNull();
-            posResponse.Details.CardCountryCode.Should().BeNull();
-            posResponse.Method.Should().Be(PaymentMethod.PointOfSale);
+            posResponse.Details.TerminalId.ShouldBe(paymentRequest.TerminalId);
+            posResponse.Details.CardNumber.ShouldBeNull();
+            posResponse.Details.CardFingerprint.ShouldBeNull();
+            posResponse.Details.CardAudience.ShouldBeNull();
+            posResponse.Details.CardLabel.ShouldBeNull();
+            posResponse.Details.CardCountryCode.ShouldBeNull();
+            posResponse.Method.ShouldBe(PaymentMethod.PointOfSale);
         }
     }
 
@@ -561,10 +562,10 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         });
 
         // Then
-        captureResponse.Should().NotBeNull();
-        paymentResponse.Status.Should().Be(PaymentStatus.Authorized);
-        paymentRequest.CaptureMode.Should().Be(CaptureMode.Manual);
-        paymentResponse.CaptureBefore.Should().NotBeNull();
+        captureResponse.ShouldNotBeNull();
+        paymentResponse.Status.ShouldBe(PaymentStatus.Authorized);
+        paymentRequest.CaptureMode.ShouldBe(CaptureMode.Manual);
+        paymentResponse.CaptureBefore.ShouldNotBeNull();
     }
 
     [DefaultRetryFact]
@@ -582,7 +583,7 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         PaymentResponse paymentResponse = await _paymentClient.CreatePaymentAsync(paymentRequest);
 
         // Then
-        paymentResponse.CaptureDelay.Should().Be(paymentRequest.CaptureDelay);
+        paymentResponse.CaptureDelay.ShouldBe(paymentRequest.CaptureDelay);
     }
 
     private async Task<MandateResponse> GetFirstValidMandate() {

--- a/tests/Mollie.Tests.Integration/Api/ProfileTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/ProfileTests.cs
@@ -31,9 +31,9 @@ public class ProfileTests : BaseMollieApiTestClass, IDisposable {
 
         // Then: Make sure we get a valid response
         profileResponse.ShouldNotBeNull();
-        profileResponse.Id.ShouldBeNullOrEmpty();
-        profileResponse.Email.ShouldBeNullOrEmpty();
-        profileResponse.Status.ShouldBeNullOrEmpty();
+        profileResponse.Id.ShouldNotBeNullOrEmpty();
+        profileResponse.Email.ShouldNotBeNullOrEmpty();
+        profileResponse.Status.ShouldNotBeNullOrEmpty();
     }
 
     [DefaultRetryFact]

--- a/tests/Mollie.Tests.Integration/Api/ProfileTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/ProfileTests.cs
@@ -6,7 +6,7 @@ using Mollie.Api.Models.Profile.Response;
 using Mollie.Tests.Integration.Framework;
 using System.Linq;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Models;
 using Mollie.Api.Models.List.Response;
@@ -30,10 +30,10 @@ public class ProfileTests : BaseMollieApiTestClass, IDisposable {
         ProfileResponse profileResponse = await _profileClient.GetCurrentProfileAsync();
 
         // Then: Make sure we get a valid response
-        profileResponse.Should().NotBeNull();
-        profileResponse.Id.Should().NotBeNullOrEmpty();
-        profileResponse.Email.Should().NotBeNullOrEmpty();
-        profileResponse.Status.Should().NotBeNullOrEmpty();
+        profileResponse.ShouldNotBeNull();
+        profileResponse.Id.ShouldBeNullOrEmpty();
+        profileResponse.Email.ShouldBeNullOrEmpty();
+        profileResponse.Status.ShouldBeNullOrEmpty();
     }
 
     [DefaultRetryFact]
@@ -44,8 +44,8 @@ public class ProfileTests : BaseMollieApiTestClass, IDisposable {
         PaymentMethodResponse paymentMethodResponse = await _profileClient.EnablePaymentMethodAsync(PaymentMethod.CreditCard);
 
         // Then: Make sure a payment method is returned
-        paymentMethodResponse.Should().NotBeNull();
-        paymentMethodResponse.Id.Should().Be(PaymentMethod.CreditCard);
+        paymentMethodResponse.ShouldNotBeNull();
+        paymentMethodResponse.Id.ShouldBe(PaymentMethod.CreditCard);
     }
 
     [DefaultRetryFact(Skip = "We can only test this in debug mode, because we need to retrieve a oauth access token to test this method")]
@@ -60,8 +60,8 @@ public class ProfileTests : BaseMollieApiTestClass, IDisposable {
             PaymentMethodResponse paymentMethodResponse = await profileClient.EnablePaymentMethodAsync(profileToTestWith.Id, PaymentMethod.Ideal);
 
             // Then: Make sure a payment method is returned
-            paymentMethodResponse.Should().NotBeNull();
-            paymentMethodResponse.Id.Should().NotBeNullOrEmpty();
+            paymentMethodResponse.ShouldNotBeNull();
+            paymentMethodResponse.Id.ShouldBeNullOrEmpty();
         }
     }
 
@@ -82,7 +82,7 @@ public class ProfileTests : BaseMollieApiTestClass, IDisposable {
         ProfileResponse profileResponse = await profileClient.CreateProfileAsync(profileRequest);
 
         // Then: Make sure the profile that is created matched the profile request
-        profileResponse.Should().NotBeNull();
+        profileResponse.ShouldNotBeNull();
     }
 
     [DefaultRetryFact(Skip = "Don't disable payment methods, other tests might break")]

--- a/tests/Mollie.Tests.Integration/Api/RefundTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/RefundTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Models;
@@ -41,7 +41,7 @@ public class RefundTests : BaseMollieApiTestClass, IDisposable {
         RefundResponse refundResponse = await _refundClient.CreatePaymentRefundAsync(payment.Id, refundRequest);
 
         // Then
-        refundResponse.Should().NotBeNull();
+        refundResponse.ShouldNotBeNull();
     }
 
     [DefaultRetryFact(Skip = "We can only test this in debug mode, because we actually have to use the PaymentUrl to make the payment, since Mollie can only refund payments that have been paid")]
@@ -60,7 +60,7 @@ public class RefundTests : BaseMollieApiTestClass, IDisposable {
         RefundResponse refundResponse = await _refundClient.CreatePaymentRefundAsync(payment.Id, refundRequest);
 
         // Then
-        refundResponse.Amount.Should().Be(refundRequest.Amount);
+        refundResponse.Amount.ShouldBe(refundRequest.Amount);
     }
 
     [DefaultRetryFact(Skip = "We can only test this in debug mode, because we actually have to use the PaymentUrl to make the payment, since Mollie can only refund payments that have been paid")]
@@ -80,9 +80,9 @@ public class RefundTests : BaseMollieApiTestClass, IDisposable {
         RefundResponse result = await _refundClient.GetPaymentRefundAsync(payment.Id, refundResponse.Id);
 
         // Then
-        result.Should().NotBeNull();
-        result.Id.Should().Be(refundResponse.Id);
-        refundResponse.Amount.Should().Be(refundRequest.Amount);
+        result.ShouldNotBeNull();
+        result.Id.ShouldBe(refundResponse.Id);
+        refundResponse.Amount.ShouldBe(refundRequest.Amount);
     }
 
     [DefaultRetryFact]
@@ -94,8 +94,8 @@ public class RefundTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<RefundResponse> refundList = await _refundClient.GetPaymentRefundListAsync(payment.Id);
 
         // Then
-        refundList.Should().NotBeNull();
-        refundList.Items.Should().NotBeNull();
+        refundList.ShouldNotBeNull();
+        refundList.Items.ShouldNotBeNull();
     }
 
     [DefaultRetryFact(Skip = "We can only test this in debug mode, because we actually have to use the PaymentUrl to make the payment, since Mollie can only refund payments that have been paid")]
@@ -117,7 +117,7 @@ public class RefundTests : BaseMollieApiTestClass, IDisposable {
         RefundResponse refundResponse = await _refundClient.CreatePaymentRefundAsync(payment.Id, refundRequest);
 
         // Then: Make sure we get the same json result as metadata
-        refundResponse.Metadata.Should().Be(metadata);
+        refundResponse.Metadata.ShouldBe(metadata);
     }
 
     private async Task<PaymentResponse> CreatePayment(string amount = "100.00") {

--- a/tests/Mollie.Tests.Integration/Api/ShipmentTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/ShipmentTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Models.List.Response;
@@ -26,8 +26,8 @@ public class ShipmentTests : BaseMollieApiTestClass, IDisposable {
         ShipmentResponse result = await _shipmentClient.CreateShipmentAsync(validOrderId, shipmentRequest);
 
         // Then: Make sure we get a valid shipment response
-        result.Should().NotBeNull();
-        result.CreatedAt.Should().BeAfter(DateTime.Now);
+        result.ShouldNotBeNull();
+        result.CreatedAt.ShouldBeGreaterThan(DateTime.Now);
     }
 
     [DefaultRetryFact(Skip = "For manual testing only")]
@@ -35,8 +35,8 @@ public class ShipmentTests : BaseMollieApiTestClass, IDisposable {
         string validOrderId = "XXXXX";
         ListResponse<ShipmentResponse> result = await _shipmentClient.GetShipmentListAsync(validOrderId);
 
-        result.Should().NotBeNull();
-        result.Count.Should().BeGreaterThan(0);
+        result.ShouldNotBeNull();
+        result.Count.ShouldBeGreaterThan(0);
     }
 
     private ShipmentRequest CreateShipmentWithOnlyRequiredFields() {

--- a/tests/Mollie.Tests.Integration/Api/SubscriptionTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/SubscriptionTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Models;
@@ -34,8 +34,8 @@ public class SubscriptionTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<SubscriptionResponse> response = await _subscriptionClient.GetSubscriptionListAsync(customerId);
 
         // Then
-        response.Should().NotBeNull();
-        response.Items.Should().NotBeNull();
+        response.ShouldNotBeNull();
+        response.Items.ShouldNotBeNull();
     }
 
     [DefaultRetryFact]
@@ -46,8 +46,8 @@ public class SubscriptionTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<SubscriptionResponse> response = await _subscriptionClient.GetAllSubscriptionList();
 
         // Then
-        response.Should().NotBeNull();
-        response.Items.Should().NotBeNull();
+        response.ShouldNotBeNull();
+        response.Items.ShouldNotBeNull();
     }
 
     [DefaultRetryFact]
@@ -60,7 +60,7 @@ public class SubscriptionTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<SubscriptionResponse> response = await _subscriptionClient.GetSubscriptionListAsync(customerId, null, numberOfSubscriptions);
 
         // Then
-        response.Items.Count.Should().BeLessOrEqualTo(numberOfSubscriptions);
+        response.Items.Count.ShouldBeLessThanOrEqualTo(numberOfSubscriptions);
     }
 
     [DefaultRetryFact]
@@ -80,12 +80,12 @@ public class SubscriptionTests : BaseMollieApiTestClass, IDisposable {
         SubscriptionResponse subscriptionResponse = await _subscriptionClient.CreateSubscriptionAsync(customerId, subscriptionRequest);
 
         // Then
-        subscriptionResponse.Amount.Should().Be(subscriptionRequest.Amount);
-        subscriptionResponse.Times.Should().Be(subscriptionRequest.Times);
-        subscriptionResponse.Interval.Should().Be(subscriptionRequest.Interval);
-        subscriptionResponse.Description.Should().Be(subscriptionRequest.Description);
-        subscriptionResponse.WebhookUrl.Should().Be(subscriptionRequest.WebhookUrl);
-        subscriptionResponse.StartDate.Should().Be(subscriptionRequest.StartDate.Value.Date);
+        subscriptionResponse.Amount.ShouldBe(subscriptionRequest.Amount);
+        subscriptionResponse.Times.ShouldBe(subscriptionRequest.Times);
+        subscriptionResponse.Interval.ShouldBe(subscriptionRequest.Interval);
+        subscriptionResponse.Description.ShouldBe(subscriptionRequest.Description);
+        subscriptionResponse.WebhookUrl.ShouldBe(subscriptionRequest.WebhookUrl);
+        subscriptionResponse.StartDate.ShouldBe(subscriptionRequest.StartDate.Value.Date);
     }
 
     [DefaultRetryFact]
@@ -102,7 +102,7 @@ public class SubscriptionTests : BaseMollieApiTestClass, IDisposable {
             SubscriptionResponse response = await _subscriptionClient.UpdateSubscriptionAsync(customerId, activeSubscription.Id, request);
 
             // Then
-            response.Description.Should().Be(request.Description);
+            response.Description.ShouldBe(request.Description);
         }
     }
 
@@ -120,7 +120,7 @@ public class SubscriptionTests : BaseMollieApiTestClass, IDisposable {
             SubscriptionResponse cancelledSubscription = await _subscriptionClient.GetSubscriptionAsync(customerId, subscriptionToCancel.Id);
 
             // Then
-            cancelledSubscription.Status.Should().Be(SubscriptionStatus.Canceled);
+            cancelledSubscription.Status.ShouldBe(SubscriptionStatus.Canceled);
         }
     }
 
@@ -144,7 +144,7 @@ public class SubscriptionTests : BaseMollieApiTestClass, IDisposable {
             SubscriptionResponse result = await _subscriptionClient.CreateSubscriptionAsync(customerId, subscriptionRequest);
 
             // Then: Make sure we get the same json result as metadata
-            IsJsonResultEqual(result.Metadata, json).Should().BeTrue();
+            IsJsonResultEqual(result.Metadata, json).ShouldBeTrue();
         }
     }
 

--- a/tests/Mollie.Tests.Integration/Api/TerminalTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/TerminalTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Models.List.Response;
@@ -25,8 +25,8 @@ public class TerminalTests : BaseMollieApiTestClass, IDisposable {
         ListResponse<TerminalResponse> response = await _terminalClient.GetTerminalListAsync();
 
         // Then
-        response.Should().NotBeNull();
-        response.Items.Should().NotBeNull();
+        response.ShouldNotBeNull();
+        response.Items.ShouldNotBeNull();
     }
 
     [DefaultRetryFact(Skip = "Not implemented by Mollie yet")]
@@ -40,8 +40,8 @@ public class TerminalTests : BaseMollieApiTestClass, IDisposable {
             TerminalResponse response = await _terminalClient.GetTerminalAsync(firstTerminal.Id);
 
             // Then
-            response.Should().NotBeNull();
-            response.Id.Should().Be(firstTerminal.Id);
+            response.ShouldNotBeNull();
+            response.Id.ShouldBe(firstTerminal.Id);
         }
     }
 

--- a/tests/Mollie.Tests.Integration/Mollie.Tests.Integration.csproj
+++ b/tests/Mollie.Tests.Integration/Mollie.Tests.Integration.csproj
@@ -23,7 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
@@ -31,6 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xRetry" Version="1.9.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/tests/Mollie.Tests.Unit/Client/BalanceClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/BalanceClientTests.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Mollie.Api.Client;
 using Mollie.Api.Models;
 using Mollie.Api.Models.Balance.Response;
@@ -11,6 +10,7 @@ using Mollie.Api.Models.Balance.Response.BalanceReport.Specific.StatusBalance;
 using Mollie.Api.Models.Balance.Response.BalanceReport.Specific.TransactionCategories;
 using Mollie.Api.Models.Balance.Response.BalanceTransaction.Specific;
 using RichardSzalay.MockHttp;
+using Shouldly;
 using Xunit;
 
 namespace Mollie.Tests.Unit.Client {
@@ -30,28 +30,28 @@ namespace Mollie.Tests.Unit.Client {
 
           // Then: Response should be parsed
           mockHttp.VerifyNoOutstandingExpectation();
-          balanceResponse.Should().NotBeNull();
-          balanceResponse.Id.Should().Be(getBalanceResponseFactory.BalanceId);
-          balanceResponse.CreatedAt.ToUniversalTime().Should().Be(getBalanceResponseFactory.CreatedAt);
-          balanceResponse.TransferThreshold.Currency.Should().Be(getBalanceResponseFactory.TransferThreshold.Currency);
-          balanceResponse.Currency.Should().Be(getBalanceResponseFactory.Currency);
-          balanceResponse.Status.Should().Be(getBalanceResponseFactory.Status);
-          balanceResponse.AvailableAmount.Currency.Should().Be(getBalanceResponseFactory.AvailableAmount.Currency);
-          balanceResponse.AvailableAmount.Value.Should().Be(getBalanceResponseFactory.AvailableAmount.Value);
-          balanceResponse.PendingAmount.Value.Should().Be(getBalanceResponseFactory.PendingAmount.Value);
-          balanceResponse.PendingAmount.Currency.Should().Be(getBalanceResponseFactory.PendingAmount.Currency);
-          balanceResponse.TransferFrequency.Should().Be(getBalanceResponseFactory.TransferFrequency);
-          balanceResponse.TransferReference.Should().Be(getBalanceResponseFactory.TransferReference);
-          balanceResponse.TransferThreshold.Currency.Should().Be(getBalanceResponseFactory.TransferThreshold.Currency);
-          balanceResponse.TransferThreshold.Value.Should().Be(getBalanceResponseFactory.TransferThreshold.Value);
-          balanceResponse.TransferDestination.Type.Should().Be(getBalanceResponseFactory.TransferDestination.Type);
-          balanceResponse.TransferDestination.BankAccount.Should().Be(getBalanceResponseFactory.TransferDestination.BankAccount);
-          balanceResponse.TransferDestination.BeneficiaryName.Should().Be(getBalanceResponseFactory.TransferDestination.BeneficiaryName);
-          balanceResponse.Links.Should().NotBeNull();
-          balanceResponse.Links.Self.Href.Should().Be($"https://api.mollie.com/v2/balances/{getBalanceResponseFactory.BalanceId}");
-          balanceResponse.Links.Self.Type.Should().Be("application/hal+json");
-          balanceResponse.Links.Documentation.Href.Should().Be($"https://docs.mollie.com/reference/v2/balances-api/get-balance");
-          balanceResponse.Links.Documentation.Type.Should().Be("text/html");
+          balanceResponse.ShouldNotBeNull();
+          balanceResponse.Id.ShouldBe(getBalanceResponseFactory.BalanceId);
+          balanceResponse.CreatedAt.ToUniversalTime().ShouldBe(getBalanceResponseFactory.CreatedAt);
+          balanceResponse.TransferThreshold.Currency.ShouldBe(getBalanceResponseFactory.TransferThreshold.Currency);
+          balanceResponse.Currency.ShouldBe(getBalanceResponseFactory.Currency);
+          balanceResponse.Status.ShouldBe(getBalanceResponseFactory.Status);
+          balanceResponse.AvailableAmount.Currency.ShouldBe(getBalanceResponseFactory.AvailableAmount.Currency);
+          balanceResponse.AvailableAmount.Value.ShouldBe(getBalanceResponseFactory.AvailableAmount.Value);
+          balanceResponse.PendingAmount.Value.ShouldBe(getBalanceResponseFactory.PendingAmount.Value);
+          balanceResponse.PendingAmount.Currency.ShouldBe(getBalanceResponseFactory.PendingAmount.Currency);
+          balanceResponse.TransferFrequency.ShouldBe(getBalanceResponseFactory.TransferFrequency);
+          balanceResponse.TransferReference.ShouldBe(getBalanceResponseFactory.TransferReference);
+          balanceResponse.TransferThreshold.Currency.ShouldBe(getBalanceResponseFactory.TransferThreshold.Currency);
+          balanceResponse.TransferThreshold.Value.ShouldBe(getBalanceResponseFactory.TransferThreshold.Value);
+          balanceResponse.TransferDestination.Type.ShouldBe(getBalanceResponseFactory.TransferDestination.Type);
+          balanceResponse.TransferDestination.BankAccount.ShouldBe(getBalanceResponseFactory.TransferDestination.BankAccount);
+          balanceResponse.TransferDestination.BeneficiaryName.ShouldBe(getBalanceResponseFactory.TransferDestination.BeneficiaryName);
+          balanceResponse.Links.ShouldNotBeNull();
+          balanceResponse.Links.Self.Href.ShouldBe($"https://api.mollie.com/v2/balances/{getBalanceResponseFactory.BalanceId}");
+          balanceResponse.Links.Self.Type.ShouldBe("application/hal+json");
+          balanceResponse.Links.Documentation.Href.ShouldBe($"https://docs.mollie.com/reference/v2/balances-api/get-balance");
+          balanceResponse.Links.Documentation.Type.ShouldBe("text/html");
       }
 
       [Theory]
@@ -68,7 +68,7 @@ namespace Mollie.Tests.Unit.Client {
           var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await balanceClient.GetBalanceAsync(balanceId));
 
           // Then
-          exception.Message.Should().Be("Required URL argument 'balanceId' is null or empty");
+          exception.Message.ShouldBe("Required URL argument 'balanceId' is null or empty");
       }
 
       [Fact]
@@ -86,24 +86,24 @@ namespace Mollie.Tests.Unit.Client {
 
           // Then: Response should be parsed
           mockHttp.VerifyNoOutstandingExpectation();
-          balanceResponse.Should().NotBeNull();
-          balanceResponse.Should().NotBeNull();
-          balanceResponse.Id.Should().Be(getBalanceResponseFactory.BalanceId);
-          balanceResponse.CreatedAt.ToUniversalTime().Should().Be(getBalanceResponseFactory.CreatedAt);
-          balanceResponse.TransferThreshold.Currency.Should().Be(getBalanceResponseFactory.TransferThreshold.Currency);
-          balanceResponse.Currency.Should().Be(getBalanceResponseFactory.Currency);
-          balanceResponse.Status.Should().Be(getBalanceResponseFactory.Status);
-          balanceResponse.AvailableAmount.Currency.Should().Be(getBalanceResponseFactory.AvailableAmount.Currency);
-          balanceResponse.AvailableAmount.Value.Should().Be(getBalanceResponseFactory.AvailableAmount.Value);
-          balanceResponse.PendingAmount.Value.Should().Be(getBalanceResponseFactory.PendingAmount.Value);
-          balanceResponse.PendingAmount.Currency.Should().Be(getBalanceResponseFactory.PendingAmount.Currency);
-          balanceResponse.TransferFrequency.Should().Be(getBalanceResponseFactory.TransferFrequency);
-          balanceResponse.TransferReference.Should().Be(getBalanceResponseFactory.TransferReference);
-          balanceResponse.TransferThreshold.Currency.Should().Be(getBalanceResponseFactory.TransferThreshold.Currency);
-          balanceResponse.TransferThreshold.Value.Should().Be(getBalanceResponseFactory.TransferThreshold.Value);
-          balanceResponse.TransferDestination.Type.Should().Be(getBalanceResponseFactory.TransferDestination.Type);
-          balanceResponse.TransferDestination.BankAccount.Should().Be(getBalanceResponseFactory.TransferDestination.BankAccount);
-          balanceResponse.TransferDestination.BeneficiaryName.Should().Be(getBalanceResponseFactory.TransferDestination.BeneficiaryName);
+          balanceResponse.ShouldNotBeNull();
+          balanceResponse.ShouldNotBeNull();
+          balanceResponse.Id.ShouldBe(getBalanceResponseFactory.BalanceId);
+          balanceResponse.CreatedAt.ToUniversalTime().ShouldBe(getBalanceResponseFactory.CreatedAt);
+          balanceResponse.TransferThreshold.Currency.ShouldBe(getBalanceResponseFactory.TransferThreshold.Currency);
+          balanceResponse.Currency.ShouldBe(getBalanceResponseFactory.Currency);
+          balanceResponse.Status.ShouldBe(getBalanceResponseFactory.Status);
+          balanceResponse.AvailableAmount.Currency.ShouldBe(getBalanceResponseFactory.AvailableAmount.Currency);
+          balanceResponse.AvailableAmount.Value.ShouldBe(getBalanceResponseFactory.AvailableAmount.Value);
+          balanceResponse.PendingAmount.Value.ShouldBe(getBalanceResponseFactory.PendingAmount.Value);
+          balanceResponse.PendingAmount.Currency.ShouldBe(getBalanceResponseFactory.PendingAmount.Currency);
+          balanceResponse.TransferFrequency.ShouldBe(getBalanceResponseFactory.TransferFrequency);
+          balanceResponse.TransferReference.ShouldBe(getBalanceResponseFactory.TransferReference);
+          balanceResponse.TransferThreshold.Currency.ShouldBe(getBalanceResponseFactory.TransferThreshold.Currency);
+          balanceResponse.TransferThreshold.Value.ShouldBe(getBalanceResponseFactory.TransferThreshold.Value);
+          balanceResponse.TransferDestination.Type.ShouldBe(getBalanceResponseFactory.TransferDestination.Type);
+          balanceResponse.TransferDestination.BankAccount.ShouldBe(getBalanceResponseFactory.TransferDestination.BankAccount);
+          balanceResponse.TransferDestination.BeneficiaryName.ShouldBe(getBalanceResponseFactory.TransferDestination.BeneficiaryName);
       }
 
       [Fact]
@@ -119,9 +119,9 @@ namespace Mollie.Tests.Unit.Client {
 
           // Then: Response should be parsed
           mockHttp.VerifyNoOutstandingExpectation();
-          balances.Should().NotBeNull();
-          balances.Count.Should().Be(2);
-          balances.Items.Should().HaveCount(2);
+          balances.ShouldNotBeNull();
+          balances.Count.ShouldBe(2);
+          balances.Items.Count.ShouldBe(2);
       }
 
       [Fact]
@@ -143,24 +143,24 @@ namespace Mollie.Tests.Unit.Client {
 
           // Then: Response should be parsed
           mockHttp.VerifyNoOutstandingExpectation();
-          balanceReport.Should().NotBeNull();
-          balanceReport.Should().BeOfType<TransactionCategoriesReportResponse>();
+          balanceReport.ShouldNotBeNull();
+          balanceReport.ShouldBeOfType<TransactionCategoriesReportResponse>();
           var specificBalanceReport = (TransactionCategoriesReportResponse)balanceReport;
-          specificBalanceReport.Grouping.Should().Be(grouping);
-          specificBalanceReport.BalanceId.Should().Be(balanceId);
-          specificBalanceReport.Resource.Should().Be("balance-report");
-          specificBalanceReport.From.Should().Be(from);
-          specificBalanceReport.Until.Should().Be(until);
-          specificBalanceReport.Totals.Should().NotBeNull();
-          specificBalanceReport.Totals.Open.Pending.Amount.Value.Should().Be("5.30");
-          specificBalanceReport.Totals.Open.Pending.Amount.Currency.Should().Be("EUR");
-          specificBalanceReport.Totals.Open.Available.Amount.Value.Should().Be("0.11");
-          specificBalanceReport.Totals.Open.Available.Amount.Currency.Should().Be("EUR");
+          specificBalanceReport.Grouping.ShouldBe(grouping);
+          specificBalanceReport.BalanceId.ShouldBe(balanceId);
+          specificBalanceReport.Resource.ShouldBe("balance-report");
+          specificBalanceReport.From.ShouldBe(from);
+          specificBalanceReport.Until.ShouldBe(until);
+          specificBalanceReport.Totals.ShouldNotBeNull();
+          specificBalanceReport.Totals.Open.Pending.Amount.Value.ShouldBe("5.30");
+          specificBalanceReport.Totals.Open.Pending.Amount.Currency.ShouldBe("EUR");
+          specificBalanceReport.Totals.Open.Available.Amount.Value.ShouldBe("0.11");
+          specificBalanceReport.Totals.Open.Available.Amount.Currency.ShouldBe("EUR");
           var childSubTotals = specificBalanceReport.Totals.Payments.Pending.Subtotals.First();
-          childSubTotals.TransactionType.Should().Be("payment");
-          childSubTotals.Count.Should().Be(36);
+          childSubTotals.TransactionType.ShouldBe("payment");
+          childSubTotals.Count.ShouldBe(36);
           var childChildSubTotals = childSubTotals.Subtotals.First();
-          childChildSubTotals.Method.Should().Be("ideal");
+          childChildSubTotals.Method.ShouldBe("ideal");
       }
 
       [Theory]
@@ -179,7 +179,7 @@ namespace Mollie.Tests.Unit.Client {
           var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await balanceClient.GetBalanceReportAsync(balanceId, from, until));
 
           // Then
-          exception.Message.Should().Be("Required URL argument 'balanceId' is null or empty");
+          exception.Message.ShouldBe("Required URL argument 'balanceId' is null or empty");
       }
 
       [Fact]
@@ -201,23 +201,23 @@ namespace Mollie.Tests.Unit.Client {
 
           // Then: Response should be parsed
           mockHttp.VerifyNoOutstandingExpectation();
-          balanceReport.Should().NotBeNull();
-          balanceReport.Should().BeOfType<StatusBalanceReportResponse>();
+          balanceReport.ShouldNotBeNull();
+          balanceReport.ShouldBeOfType<StatusBalanceReportResponse>();
           var specificBalanceReport = (StatusBalanceReportResponse)balanceReport;
-          specificBalanceReport.Grouping.Should().Be(grouping);
-          specificBalanceReport.BalanceId.Should().Be(balanceId);
-          specificBalanceReport.Resource.Should().Be("balance-report");
-          specificBalanceReport.From.Should().Be(from);
-          specificBalanceReport.Until.Should().Be(until);
-          specificBalanceReport.Totals.Should().NotBeNull();
-          specificBalanceReport.Totals.PendingBalance.Open.Amount.Value.Should().Be("5.30");
-          specificBalanceReport.Totals.PendingBalance.Open.Amount.Currency.Should().Be(Currency.EUR);
-          specificBalanceReport.Totals.AvailableBalance.MovedFromPending.Amount.Value.Should().Be("3.38");
-          specificBalanceReport.Totals.AvailableBalance.MovedFromPending.Amount.Currency.Should().Be(Currency.EUR);
+          specificBalanceReport.Grouping.ShouldBe(grouping);
+          specificBalanceReport.BalanceId.ShouldBe(balanceId);
+          specificBalanceReport.Resource.ShouldBe("balance-report");
+          specificBalanceReport.From.ShouldBe(from);
+          specificBalanceReport.Until.ShouldBe(until);
+          specificBalanceReport.Totals.ShouldNotBeNull();
+          specificBalanceReport.Totals.PendingBalance.Open.Amount.Value.ShouldBe("5.30");
+          specificBalanceReport.Totals.PendingBalance.Open.Amount.Currency.ShouldBe(Currency.EUR);
+          specificBalanceReport.Totals.AvailableBalance.MovedFromPending.Amount.Value.ShouldBe("3.38");
+          specificBalanceReport.Totals.AvailableBalance.MovedFromPending.Amount.Currency.ShouldBe(Currency.EUR);
           var childSubTotals = specificBalanceReport.Totals.AvailableBalance.MovedFromPending.Subtotals.First();
-          childSubTotals.TransactionType.Should().Be("payment");
+          childSubTotals.TransactionType.ShouldBe("payment");
           var childChildSubtotals = childSubTotals.Subtotals.First();
-          childChildSubtotals.Method.Should().Be("ideal");
+          childChildSubtotals.Method.ShouldBe("ideal");
       }
 
       [Fact]
@@ -234,20 +234,20 @@ namespace Mollie.Tests.Unit.Client {
 
           // Then: Response should be parsed
           mockHttp.VerifyNoOutstandingExpectation();
-          balanceTransactions?.Items?.Should().NotBeNull();
-          balanceTransactions.Count.Should().Be(balanceTransactions.Items.Count());
+          balanceTransactions?.Items?.ShouldNotBeNull();
+          balanceTransactions.Count.ShouldBe(balanceTransactions.Items.Count());
           var transaction = balanceTransactions.Items.First();
-          transaction.Resource.Should().Be("balance_transactions");
-          transaction.Id.Should().Be("baltr_9S8yk4FFqqi2Qm6K3rqRH");
-          transaction.Type.Should().Be("outgoing-transfer");
-          transaction.ResultAmount.Value.Should().Be("-7.76");
-          transaction.ResultAmount.Currency.Should().Be(Currency.EUR);
-          transaction.InitialAmount.Value.Should().Be("-7.76");
-          transaction.InitialAmount.Currency.Should().Be(Currency.EUR);
-          transaction.Should().BeOfType<SettlementBalanceTransactionResponse>();
+          transaction.Resource.ShouldBe("balance_transactions");
+          transaction.Id.ShouldBe("baltr_9S8yk4FFqqi2Qm6K3rqRH");
+          transaction.Type.ShouldBe("outgoing-transfer");
+          transaction.ResultAmount.Value.ShouldBe("-7.76");
+          transaction.ResultAmount.Currency.ShouldBe(Currency.EUR);
+          transaction.InitialAmount.Value.ShouldBe("-7.76");
+          transaction.InitialAmount.Currency.ShouldBe(Currency.EUR);
+          transaction.ShouldBeOfType<SettlementBalanceTransactionResponse>();
           var transactionContext = (SettlementBalanceTransactionResponse)transaction;
-          transactionContext.Context.SettlementId.Should().Be("stl_ma2vu8");
-          transactionContext.Context.TransferId.Should().Be("trf_ma2vu8");
+          transactionContext.Context.SettlementId.ShouldBe("stl_ma2vu8");
+          transactionContext.Context.TransferId.ShouldBe("trf_ma2vu8");
       }
 
       [Theory]
@@ -264,7 +264,7 @@ namespace Mollie.Tests.Unit.Client {
           var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await balanceClient.GetBalanceTransactionListAsync(balanceId));
 
           // Then
-          exception.Message.Should().Be("Required URL argument 'balanceId' is null or empty");
+          exception.Message.ShouldBe("Required URL argument 'balanceId' is null or empty");
       }
 
       [Fact]
@@ -280,8 +280,8 @@ namespace Mollie.Tests.Unit.Client {
 
           // Then: Response should be parsed
           mockHttp.VerifyNoOutstandingExpectation();
-          balanceTransactions?.Items?.Should().NotBeNull();
-          balanceTransactions.Count.Should().Be(balanceTransactions.Items.Count());
+          balanceTransactions?.Items?.ShouldNotBeNull();
+          balanceTransactions.Count.ShouldBe(balanceTransactions.Items.Count());
       }
 
       private readonly string DefaultListBalanceTransactionsResponse = @"

--- a/tests/Mollie.Tests.Unit/Client/BaseMollieClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/BaseMollieClientTests.cs
@@ -2,7 +2,7 @@
 using System.Net.Http;
 using System.Net.Mime;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Models;
 using Mollie.Api.Models.Payment.Request;
@@ -45,8 +45,8 @@ public class BaseMollieClientTests : BaseClientTests {
         var exception = await Assert.ThrowsAsync<MollieApiException>(() => paymentClient.CreatePaymentAsync(paymentRequest));
 
         // Assert
-        exception.Details.Detail.Should().Be(errorMessage);
-        exception.Details.Status.Should().Be(errorStatus);
+        exception.Details.Detail.ShouldBe(errorMessage);
+        exception.Details.Status.ShouldBe(errorStatus);
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class BaseMollieClientTests : BaseClientTests {
         var exception = await Assert.ThrowsAsync<MollieApiException>(() => paymentClient.CreatePaymentAsync(paymentRequest));
 
         // Assert
-        exception.Details.Detail.Should().Be(responseBody);
-        exception.Details.Status.Should().Be((int)HttpStatusCode.UnprocessableEntity);
+        exception.Details.Detail.ShouldBe(responseBody);
+        exception.Details.Status.ShouldBe((int)HttpStatusCode.UnprocessableEntity);
     }
 }

--- a/tests/Mollie.Tests.Unit/Client/CaptureClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/CaptureClientTests.cs
@@ -3,7 +3,7 @@ using Mollie.Api.Client;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Models;
 using Mollie.Api.Models.Capture.Request;
 using Mollie.Api.Models.Capture.Response;
@@ -114,13 +114,13 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then: Response should be parsed
             mockHttp.VerifyNoOutstandingExpectation();
-            captureResponse.Should().NotBeNull();
-            captureResponse.PaymentId.Should().Be(defaultPaymentId);
-            captureResponse.ShipmentId.Should().Be(defaultShipmentId);
-            captureResponse.SettlementId.Should().Be(defaultSettlementId);
-            captureResponse.Amount.Value.Should().Be(defaultAmountValue);
-            captureResponse.Amount.Currency.Should().Be(defaultAmountCurrency);
-            captureResponse.Status.Should().Be(defaultStatus);
+            captureResponse.ShouldNotBeNull();
+            captureResponse.PaymentId.ShouldBe(defaultPaymentId);
+            captureResponse.ShipmentId.ShouldBe(defaultShipmentId);
+            captureResponse.SettlementId.ShouldBe(defaultSettlementId);
+            captureResponse.Amount.Value.ShouldBe(defaultAmountValue);
+            captureResponse.Amount.Currency.ShouldBe(defaultAmountCurrency);
+            captureResponse.Status.ShouldBe(defaultStatus);
         }
 
         [Fact]
@@ -136,15 +136,15 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then: Response should be parsed
             mockHttp.VerifyNoOutstandingExpectation();
-            listCaptureResponse.Should().NotBeNull();
-            listCaptureResponse.Count.Should().Be(1);
+            listCaptureResponse.ShouldNotBeNull();
+            listCaptureResponse.Count.ShouldBe(1);
             CaptureResponse captureResponse = listCaptureResponse.Items.First();
-            captureResponse.PaymentId.Should().Be(defaultPaymentId);
-            captureResponse.ShipmentId.Should().Be(defaultShipmentId);
-            captureResponse.SettlementId.Should().Be(defaultSettlementId);
-            captureResponse.Amount.Value.Should().Be(defaultAmountValue);
-            captureResponse.Amount.Currency.Should().Be(defaultAmountCurrency);
-            captureResponse.Status.Should().Be(defaultStatus);
+            captureResponse.PaymentId.ShouldBe(defaultPaymentId);
+            captureResponse.ShipmentId.ShouldBe(defaultShipmentId);
+            captureResponse.SettlementId.ShouldBe(defaultSettlementId);
+            captureResponse.Amount.Value.ShouldBe(defaultAmountValue);
+            captureResponse.Amount.Currency.ShouldBe(defaultAmountCurrency);
+            captureResponse.Status.ShouldBe(defaultStatus);
         }
 
         [Theory]
@@ -161,7 +161,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await captureClient.GetCaptureAsync(paymentId, "capture-id"));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'paymentId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'paymentId' is null or empty");
         }
 
         [Theory]
@@ -178,7 +178,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await captureClient.GetCaptureAsync("payment-id", captureId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'captureId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'captureId' is null or empty");
         }
 
         [Theory]
@@ -195,7 +195,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await captureClient.GetCaptureListAsync(paymentId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'paymentId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'paymentId' is null or empty");
         }
 
         [Theory]
@@ -216,7 +216,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await captureClient.CreateCapture(paymentId, captureRequest));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'paymentId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'paymentId' is null or empty");
         }
 
         [Fact]
@@ -238,8 +238,8 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingRequest();
-            response.Id.Should().Be(defaultCaptureId);
-            response.PaymentId.Should().Be(defaultPaymentId);
+            response.Id.ShouldBe(defaultCaptureId);
+            response.PaymentId.ShouldBe(defaultPaymentId);
         }
     }
 }

--- a/tests/Mollie.Tests.Unit/Client/ChargebackClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/ChargebackClientTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Models.Chargeback.Response;
 using RichardSzalay.MockHttp;
@@ -61,11 +61,11 @@ namespace Mollie.Tests.Unit.Client {
             ChargebackResponse chargebackResponse = await chargebackClient.GetChargebackAsync(defaultPaymentId, defaultChargebackId);
 
             // Then
-            chargebackResponse.PaymentId.Should().Be(defaultPaymentId);
-            chargebackResponse.Id.Should().Be(defaultChargebackId);
-            chargebackResponse.Reason.Should().NotBeNull();
-            chargebackResponse.Reason!.Code.Should().Be(defaultChargebackReasonCode);
-            chargebackResponse.Reason.Description.Should().Be(defaultChargebackReason);
+            chargebackResponse.PaymentId.ShouldBe(defaultPaymentId);
+            chargebackResponse.Id.ShouldBe(defaultChargebackId);
+            chargebackResponse.Reason.ShouldNotBeNull();
+            chargebackResponse.Reason!.Code.ShouldBe(defaultChargebackReasonCode);
+            chargebackResponse.Reason.Description.ShouldBe(defaultChargebackReason);
         }
 
         [Theory]
@@ -139,7 +139,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await chargebackClient.GetChargebackAsync(paymentId, "chargeback-id"));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'paymentId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'paymentId' is null or empty");
         }
 
         [Theory]
@@ -156,7 +156,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await chargebackClient.GetChargebackAsync("payment-id", chargebackId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'chargebackId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'chargebackId' is null or empty");
         }
 
         [Theory]
@@ -173,7 +173,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await chargebackClient.GetChargebackListAsync(paymentId: paymentId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'paymentId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'paymentId' is null or empty");
         }
     }
 }

--- a/tests/Mollie.Tests.Unit/Client/ClientLinkClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/ClientLinkClientTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Models;
 using Mollie.Api.Models.ClientLink.Request;
@@ -39,8 +39,8 @@ public class ClientLinkClientTests : BaseClientTests
         ClientLinkResponse response = await clientLinkClient.CreateClientLinkAsync(request);
 
         // Then
-        response.Id.Should().Be(clientLinkId);
-        response.Links.ClientLink.Href.Should().Be(clientLinkUrl);
+        response.Id.ShouldBe(clientLinkId);
+        response.Links.ClientLink.Href.ShouldBe(clientLinkUrl);
         mockHttp.VerifyNoOutstandingRequest();
     }
 
@@ -70,12 +70,11 @@ public class ClientLinkClientTests : BaseClientTests
 
         // Assert
         string expectedApprovalPrompt = forceApprovalPrompt ? "force" : "auto";
-        result.Should()
-            .Be("https://my.mollie.com/dashboard/client-link/csr_vZCnNQsV2UtfXxYifWKWH" +
-                $"?client_id={clientId}" +
-                $"&state={state}" +
-                "&scope=onboarding.read+organizations.read+payments.write+payments.read+profiles.write" +
-                $"&approval_prompt={expectedApprovalPrompt}");
+        result.ShouldBe("https://my.mollie.com/dashboard/client-link/csr_vZCnNQsV2UtfXxYifWKWH" +
+                        $"?client_id={clientId}" +
+                        $"&state={state}" +
+                        "&scope=onboarding.read+organizations.read+payments.write+payments.read+profiles.write" +
+                        $"&approval_prompt={expectedApprovalPrompt}");
     }
 
     private string CreateClientLinkResponseJson(string id, string clientLinkUrl)

--- a/tests/Mollie.Tests.Unit/Client/ConnectClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/ConnectClientTests.cs
@@ -2,7 +2,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Models.Connect.Request;
 using Mollie.Api.Models.Connect.Response;
@@ -29,7 +29,7 @@ public class ConnectClientTests : BaseClientTests
 
         // Assert
         string expectedUrl = $"https://my.mollie.com/oauth2/authorize?client_id={ClientId}&state=abcde&scope=payments.read&response_type=code&approval_prompt=auto";
-        authorizationUrl.Should().Be(expectedUrl);
+        authorizationUrl.ShouldBe(expectedUrl);
     }
 
     [Theory]
@@ -50,13 +50,13 @@ public class ConnectClientTests : BaseClientTests
 
         // Assert
         mockHttp.VerifyNoOutstandingExpectation();
-        tokenRequest.GrantType.Should().Be(expectedGrantType);
-        tokenResponse.Should().NotBeNull();
-        tokenResponse.AccessToken.Should().Be("access_46EUJ6x8jFJZZeAvhNH4JVey6qVpqR");
-        tokenResponse.RefreshToken.Should().Be("refresh_FS4xc3Mgci2xQ5s5DzaLXh3HhaTZOP");
-        tokenResponse.ExpiresIn.Should().Be(3600);
-        tokenResponse.TokenType.Should().Be("bearer");
-        tokenResponse.Scope.Should().Be("payments.read organizations.read");
+        tokenRequest.GrantType.ShouldBe(expectedGrantType);
+        tokenResponse.ShouldNotBeNull();
+        tokenResponse.AccessToken.ShouldBe("access_46EUJ6x8jFJZZeAvhNH4JVey6qVpqR");
+        tokenResponse.RefreshToken.ShouldBe("refresh_FS4xc3Mgci2xQ5s5DzaLXh3HhaTZOP");
+        tokenResponse.ExpiresIn.ShouldBe(3600);
+        tokenResponse.TokenType.ShouldBe("bearer");
+        tokenResponse.Scope.ShouldBe("payments.read organizations.read");
     }
 
     [Fact]

--- a/tests/Mollie.Tests.Unit/Client/CustomerClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/CustomerClientTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Models;
 using Mollie.Api.Models.Customer.Request;
@@ -30,7 +30,7 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            customerResponse.Should().NotBeNull();
+            customerResponse.ShouldNotBeNull();
         }
 
         [Theory]
@@ -51,7 +51,7 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            result.Should().NotBeNull();
+            result.ShouldNotBeNull();
         }
 
         [Theory]
@@ -74,7 +74,7 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            result.Should().NotBeNull();
+            result.ShouldNotBeNull();
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await customerClient.UpdateCustomerAsync(customerId, new CustomerRequest()));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'customerId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'customerId' is null or empty");
         }
 
         [Theory]
@@ -124,7 +124,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await customerClient.DeleteCustomerAsync(customerId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'customerId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'customerId' is null or empty");
         }
 
         [Theory]
@@ -141,7 +141,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await customerClient.GetCustomerAsync(customerId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'customerId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'customerId' is null or empty");
         }
 
         [Theory]
@@ -158,7 +158,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await customerClient.GetCustomerPaymentListAsync(customerId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'customerId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'customerId' is null or empty");
         }
 
         [Theory]
@@ -180,7 +180,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await customerClient.CreateCustomerPayment(customerId, paymentRequest));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'customerId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'customerId' is null or empty");
         }
 
         private const string DefaultCustomerJsonToReturn = @"{

--- a/tests/Mollie.Tests.Unit/Client/InvoiceClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/InvoiceClientTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using RichardSzalay.MockHttp;
 using Xunit;
@@ -25,12 +25,12 @@ public class InvoiceClientTests : BaseClientTests
 
         // Then
         mockHttp.VerifyNoOutstandingExpectation();
-        result.Should().NotBeNull();
-        result.Resource.Should().Be("invoice");
-        result.Id.Should().Be(invoiceId);
-        result.Reference.Should().Be("2016.10000");
-        result.VatNumber.Should().Be("NL001234567B01");
-        result.Status.Should().Be("open");
+        result.ShouldNotBeNull();
+        result.Resource.ShouldBe("invoice");
+        result.Id.ShouldBe(invoiceId);
+        result.Reference.ShouldBe("2016.10000");
+        result.VatNumber.ShouldBe("NL001234567B01");
+        result.Status.ShouldBe("open");
     }
 
     [Theory]
@@ -54,7 +54,7 @@ public class InvoiceClientTests : BaseClientTests
 
         // Then
         mockHttp.VerifyNoOutstandingExpectation();
-        result.Should().NotBeNull();
+        result.ShouldNotBeNull();
     }
 
     private const string defaultInvoice = @"{

--- a/tests/Mollie.Tests.Unit/Client/MandateClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/MandateClientTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Models.Mandate.Request;
 using Mollie.Api.Models.Payment;
@@ -29,7 +29,7 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            result.Should().NotBeNull();
+            result.ShouldNotBeNull();
         }
 
         [Theory]
@@ -51,7 +51,7 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            result.Should().NotBeNull();
+            result.ShouldNotBeNull();
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await mandateClient.GetMandateAsync(mandateId, "mandate-id"));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'customerId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'customerId' is null or empty");
         }
 
         [Theory]
@@ -106,7 +106,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await mandateClient.GetMandateAsync("customer-id", mandateId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'mandateId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'mandateId' is null or empty");
         }
 
         [Theory]
@@ -123,7 +123,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await mandateClient.GetMandateListAsync(mandateId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'customerId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'customerId' is null or empty");
         }
 
         [Theory]
@@ -144,7 +144,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await mandateClient.CreateMandateAsync(mandateId, mandateRequest));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'customerId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'customerId' is null or empty");
         }
 
         private const string DefaultMandateJsonToReturn = @"{

--- a/tests/Mollie.Tests.Unit/Client/OnboardingClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/OnboardingClientTests.cs
@@ -4,7 +4,7 @@ using Mollie.Api.Models.Onboarding.Request;
 using Mollie.Api.Models.Onboarding.Response;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace Mollie.Tests.Unit.Client {
@@ -37,11 +37,11 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then: Response should be parsed
             mockHttp.VerifyNoOutstandingExpectation();
-            onboardingResponse.Should().NotBeNull();
-            onboardingResponse.Name.Should().Be(defaultName);
-            onboardingResponse.Status.Should().Be(defaultStatus);
-            onboardingResponse.CanReceivePayments.ToString().ToLower().Should().Be(canReceivePayments);
-            onboardingResponse.CanReceiveSettlements.ToString().ToLower().Should().Be(canReceiveSettlements);
+            onboardingResponse.ShouldNotBeNull();
+            onboardingResponse.Name.ShouldBe(defaultName);
+            onboardingResponse.Status.ShouldBe(defaultStatus);
+            onboardingResponse.CanReceivePayments.ToString().ToLower().ShouldBe(canReceivePayments);
+            onboardingResponse.CanReceiveSettlements.ToString().ToLower().ShouldBe(canReceiveSettlements);
         }
 
         [Fact]

--- a/tests/Mollie.Tests.Unit/Client/OrderClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/OrderClientTests.cs
@@ -6,12 +6,14 @@ using Mollie.Api.Models.Payment;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Models.Order.Request;
 using Mollie.Api.Models.Order.Request.ManageOrderLines;
 using Mollie.Api.Models.Order.Response;
 using RichardSzalay.MockHttp;
 using Xunit;
+
+using SortDirection = Mollie.Api.Models.SortDirection;
 
 namespace Mollie.Tests.Unit.Client {
     public class OrderClientTests : BaseClientTests {
@@ -118,7 +120,7 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            orderResponse.Method.Should().Be(orderRequest.Method);
+            orderResponse.Method.ShouldBe(orderRequest.Method);
         }
 
         [Fact]
@@ -209,7 +211,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await orderClient.GetOrderAsync(orderId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'orderId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'orderId' is null or empty");
         }
 
         [Theory]
@@ -226,7 +228,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await orderClient.UpdateOrderAsync(orderId, new OrderUpdateRequest()));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'orderId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'orderId' is null or empty");
         }
 
         [Theory]
@@ -243,7 +245,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await orderClient.UpdateOrderLinesAsync(orderId, "order-line-id", new OrderLineUpdateRequest()));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'orderId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'orderId' is null or empty");
         }
 
         [Theory]
@@ -260,7 +262,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await orderClient.UpdateOrderLinesAsync("order-id", orderLineId, new OrderLineUpdateRequest()));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'orderLineId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'orderLineId' is null or empty");
         }
 
         [Theory]
@@ -288,7 +290,7 @@ namespace Mollie.Tests.Unit.Client {
                 await orderClient.ManageOrderLinesAsync(orderId, request));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'orderId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'orderId' is null or empty");
         }
 
         [Theory]
@@ -305,7 +307,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await orderClient.CancelOrderAsync(orderId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'orderId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'orderId' is null or empty");
         }
 
         [Theory]
@@ -322,7 +324,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await orderClient.CreateOrderPaymentAsync(orderId, new OrderPaymentRequest()));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'orderId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'orderId' is null or empty");
         }
 
         private OrderRequest CreateOrderRequestWithOnlyRequiredFields() {

--- a/tests/Mollie.Tests.Unit/Client/OrganizationClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/OrganizationClientTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Models.Organization;
 using RichardSzalay.MockHttp;
@@ -20,14 +20,14 @@ public class OrganizationClientTests : BaseClientTests
             .Respond("application/json", defaultOrganizationResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var organizationsClient = new OrganizationClient("access_abcde", httpClient);
-        
+
         // Act
         var result = await organizationsClient.GetCurrentOrganizationAsync();
 
         // Assert
         AssertDefaultOrganization(result);
     }
-    
+
     [Fact]
     public async Task GetOrganizationAsync_ResponseIsDeserializedInExpectedFormat()
     {
@@ -39,7 +39,7 @@ public class OrganizationClientTests : BaseClientTests
             .Respond("application/json", defaultOrganizationResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var organizationsClient = new OrganizationClient("access_abcde", httpClient);
-        
+
         // Act
         var result = await organizationsClient.GetOrganizationAsync(organizationId);
 
@@ -57,38 +57,38 @@ public class OrganizationClientTests : BaseClientTests
             .Respond("application/json", defaultOrganizationListResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var organizationsClient = new OrganizationClient("access_abcde", httpClient);
-        
+
         // Act
         var result = await organizationsClient.GetOrganizationListAsync();
 
         // Assert
-        result.Count.Should().Be(2);
-        result.Items.Should().HaveCount(2);
+        result.Count.ShouldBe(2);
+        result.Items.Count.ShouldBe(2);
     }
 
     private void AssertDefaultOrganization(OrganizationResponse response)
     {
-        response.Resource.Should().Be("organization");
-        response.Id.Should().Be("org_12345678");
-        response.Name.Should().Be("Mollie B.V.");
-        response.Email.Should().Be("info@mollie.com");
-        response.Address.StreetAndNumber.Should().Be("Keizersgracht 126");
-        response.Address.PostalCode.Should().Be("1015 CW");
-        response.Address.City.Should().Be("Amsterdam");
-        response.Address.Country.Should().Be("NL");
-        response.RegistrationNumber.Should().Be("30204462");
-        response.VatNumber.Should().Be("NL815839091B01");
-        response.VatRegulation.Should().BeNullOrEmpty();
-        response.Links.Self.Href.Should().Be("https://api.mollie.com/v2/organizations/me");
-        response.Links.Chargebacks.Href.Should().Be("https://api.mollie.com/v2/chargebacks");
-        response.Links.Customers.Href.Should().Be("https://api.mollie.com/v2/customers");
-        response.Links.Invoices.Href.Should().Be("https://api.mollie.com/v2/invoices");
-        response.Links.Payments.Href.Should().Be("https://api.mollie.com/v2/payments");
-        response.Links.Profiles.Href.Should().Be("https://api.mollie.com/v2/profiles");
-        response.Links.Refunds.Href.Should().Be("https://api.mollie.com/v2/refunds");
-        response.Links.Settlements.Href.Should().Be("https://api.mollie.com/v2/settlements");
-        response.Links.Dashboard.Href.Should().Be("https://mollie.com/dashboard/org_12345678");
-        response.Links.Documentation.Href.Should().Be("https://docs.mollie.com/reference/v2/organizations-api/current-organization");
+        response.Resource.ShouldBe("organization");
+        response.Id.ShouldBe("org_12345678");
+        response.Name.ShouldBe("Mollie B.V.");
+        response.Email.ShouldBe("info@mollie.com");
+        response.Address.StreetAndNumber.ShouldBe("Keizersgracht 126");
+        response.Address.PostalCode.ShouldBe("1015 CW");
+        response.Address.City.ShouldBe("Amsterdam");
+        response.Address.Country.ShouldBe("NL");
+        response.RegistrationNumber.ShouldBe("30204462");
+        response.VatNumber.ShouldBe("NL815839091B01");
+        response.VatRegulation.ShouldBeNullOrEmpty();
+        response.Links.Self.Href.ShouldBe("https://api.mollie.com/v2/organizations/me");
+        response.Links.Chargebacks.Href.ShouldBe("https://api.mollie.com/v2/chargebacks");
+        response.Links.Customers.Href.ShouldBe("https://api.mollie.com/v2/customers");
+        response.Links.Invoices.Href.ShouldBe("https://api.mollie.com/v2/invoices");
+        response.Links.Payments.Href.ShouldBe("https://api.mollie.com/v2/payments");
+        response.Links.Profiles.Href.ShouldBe("https://api.mollie.com/v2/profiles");
+        response.Links.Refunds.Href.ShouldBe("https://api.mollie.com/v2/refunds");
+        response.Links.Settlements.Href.ShouldBe("https://api.mollie.com/v2/settlements");
+        response.Links.Dashboard.Href.ShouldBe("https://mollie.com/dashboard/org_12345678");
+        response.Links.Documentation.Href.ShouldBe("https://docs.mollie.com/reference/v2/organizations-api/current-organization");
     }
 
     private const string defaultOrganizationListResponse = @$"
@@ -101,7 +101,7 @@ public class OrganizationClientTests : BaseClientTests
         ]
     }}
 }}";
-    
+
     private const string defaultOrganizationResponse = @"{
      ""resource"": ""organization"",
      ""id"": ""org_12345678"",

--- a/tests/Mollie.Tests.Unit/Client/PaymentClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/PaymentClientTests.cs
@@ -8,11 +8,12 @@ using RichardSzalay.MockHttp;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
-using FluentAssertions.Extensions;
+using Shouldly;
 using Mollie.Api.Models.Payment.Request.PaymentSpecificParameters;
 using Mollie.Api.Models.Payment.Response.PaymentSpecificParameters;
 using Xunit;
+
+using SortDirection = Mollie.Api.Models.SortDirection;
 
 namespace Mollie.Tests.Unit.Client;
 
@@ -76,27 +77,27 @@ public class PaymentClientTests : BaseClientTests {
 
         // Then
         AssertPaymentIsEqual(paymentRequest, paymentResponse);
-        paymentResponse.AuthorizedAt!.Value.ToUniversalTime().Should().Be(DateTime.SpecifyKind(19.March(2018).At(13, 28, 37), DateTimeKind.Utc));
-        paymentResponse.CreatedAt!.ToUniversalTime().Should().Be(DateTime.SpecifyKind(20.March(2018).At(13, 13, 37), DateTimeKind.Utc));
-        paymentResponse.PaidAt!.Value.ToUniversalTime().Should().Be(DateTime.SpecifyKind(21.March(2018).At(13, 28, 37), DateTimeKind.Utc));
-        paymentResponse.CanceledAt!.Value.ToUniversalTime().Should().Be(DateTime.SpecifyKind(22.March(2018).At(13, 28, 37), DateTimeKind.Utc));
-        paymentResponse.ExpiredAt!.Value.ToUniversalTime().Should().Be(DateTime.SpecifyKind(23.March(2018).At(13, 28, 37), DateTimeKind.Utc));
-        paymentResponse.FailedAt!.Value.ToUniversalTime().Should().Be(DateTime.SpecifyKind(24.March(2018).At(13, 28, 37), DateTimeKind.Utc));
-        paymentResponse.CaptureBefore!.Value.ToUniversalTime().Should().Be(DateTime.SpecifyKind(25.March(2018).At(13, 28, 37), DateTimeKind.Utc));
-        paymentResponse.AmountRefunded!.Value.Should().Be("10.00");
-        paymentResponse.AmountRefunded.Currency.Should().Be(Currency.EUR);
-        paymentResponse.AmountRemaining!.Value.Should().Be("90.00");
-        paymentResponse.AmountRemaining.Currency.Should().Be(Currency.EUR);
-        paymentResponse.AmountChargedBack!.Value.Should().Be("10.00");
-        paymentResponse.AmountChargedBack.Currency.Should().Be(Currency.EUR);
-        paymentResponse.CancelUrl.Should().Be("https://webshop.example.org/order/12345/cancel");
-        paymentResponse.CountryCode.Should().Be("NL");
-        paymentResponse.SettlementId.Should().Be("stl_jDk30akdN");
-        paymentResponse.SubscriptionId.Should().Be("sub_rVKGtNd6s3");
-        paymentResponse.ApplicationFee.Should().NotBeNull();
-        paymentResponse.ApplicationFee!.Amount.Value.Should().Be("1.00");
-        paymentResponse.ApplicationFee.Amount.Currency.Should().Be(Currency.EUR);
-        paymentResponse.ApplicationFee.Description.Should().Be("description");
+        paymentResponse.AuthorizedAt!.Value.ToUniversalTime().ShouldBe(DateTime.SpecifyKind(new DateTime(2018, 3, 19, 13, 28, 37), DateTimeKind.Utc));
+        paymentResponse.CreatedAt!.ToUniversalTime().ShouldBe(DateTime.SpecifyKind(new DateTime(2018, 3, 20, 13, 13, 37), DateTimeKind.Utc));
+        paymentResponse.PaidAt!.Value.ToUniversalTime().ShouldBe(DateTime.SpecifyKind(new DateTime(2018, 3, 21, 13, 28, 37), DateTimeKind.Utc));
+        paymentResponse.CanceledAt!.Value.ToUniversalTime().ShouldBe(DateTime.SpecifyKind(new DateTime(2018, 3, 22, 13, 28, 37), DateTimeKind.Utc));
+        paymentResponse.ExpiredAt!.Value.ToUniversalTime().ShouldBe(DateTime.SpecifyKind(new DateTime(2018, 3, 23, 13, 28, 37), DateTimeKind.Utc));
+        paymentResponse.FailedAt!.Value.ToUniversalTime().ShouldBe(DateTime.SpecifyKind(new DateTime(2018, 3, 24, 13, 28, 37), DateTimeKind.Utc));
+        paymentResponse.CaptureBefore!.Value.ToUniversalTime().ShouldBe(DateTime.SpecifyKind(new DateTime(2018, 3, 25, 13, 28, 37), DateTimeKind.Utc));
+        paymentResponse.AmountRefunded!.Value.ShouldBe("10.00");
+        paymentResponse.AmountRefunded.Currency.ShouldBe(Currency.EUR);
+        paymentResponse.AmountRemaining!.Value.ShouldBe("90.00");
+        paymentResponse.AmountRemaining.Currency.ShouldBe(Currency.EUR);
+        paymentResponse.AmountChargedBack!.Value.ShouldBe("10.00");
+        paymentResponse.AmountChargedBack.Currency.ShouldBe(Currency.EUR);
+        paymentResponse.CancelUrl.ShouldBe("https://webshop.example.org/order/12345/cancel");
+        paymentResponse.CountryCode.ShouldBe("NL");
+        paymentResponse.SettlementId.ShouldBe("stl_jDk30akdN");
+        paymentResponse.SubscriptionId.ShouldBe("sub_rVKGtNd6s3");
+        paymentResponse.ApplicationFee.ShouldNotBeNull();
+        paymentResponse.ApplicationFee!.Amount.Value.ShouldBe("1.00");
+        paymentResponse.ApplicationFee.Amount.Currency.ShouldBe(Currency.EUR);
+        paymentResponse.ApplicationFee.Description.ShouldBe("description");
     }
 
     [Fact]
@@ -127,7 +128,7 @@ public class PaymentClientTests : BaseClientTests {
         // Then
         mockHttp.VerifyNoOutstandingExpectation();
         AssertPaymentIsEqual(paymentRequest, paymentResponse);
-        paymentResponse.Method.Should().Be(paymentRequest.Method);
+        paymentResponse.Method.ShouldBe(paymentRequest.Method);
     }
 
     [Fact]
@@ -162,7 +163,7 @@ public class PaymentClientTests : BaseClientTests {
         // Then
         mockHttp.VerifyNoOutstandingExpectation();
         AssertPaymentIsEqual(paymentRequest, paymentResponse);
-        paymentResponse.Method.Should().BeNull();
+        paymentResponse.Method.ShouldBeNull();
     }
 
     [Fact]
@@ -215,7 +216,7 @@ public class PaymentClientTests : BaseClientTests {
         // Then
         mockHttp.VerifyNoOutstandingExpectation();
         AssertPaymentIsEqual(paymentRequest, paymentResponse);
-        paymentResponse.Method.Should().BeNull();
+        paymentResponse.Method.ShouldBeNull();
     }
 
     [Fact]
@@ -251,29 +252,29 @@ public class PaymentClientTests : BaseClientTests {
 
         // Then
         mockHttp.VerifyNoOutstandingExpectation();
-        payment.Resource.Should().Be("payment");
-        payment.Id.Should().Be(paymentId);
-        payment.Amount.Value.Should().Be("100.00");
-        payment.Amount.Currency.Should().Be(Currency.EUR);
-        payment.Description.Should().Be("Description");
-        payment.Method.Should().BeNull();
-        payment.Status.Should().Be(PaymentStatus.Open);
-        payment.IsCancelable.Should().BeFalse();
-        payment.Locale.Should().Be("nl_NL");
-        payment.ExpiresAt!.Value.ToUniversalTime().Should().Be(DateTime.SpecifyKind(20.March(2018).At(13, 28, 37), DateTimeKind.Utc));
-        payment.ProfileId.Should().Be("pfl_QkEhN94Ba");
-        payment.SequenceType.Should().Be(SequenceType.OneOff);
-        payment.RedirectUrl.Should().Be("https://webshop.example.org/order/12345/");
-        payment.WebhookUrl.Should().Be("https://webshop.example.org/payments/webhook/");
-        payment.Links.Should().NotBeNull();
-        payment.Links.Self.Href.Should().Be("https://api.mollie.com/v2/payments/tr_WDqYK6vllg");
-        payment.Links.Self.Type.Should().Be("application/hal+json");
-        payment.Links.Checkout!.Href.Should().Be("https://www.mollie.com/payscreen/select-method/WDqYK6vllg");
-        payment.Links.Checkout.Type.Should().Be("text/html");
-        payment.Links.Dashboard.Href.Should().Be("https://www.mollie.com/dashboard/org_12345678/payments/tr_WDqYK6vllg");
-        payment.Links.Dashboard.Type.Should().Be("text/html");
-        payment.Links.Documentation.Href.Should().Be("https://docs.mollie.com/reference/v2/payments-api/get-payment");
-        payment.Links.Documentation.Type.Should().Be("text/html");
+        payment.Resource.ShouldBe("payment");
+        payment.Id.ShouldBe(paymentId);
+        payment.Amount.Value.ShouldBe("100.00");
+        payment.Amount.Currency.ShouldBe(Currency.EUR);
+        payment.Description.ShouldBe("Description");
+        payment.Method.ShouldBeNull();
+        payment.Status.ShouldBe(PaymentStatus.Open);
+        payment.IsCancelable.ShouldBe(false);
+        payment.Locale.ShouldBe("nl_NL");
+        payment.ExpiresAt!.Value.ToUniversalTime().ShouldBe(DateTime.SpecifyKind(new DateTime(2018, 3, 20, 13, 28, 37), DateTimeKind.Utc));
+        payment.ProfileId.ShouldBe("pfl_QkEhN94Ba");
+        payment.SequenceType.ShouldBe(SequenceType.OneOff);
+        payment.RedirectUrl.ShouldBe("https://webshop.example.org/order/12345/");
+        payment.WebhookUrl.ShouldBe("https://webshop.example.org/payments/webhook/");
+        payment.Links.ShouldNotBeNull();
+        payment.Links.Self.Href.ShouldBe("https://api.mollie.com/v2/payments/tr_WDqYK6vllg");
+        payment.Links.Self.Type.ShouldBe("application/hal+json");
+        payment.Links.Checkout!.Href.ShouldBe("https://www.mollie.com/payscreen/select-method/WDqYK6vllg");
+        payment.Links.Checkout.Type.ShouldBe("text/html");
+        payment.Links.Dashboard.Href.ShouldBe("https://www.mollie.com/dashboard/org_12345678/payments/tr_WDqYK6vllg");
+        payment.Links.Dashboard.Type.ShouldBe("text/html");
+        payment.Links.Documentation.Href.ShouldBe("https://docs.mollie.com/reference/v2/payments-api/get-payment");
+        payment.Links.Documentation.Type.ShouldBe("text/html");
     }
 
     [Fact]
@@ -328,27 +329,27 @@ public class PaymentClientTests : BaseClientTests {
         var payment = await paymentClient.GetPaymentAsync(paymentId);
 
         // Then
-        payment.Should().BeOfType<BankTransferPaymentResponse>();
+        payment.ShouldBeOfType<BankTransferPaymentResponse>();
         var bankTransferPayment = payment as BankTransferPaymentResponse;
-        bankTransferPayment.Details.BankName.Should().Be("bank-name");
-        bankTransferPayment.Details.BankAccount.Should().Be("bank-account");
-        bankTransferPayment.Details.BankBic.Should().Be("bank-bic");
-        bankTransferPayment.Details.TransferReference.Should().Be("transfer-reference");
-        bankTransferPayment.Details.ConsumerName.Should().Be("consumer-name");
-        bankTransferPayment.Details.ConsumerAccount.Should().Be("consumer-account");
-        bankTransferPayment.Details.ConsumerBic.Should().Be("consumer-bic");
-        bankTransferPayment.Details.BillingEmail.Should().Be("billing-email");
-        bankTransferPayment.Details.QrCode.Should().NotBeNull();
-        bankTransferPayment.Details.QrCode.Height.Should().Be(5);
-        bankTransferPayment.Details.QrCode.Width.Should().Be(10);
-        bankTransferPayment.Details.QrCode.Src.Should().Be("https://www.mollie.com/qr/12345678.png");
-        bankTransferPayment.Links.Should().NotBeNull();
-        bankTransferPayment.Links.Status.Should().NotBeNull();
-        bankTransferPayment.Links.Status.Href.Should().Be("https://api.mollie.com/v2/payments/tr_WDqYK6vllg");
-        bankTransferPayment.Links.Status.Type.Should().Be("application/hal+json");
-        bankTransferPayment.Links.PayOnline.Should().NotBeNull();
-        bankTransferPayment.Links.PayOnline.Href.Should().Be("https://www.mollie.com/payscreen/select-method/WDqYK6vllg");
-        bankTransferPayment.Links.PayOnline.Type.Should().Be("text/html");
+        bankTransferPayment.Details.BankName.ShouldBe("bank-name");
+        bankTransferPayment.Details.BankAccount.ShouldBe("bank-account");
+        bankTransferPayment.Details.BankBic.ShouldBe("bank-bic");
+        bankTransferPayment.Details.TransferReference.ShouldBe("transfer-reference");
+        bankTransferPayment.Details.ConsumerName.ShouldBe("consumer-name");
+        bankTransferPayment.Details.ConsumerAccount.ShouldBe("consumer-account");
+        bankTransferPayment.Details.ConsumerBic.ShouldBe("consumer-bic");
+        bankTransferPayment.Details.BillingEmail.ShouldBe("billing-email");
+        bankTransferPayment.Details.QrCode.ShouldNotBeNull();
+        bankTransferPayment.Details.QrCode.Height.ShouldBe(5);
+        bankTransferPayment.Details.QrCode.Width.ShouldBe(10);
+        bankTransferPayment.Details.QrCode.Src.ShouldBe("https://www.mollie.com/qr/12345678.png");
+        bankTransferPayment.Links.ShouldNotBeNull();
+        bankTransferPayment.Links.Status.ShouldNotBeNull();
+        bankTransferPayment.Links.Status.Href.ShouldBe("https://api.mollie.com/v2/payments/tr_WDqYK6vllg");
+        bankTransferPayment.Links.Status.Type.ShouldBe("application/hal+json");
+        bankTransferPayment.Links.PayOnline.ShouldNotBeNull();
+        bankTransferPayment.Links.PayOnline.Href.ShouldBe("https://www.mollie.com/payscreen/select-method/WDqYK6vllg");
+        bankTransferPayment.Links.PayOnline.Type.ShouldBe("text/html");
     }
 
     [Fact]
@@ -390,17 +391,17 @@ public class PaymentClientTests : BaseClientTests {
         var result = await paymentClient.GetPaymentAsync(paymentId);
 
         // Then
-        result.Should().BeOfType<BancontactPaymentResponse>();
+        result.ShouldBeOfType<BancontactPaymentResponse>();
         var banContactPayment = result as BancontactPaymentResponse;
-        banContactPayment.Details.CardNumber.Should().Be("1234567890123456");
-        banContactPayment.Details.QrCode.Should().NotBeNull();
-        banContactPayment.Details.QrCode.Height.Should().Be(5);
-        banContactPayment.Details.QrCode.Width.Should().Be(10);
-        banContactPayment.Details.QrCode.Src.Should().Be("https://www.mollie.com/qr/12345678.png");
-        banContactPayment.Details.ConsumerName.Should().Be("consumer-name");
-        banContactPayment.Details.ConsumerAccount.Should().Be("consumer-account");
-        banContactPayment.Details.ConsumerBic.Should().Be("consumer-bic");
-        banContactPayment.Details.FailureReason.Should().Be("failure-reason");
+        banContactPayment.Details.CardNumber.ShouldBe("1234567890123456");
+        banContactPayment.Details.QrCode.ShouldNotBeNull();
+        banContactPayment.Details.QrCode.Height.ShouldBe(5);
+        banContactPayment.Details.QrCode.Width.ShouldBe(10);
+        banContactPayment.Details.QrCode.Src.ShouldBe("https://www.mollie.com/qr/12345678.png");
+        banContactPayment.Details.ConsumerName.ShouldBe("consumer-name");
+        banContactPayment.Details.ConsumerAccount.ShouldBe("consumer-account");
+        banContactPayment.Details.ConsumerBic.ShouldBe("consumer-bic");
+        banContactPayment.Details.FailureReason.ShouldBe("failure-reason");
     }
 
     [Fact]
@@ -470,21 +471,21 @@ public class PaymentClientTests : BaseClientTests {
         // Then
         mockHttp.VerifyNoOutstandingExpectation();
         var specificPaymentResponse = result as SepaDirectDebitResponse;
-        specificPaymentResponse.Should().NotBeNull();
-        specificPaymentResponse.Details.ConsumerName.Should().Be("consumer-name");
-        specificPaymentResponse.Details.ConsumerAccount.Should().Be("consumer-account");
-        specificPaymentResponse.Details.ConsumerBic.Should().Be("consumer-bic");
-        specificPaymentResponse.Details.TransferReference.Should().Be("transfer-reference");
-        specificPaymentResponse.Details.BankReasonCode.Should().Be("bank-reason-code");
-        specificPaymentResponse.Details.BankReason.Should().Be("bank-reason");
-        specificPaymentResponse.Details.BatchReference.Should().Be("batch-reference");
-        specificPaymentResponse.Details.MandateReference.Should().Be("mandate-reference");
-        specificPaymentResponse.Details.CreditorIdentifier.Should().Be("creditor-identifier");
-        specificPaymentResponse.Details.DueDate.Should().Be("03/20/2018 00:00:00");
-        specificPaymentResponse.Details.SignatureDate.Should().Be("03/20/2018 00:00:00");
-        specificPaymentResponse.Details.EndToEndIdentifier.Should().Be("end-to-end-identifier");
-        specificPaymentResponse.Details.BatchReference.Should().Be("batch-reference");
-        specificPaymentResponse.Details.FileReference.Should().Be("file-reference");
+        specificPaymentResponse.ShouldNotBeNull();
+        specificPaymentResponse.Details.ConsumerName.ShouldBe("consumer-name");
+        specificPaymentResponse.Details.ConsumerAccount.ShouldBe("consumer-account");
+        specificPaymentResponse.Details.ConsumerBic.ShouldBe("consumer-bic");
+        specificPaymentResponse.Details.TransferReference.ShouldBe("transfer-reference");
+        specificPaymentResponse.Details.BankReasonCode.ShouldBe("bank-reason-code");
+        specificPaymentResponse.Details.BankReason.ShouldBe("bank-reason");
+        specificPaymentResponse.Details.BatchReference.ShouldBe("batch-reference");
+        specificPaymentResponse.Details.MandateReference.ShouldBe("mandate-reference");
+        specificPaymentResponse.Details.CreditorIdentifier.ShouldBe("creditor-identifier");
+        specificPaymentResponse.Details.DueDate.ShouldBe("03/20/2018 00:00:00");
+        specificPaymentResponse.Details.SignatureDate.ShouldBe("03/20/2018 00:00:00");
+        specificPaymentResponse.Details.EndToEndIdentifier.ShouldBe("end-to-end-identifier");
+        specificPaymentResponse.Details.BatchReference.ShouldBe("batch-reference");
+        specificPaymentResponse.Details.FileReference.ShouldBe("file-reference");
     }
 
     [Fact]
@@ -533,23 +534,23 @@ public class PaymentClientTests : BaseClientTests {
         var result = await paymentClient.GetPaymentAsync(paymentId);
 
         // Then
-        result.Should().BeOfType<PayPalPaymentResponse>();
+        result.ShouldBeOfType<PayPalPaymentResponse>();
         var payPalPayment = result as PayPalPaymentResponse;
-        payPalPayment.Details.ConsumerName.Should().Be("consumer-name");
-        payPalPayment.Details.ConsumerAccount.Should().Be("consumer-account");
-        payPalPayment.Details.PayPalReference.Should().Be("paypal-ref");
-        payPalPayment.Details.PaypalPayerId.Should().Be("paypal-payer-id");
-        payPalPayment.Details.SellerProtection.Should().Be("Eligible");
-        payPalPayment.Details.ShippingAddress.Should().NotBeNull();
-        payPalPayment.Details.ShippingAddress.StreetAndNumber.Should().Be("street-and-number");
-        payPalPayment.Details.ShippingAddress.StreetAdditional.Should().Be("street-additional");
-        payPalPayment.Details.ShippingAddress.PostalCode.Should().Be("postal-code");
-        payPalPayment.Details.ShippingAddress.City.Should().Be("city");
-        payPalPayment.Details.ShippingAddress.Region.Should().Be("region");
-        payPalPayment.Details.ShippingAddress.Country.Should().Be("country");
-        payPalPayment.Details.PaypalFee.Should().NotBeNull();
-        payPalPayment.Details.PaypalFee.Currency.Should().Be("EUR");
-        payPalPayment.Details.PaypalFee.Value.Should().Be("100.00");
+        payPalPayment.Details.ConsumerName.ShouldBe("consumer-name");
+        payPalPayment.Details.ConsumerAccount.ShouldBe("consumer-account");
+        payPalPayment.Details.PayPalReference.ShouldBe("paypal-ref");
+        payPalPayment.Details.PaypalPayerId.ShouldBe("paypal-payer-id");
+        payPalPayment.Details.SellerProtection.ShouldBe("Eligible");
+        payPalPayment.Details.ShippingAddress.ShouldNotBeNull();
+        payPalPayment.Details.ShippingAddress.StreetAndNumber.ShouldBe("street-and-number");
+        payPalPayment.Details.ShippingAddress.StreetAdditional.ShouldBe("street-additional");
+        payPalPayment.Details.ShippingAddress.PostalCode.ShouldBe("postal-code");
+        payPalPayment.Details.ShippingAddress.City.ShouldBe("city");
+        payPalPayment.Details.ShippingAddress.Region.ShouldBe("region");
+        payPalPayment.Details.ShippingAddress.Country.ShouldBe("country");
+        payPalPayment.Details.PaypalFee.ShouldNotBeNull();
+        payPalPayment.Details.PaypalFee.Currency.ShouldBe("EUR");
+        payPalPayment.Details.PaypalFee.Value.ShouldBe("100.00");
     }
 
     [Fact]
@@ -644,18 +645,18 @@ public class PaymentClientTests : BaseClientTests {
         // Then
         mockHttp.VerifyNoOutstandingExpectation();
         var specificPaymentResponse = result as CreditCardPaymentResponse;
-        specificPaymentResponse.Should().NotBeNull();
-        specificPaymentResponse.Details.CardNumber.Should().Be("1234567890123456");
-        specificPaymentResponse.Details.CardHolder.Should().Be("John Doe");
-        specificPaymentResponse.Details.CardFingerprint.Should().Be("fingerprint");
-        specificPaymentResponse.Details.CardAudience.Should().Be("audience");
-        specificPaymentResponse.Details.CardLabel.Should().Be("American Express");
-        specificPaymentResponse.Details.CardCountryCode.Should().Be("NL");
-        specificPaymentResponse.Details.CardSecurity.Should().Be("security");
-        specificPaymentResponse.Details.FeeRegion.Should().Be("american-express");
-        specificPaymentResponse.Details.FailureReason.Should().Be("unknown_reason");
-        specificPaymentResponse.Details.FailureMessage.Should().Be("faulure-message");
-        specificPaymentResponse.Details.Wallet.Should().Be("applepay");
+        specificPaymentResponse.ShouldNotBeNull();
+        specificPaymentResponse.Details.CardNumber.ShouldBe("1234567890123456");
+        specificPaymentResponse.Details.CardHolder.ShouldBe("John Doe");
+        specificPaymentResponse.Details.CardFingerprint.ShouldBe("fingerprint");
+        specificPaymentResponse.Details.CardAudience.ShouldBe("audience");
+        specificPaymentResponse.Details.CardLabel.ShouldBe("American Express");
+        specificPaymentResponse.Details.CardCountryCode.ShouldBe("NL");
+        specificPaymentResponse.Details.CardSecurity.ShouldBe("security");
+        specificPaymentResponse.Details.FeeRegion.ShouldBe("american-express");
+        specificPaymentResponse.Details.FailureReason.ShouldBe("unknown_reason");
+        specificPaymentResponse.Details.FailureMessage.ShouldBe("faulure-message");
+        specificPaymentResponse.Details.Wallet.ShouldBe("applepay");
     }
 
     [Fact]
@@ -729,19 +730,19 @@ public class PaymentClientTests : BaseClientTests {
         // Then
         mockHttp.VerifyNoOutstandingExpectation();
         var specificPaymentResponse = result as GiftcardPaymentResponse;
-        specificPaymentResponse.Should().NotBeNull();
-        specificPaymentResponse.Details.VoucherNumber.Should().Be("voucher-number");
-        specificPaymentResponse.Details.Giftcards.Should().NotBeNull();
-        specificPaymentResponse.Details.Giftcards.Count.Should().Be(1);
-        specificPaymentResponse.Details.Giftcards[0].Issuer.Should().Be("issuer");
-        specificPaymentResponse.Details.Giftcards[0].Amount.Should().NotBeNull();
-        specificPaymentResponse.Details.Giftcards[0].Amount.Currency.Should().Be("EUR");
-        specificPaymentResponse.Details.Giftcards[0].Amount.Value.Should().Be("100.00");
-        specificPaymentResponse.Details.Giftcards[0].VoucherNumber.Should().Be("voucher-number");
-        specificPaymentResponse.Details.RemainderAmount.Should().NotBeNull();
-        specificPaymentResponse.Details.RemainderAmount.Currency.Should().Be("EUR");
-        specificPaymentResponse.Details.RemainderAmount.Value.Should().Be("100.00");
-        specificPaymentResponse.Details.RemainderMethod.Should().Be("ideal");
+        specificPaymentResponse.ShouldNotBeNull();
+        specificPaymentResponse.Details.VoucherNumber.ShouldBe("voucher-number");
+        specificPaymentResponse.Details.Giftcards.ShouldNotBeNull();
+        specificPaymentResponse.Details.Giftcards.Count.ShouldBe(1);
+        specificPaymentResponse.Details.Giftcards[0].Issuer.ShouldBe("issuer");
+        specificPaymentResponse.Details.Giftcards[0].Amount.ShouldNotBeNull();
+        specificPaymentResponse.Details.Giftcards[0].Amount.Currency.ShouldBe("EUR");
+        specificPaymentResponse.Details.Giftcards[0].Amount.Value.ShouldBe("100.00");
+        specificPaymentResponse.Details.Giftcards[0].VoucherNumber.ShouldBe("voucher-number");
+        specificPaymentResponse.Details.RemainderAmount.ShouldNotBeNull();
+        specificPaymentResponse.Details.RemainderAmount.Currency.ShouldBe("EUR");
+        specificPaymentResponse.Details.RemainderAmount.Value.ShouldBe("100.00");
+        specificPaymentResponse.Details.RemainderMethod.ShouldBe("ideal");
     }
 
     [Fact]
@@ -775,11 +776,11 @@ public class PaymentClientTests : BaseClientTests {
         var result = await paymentClient.GetPaymentAsync(paymentId);
 
         // Then
-        result.Should().BeOfType<BelfiusPaymentResponse>();
+        result.ShouldBeOfType<BelfiusPaymentResponse>();
         var belfiusPayment = result as BelfiusPaymentResponse;
-        belfiusPayment!.Details.ConsumerName.Should().Be("consumer-name");
-        belfiusPayment.Details.ConsumerAccount.Should().Be("consumer-account");
-        belfiusPayment.Details.ConsumerBic.Should().Be("consumer-bic");
+        belfiusPayment!.Details.ConsumerName.ShouldBe("consumer-name");
+        belfiusPayment.Details.ConsumerAccount.ShouldBe("consumer-account");
+        belfiusPayment.Details.ConsumerBic.ShouldBe("consumer-bic");
     }
 
     [Fact]
@@ -814,11 +815,11 @@ public class PaymentClientTests : BaseClientTests {
         var result = await paymentClient.GetPaymentAsync(paymentId);
 
         // Then
-        result.Should().BeOfType<IngHomePayPaymentResponse>();
+        result.ShouldBeOfType<IngHomePayPaymentResponse>();
         var ingHomePayPayment = result as IngHomePayPaymentResponse;
-        ingHomePayPayment!.Details.ConsumerName.Should().Be("consumer-name");
-        ingHomePayPayment.Details.ConsumerAccount.Should().Be("consumer-account");
-        ingHomePayPayment.Details.ConsumerBic.Should().Be("consumer-bic");
+        ingHomePayPayment!.Details.ConsumerName.ShouldBe("consumer-name");
+        ingHomePayPayment.Details.ConsumerAccount.ShouldBe("consumer-account");
+        ingHomePayPayment.Details.ConsumerBic.ShouldBe("consumer-bic");
     }
 
     [Fact]
@@ -853,11 +854,11 @@ public class PaymentClientTests : BaseClientTests {
         var result = await paymentClient.GetPaymentAsync(paymentId);
 
         // Then
-        result.Should().BeOfType<KbcPaymentResponse>();
+        result.ShouldBeOfType<KbcPaymentResponse>();
         var kbcPayment = result as KbcPaymentResponse;
-        kbcPayment!.Details.ConsumerName.Should().Be("consumer-name");
-        kbcPayment.Details.ConsumerAccount.Should().Be("consumer-account");
-        kbcPayment.Details.ConsumerBic.Should().Be("consumer-bic");
+        kbcPayment!.Details.ConsumerName.ShouldBe("consumer-name");
+        kbcPayment.Details.ConsumerAccount.ShouldBe("consumer-account");
+        kbcPayment.Details.ConsumerBic.ShouldBe("consumer-bic");
     }
 
     [Fact]
@@ -919,13 +920,13 @@ public class PaymentClientTests : BaseClientTests {
         // Then
         mockHttp.VerifyNoOutstandingExpectation();
         var specificPaymentResponse = result as IdealPaymentResponse;
-        specificPaymentResponse!.Details.ConsumerName.Should().Be("consumer-name");
-        specificPaymentResponse.Details.ConsumerAccount.Should().Be("consumer-account");
-        specificPaymentResponse.Details.ConsumerBic.Should().Be("consumer-bic");
-        specificPaymentResponse.Details.QrCode.Should().NotBeNull();
-        specificPaymentResponse.Details.QrCode.Height.Should().Be(5);
-        specificPaymentResponse.Details.QrCode.Width.Should().Be(10);
-        specificPaymentResponse.Details.QrCode.Src.Should().Be("https://www.mollie.com/qr/12345678.png");
+        specificPaymentResponse!.Details.ConsumerName.ShouldBe("consumer-name");
+        specificPaymentResponse.Details.ConsumerAccount.ShouldBe("consumer-account");
+        specificPaymentResponse.Details.ConsumerBic.ShouldBe("consumer-bic");
+        specificPaymentResponse.Details.QrCode.ShouldNotBeNull();
+        specificPaymentResponse.Details.QrCode.Height.ShouldBe(5);
+        specificPaymentResponse.Details.QrCode.Width.ShouldBe(10);
+        specificPaymentResponse.Details.QrCode.Src.ShouldBe("https://www.mollie.com/qr/12345678.png");
     }
 
     [Fact]
@@ -960,11 +961,11 @@ public class PaymentClientTests : BaseClientTests {
         var result = await paymentClient.GetPaymentAsync(paymentId);
 
         // Then
-        result.Should().BeOfType<SofortPaymentResponse>();
+        result.ShouldBeOfType<SofortPaymentResponse>();
         var sofortPayment = result as SofortPaymentResponse;
-        sofortPayment!.Details.ConsumerName.Should().Be("consumer-name");
-        sofortPayment.Details.ConsumerAccount.Should().Be("consumer-account");
-        sofortPayment.Details.ConsumerBic.Should().Be("consumer-bic");
+        sofortPayment!.Details.ConsumerName.ShouldBe("consumer-name");
+        sofortPayment.Details.ConsumerAccount.ShouldBe("consumer-account");
+        sofortPayment.Details.ConsumerBic.ShouldBe("consumer-bic");
     }
 
     [Theory]
@@ -981,7 +982,7 @@ public class PaymentClientTests : BaseClientTests {
         var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await paymentClient.GetPaymentAsync(paymentId));
 
         // Then
-        exception.Message.Should().Be("Required URL argument 'paymentId' is null or empty");
+        exception.Message.ShouldBe("Required URL argument 'paymentId' is null or empty");
     }
 
     [Fact]
@@ -1016,12 +1017,12 @@ public class PaymentClientTests : BaseClientTests {
 
         // Then
         mockHttp.VerifyNoOutstandingExpectation();
-        result.Should().BeOfType<IdealPaymentResponse>();
+        result.ShouldBeOfType<IdealPaymentResponse>();
         var paymentResponse = result as IdealPaymentResponse;
-        paymentResponse.Details.QrCode.Should().NotBeNull();
-        paymentResponse.Details.QrCode.Height.Should().Be(5);
-        paymentResponse.Details.QrCode.Width.Should().Be(5);
-        paymentResponse.Details.QrCode.Src.Should().Be("https://www.mollie.com/qr/12345678.png");
+        paymentResponse.Details.QrCode.ShouldNotBeNull();
+        paymentResponse.Details.QrCode.Height.ShouldBe(5);
+        paymentResponse.Details.QrCode.Width.ShouldBe(5);
+        paymentResponse.Details.QrCode.Src.ShouldBe("https://www.mollie.com/qr/12345678.png");
     }
 
     [Fact]
@@ -1163,7 +1164,7 @@ public class PaymentClientTests : BaseClientTests {
         var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await paymentClient.CancelPaymentAsync(paymentId));
 
         // Then
-        exception.Message.Should().Be("Required URL argument 'paymentId' is null or empty");
+        exception.Message.ShouldBe("Required URL argument 'paymentId' is null or empty");
     }
 
     [Theory]
@@ -1180,22 +1181,22 @@ public class PaymentClientTests : BaseClientTests {
         var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await paymentClient.UpdatePaymentAsync(paymentId, new PaymentUpdateRequest()));
 
         // Then
-        exception.Message.Should().Be("Required URL argument 'paymentId' is null or empty");
+        exception.Message.ShouldBe("Required URL argument 'paymentId' is null or empty");
     }
 
     private void AssertPaymentIsEqual(PaymentRequest paymentRequest, PaymentResponse paymentResponse) {
-        paymentResponse.Amount.Value.Should().Be(paymentRequest.Amount.Value);
-        paymentResponse.Amount.Currency.Should().Be(paymentRequest.Amount.Currency);
-        paymentResponse.Description.Should().Be(paymentRequest.Description);
+        paymentResponse.Amount.Value.ShouldBe(paymentRequest.Amount.Value);
+        paymentResponse.Amount.Currency.ShouldBe(paymentRequest.Amount.Currency);
+        paymentResponse.Description.ShouldBe(paymentRequest.Description);
         if (paymentRequest.Routings != null) {
-            paymentResponse.Routings.Count.Should().Be(paymentRequest.Routings.Count);
+            paymentResponse.Routings.Count.ShouldBe(paymentRequest.Routings.Count);
             for (int i = 0; i < paymentRequest.Routings.Count; i++) {
                 var paymentRequestRouting = paymentRequest.Routings[i];
                 var paymentResponseRouting = paymentResponse.Routings[i];
-                paymentResponseRouting.Amount.Should().Be(paymentRequestRouting.Amount);
-                paymentResponseRouting.Destination.Type.Should().Be(paymentRequestRouting.Destination.Type);
-                paymentResponseRouting.Destination.OrganizationId.Should().Be(paymentRequestRouting.Destination.OrganizationId);
-                paymentResponseRouting.ReleaseDate.Should().Be(paymentRequestRouting.ReleaseDate);
+                paymentResponseRouting.Amount.ShouldBe(paymentRequestRouting.Amount);
+                paymentResponseRouting.Destination.Type.ShouldBe(paymentRequestRouting.Destination.Type);
+                paymentResponseRouting.Destination.OrganizationId.ShouldBe(paymentRequestRouting.Destination.OrganizationId);
+                paymentResponseRouting.ReleaseDate.ShouldBe(paymentRequestRouting.ReleaseDate);
             }
         }
     }

--- a/tests/Mollie.Tests.Unit/Client/PaymentLinkClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/PaymentLinkClientTests.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Models;
 using Mollie.Api.Models.List.Response;
@@ -12,6 +12,8 @@ using Mollie.Api.Models.PaymentLink.Request;
 using Mollie.Api.Models.PaymentLink.Response;
 using RichardSzalay.MockHttp;
 using Xunit;
+
+using SortDirection = Mollie.Api.Models.SortDirection;
 
 namespace Mollie.Tests.Unit.Client {
     public class PaymentLinkClientTests : BaseClientTests {
@@ -75,7 +77,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await paymentLinkClient.GetPaymentLinkAsync(paymentLinkId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'paymentLinkId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'paymentLinkId' is null or empty");
         }
 
         [Theory]
@@ -121,22 +123,22 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingRequest();
-            result.Should().NotBeNull();
-            result.Count.Should().Be(1);
+            result.ShouldNotBeNull();
+            result.Count.ShouldBe(1);
             PaymentResponse payment = result.Items.Single();
-            payment.Id.Should().Be("tr_7UhSN1zuXS");
-            payment.Amount.Value.Should().Be(DefaultPaymentAmount.ToString(CultureInfo.InvariantCulture));
-            payment.Description.Should().Be(DefaultDescription);
-            payment.RedirectUrl.Should().Be(DefaultRedirectUrl);
-            payment.WebhookUrl.Should().Be(DefaultWebhookUrl);
+            payment.Id.ShouldBe("tr_7UhSN1zuXS");
+            payment.Amount.Value.ShouldBe(DefaultPaymentAmount.ToString(CultureInfo.InvariantCulture));
+            payment.Description.ShouldBe(DefaultDescription);
+            payment.RedirectUrl.ShouldBe(DefaultRedirectUrl);
+            payment.WebhookUrl.ShouldBe(DefaultWebhookUrl);
         }
 
         private void VerifyPaymentLinkResponse(PaymentLinkResponse response) {
-            response.Amount.Value.Should().Be(DefaultPaymentAmount.ToString(CultureInfo.InvariantCulture));
-            response.Description.Should().Be(DefaultDescription);
-            response.Id.Should().Be(DefaultPaymentLinkId);
-            response.RedirectUrl.Should().Be(DefaultRedirectUrl);
-            response.WebhookUrl.Should().Be(DefaultWebhookUrl);
+            response.Amount.Value.ShouldBe(DefaultPaymentAmount.ToString(CultureInfo.InvariantCulture));
+            response.Description.ShouldBe(DefaultDescription);
+            response.Id.ShouldBe(DefaultPaymentLinkId);
+            response.RedirectUrl.ShouldBe(DefaultRedirectUrl);
+            response.WebhookUrl.ShouldBe(DefaultWebhookUrl);
         }
 
         private readonly string _defaultPaymentLinkPaymentsJsonResponse = $@"{{

--- a/tests/Mollie.Tests.Unit/Client/PaymentMethodClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/PaymentMethodClientTests.cs
@@ -3,7 +3,7 @@ using Mollie.Api.Client;
 using Mollie.Api.Models;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using RichardSzalay.MockHttp;
 using Xunit;
 
@@ -94,7 +94,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await paymentMethodClient.GetPaymentMethodAsync(paymentLinkId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'paymentMethod' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'paymentMethod' is null or empty");
         }
     }
 }

--- a/tests/Mollie.Tests.Unit/Client/PermissionClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/PermissionClientTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using RichardSzalay.MockHttp;
 using Xunit;
@@ -27,15 +27,15 @@ public class PermissionClientTests : BaseClientTests
 
         // Assert
         mockHttp.VerifyNoOutstandingExpectation();
-        response.Resource.Should().Be("permission");
-        response.Id.Should().Be("payments.read");
-        response.Description.Should().Be("View your payments");
-        response.Granted.Should().BeTrue();
-        response.Links.Should().NotBeNull();
-        response.Links.Self.Href.Should().Be("https://api.mollie.com/v2/permissions/payments.read");
-        response.Links.Self.Type.Should().Be("application/hal+json");
-        response.Links.Documentation.Href.Should().Be("https://docs.mollie.com/reference/v2/permissions-api/get-permission");
-        response.Links.Documentation.Type.Should().Be("text/html");
+        response.Resource.ShouldBe("permission");
+        response.Id.ShouldBe("payments.read");
+        response.Description.ShouldBe("View your payments");
+        response.Granted.ShouldBeTrue();
+        response.Links.ShouldNotBeNull();
+        response.Links.Self.Href.ShouldBe("https://api.mollie.com/v2/permissions/payments.read");
+        response.Links.Self.Type.ShouldBe("application/hal+json");
+        response.Links.Documentation.Href.ShouldBe("https://docs.mollie.com/reference/v2/permissions-api/get-permission");
+        response.Links.Documentation.Type.ShouldBe("text/html");
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public class PermissionClientTests : BaseClientTests
         var exception = await Assert.ThrowsAsync<ArgumentException>(() => permissionClient.GetPermissionAsync(string.Empty));
 
         // Assert
-        exception.Message.Should().Be($"Required URL argument 'permissionId' is null or empty");
+        exception.Message.ShouldBe($"Required URL argument 'permissionId' is null or empty");
     }
 
     [Fact]
@@ -69,31 +69,28 @@ public class PermissionClientTests : BaseClientTests
 
         // Assert
         mockHttp.VerifyNoOutstandingExpectation();
-        response.Count.Should().Be(2);
-        response.Should().NotBeNull();
-        response.Items.Should().HaveCount(2);
-        response.Items[0].Resource.Should().Be("permission");
-        response.Items[0].Id.Should().Be("payments.write");
-        response.Items[0].Description.Should().Be("Create new payments");
-        response.Items[0].Granted.Should().BeFalse();
-        response.Items[0].Links.Should().NotBeNull();
-        response.Items[0].Links.Self.Href.Should()
-            .Be("https://api.mollie.com/v2/permissions/payments.write");
-        response.Items[0].Links.Self.Type.Should().Be("application/hal+json");
-        response.Items[1].Resource.Should().Be("permission");
-        response.Items[1].Id.Should().Be("payments.read");
-        response.Items[1].Description.Should().Be("View your payments");
-        response.Items[1].Granted.Should().BeTrue();
-        response.Items[1].Links.Should().NotBeNull();
-        response.Items[1].Links.Self.Href.Should()
-            .Be("https://api.mollie.com/v2/permissions/payments.read");
-        response.Items[1].Links.Self.Type.Should().Be("application/hal+json");
-        response.Links.Should().NotBeNull();
-        response.Links.Self.Href.Should().Be("https://api.mollie.com/v2/permissions");
-        response.Links.Self.Type.Should().Be("application/hal+json");
-        response.Links.Documentation.Href.Should()
-            .Be("https://docs.mollie.com/reference/v2/permissions-api/list-permissions");
-        response.Links.Documentation.Type.Should().Be("text/html");
+        response.Count.ShouldBe(2);
+        response.ShouldNotBeNull();
+        response.Items.Count.ShouldBe(2);
+        response.Items[0].Resource.ShouldBe("permission");
+        response.Items[0].Id.ShouldBe("payments.write");
+        response.Items[0].Description.ShouldBe("Create new payments");
+        response.Items[0].Granted.ShouldBeFalse();
+        response.Items[0].Links.ShouldNotBeNull();
+        response.Items[0].Links.Self.Href.ShouldBe("https://api.mollie.com/v2/permissions/payments.write");
+        response.Items[0].Links.Self.Type.ShouldBe("application/hal+json");
+        response.Items[1].Resource.ShouldBe("permission");
+        response.Items[1].Id.ShouldBe("payments.read");
+        response.Items[1].Description.ShouldBe("View your payments");
+        response.Items[1].Granted.ShouldBeTrue();
+        response.Items[1].Links.ShouldNotBeNull();
+        response.Items[1].Links.Self.Href.ShouldBe("https://api.mollie.com/v2/permissions/payments.read");
+        response.Items[1].Links.Self.Type.ShouldBe("application/hal+json");
+        response.Links.ShouldNotBeNull();
+        response.Links.Self.Href.ShouldBe("https://api.mollie.com/v2/permissions");
+        response.Links.Self.Type.ShouldBe("application/hal+json");
+        response.Links.Documentation.Href.ShouldBe("https://docs.mollie.com/reference/v2/permissions-api/list-permissions");
+        response.Links.Documentation.Type.ShouldBe("text/html");
     }
 
     private const string defaultGetPermissionResponse = @"{

--- a/tests/Mollie.Tests.Unit/Client/ProfileClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/ProfileClientTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Models;
 using Mollie.Api.Models.Payment;
@@ -21,14 +21,14 @@ public class ProfileClientTests : BaseClientTests
     public async Task CreateProfileAsync_WithRequiredParameters_ResponseIsDeserializedInExpectedFormat()
     {
         // Arrange
-        ProfileRequest profileRequest = new ProfileRequest() {
+        ProfileRequest profileRequest = new() {
             Name = "My website name",
             Email = "info@mywebsite.com",
             Mode = Mode.Test,
             Phone = "+31208202070",
             Website = "https://www.mywebsite.com",
             Description = "Description",
-            CountriesOfActivity = new List<string>() { "NL" },
+            CountriesOfActivity = ["NL"],
             BusinessCategory = "OTHER_MERCHANDISE"
         };
         var mockHttp = new MockHttpMessageHandler();
@@ -44,8 +44,8 @@ public class ProfileClientTests : BaseClientTests
         // Assert
         mockHttp.VerifyNoOutstandingRequest();
         AssertDefaultProfileResponse(result);
-        result.Description.Should().Be(profileRequest.Description);
-        result.CountriesOfActivity.Should().Equal(profileRequest.CountriesOfActivity);
+        result.Description.ShouldBe(profileRequest.Description);
+        result.CountriesOfActivity.ShouldBe(profileRequest.CountriesOfActivity);
     }
 
     [Fact]
@@ -103,36 +103,36 @@ public class ProfileClientTests : BaseClientTests
 
         // Assert
         mockHttp.VerifyNoOutstandingRequest();
-        result.Count.Should().Be(1);
+        result.Count.ShouldBe(1);
         var profile = result.Items[0];
-        profile.Resource.Should().Be("profiles");
-        profile.Id.Should().Be("pfl_v9hTwCvYqw");
-        profile.Mode.Should().Be(Mode.Live);
-        profile.Name.Should().Be("My website name");
-        profile.Email.Should().Be("info@mywebsite.com");
-        profile.Website.Should().Be("https://www.mywebsite.com");
-        profile.Phone.Should().Be("+31208202070");
-        profile.BusinessCategory.Should().Be("OTHER_MERCHANDISE");
-        profile.Status.Should().Be(ProfileStatus.Verified);
-        profile.Review.Status.Should().Be(ReviewStatus.Pending);
-        profile.CreatedAt.Should().Be(DateTime.Parse("2018-03-20T09:28:37+00:00"));
-        profile.Links.Should().NotBeNull();
-        profile.Links.Self.Href.Should().Be("https://api.mollie.com/v2/profiles/pfl_v9hTwCvYqw");
-        profile.Links.Self.Type.Should().Be("application/hal+json");
-        profile.Links.Dashboard.Href.Should().Be("https://www.mollie.com/dashboard/org_123456789/settings/profiles/pfl_v9hTwCvYqw");
-        profile.Links.Dashboard.Type.Should().Be("text/html");
-        profile.Links.Chargebacks.Href.Should().Be("https://api.mollie.com/v2/chargebacks?profileId=pfl_v9hTwCvYqw");
-        profile.Links.Chargebacks.Type.Should().Be("application/hal+json");
-        profile.Links.Methods.Href.Should().Be("https://api.mollie.com/v2/methods?profileId=pfl_v9hTwCvYqw");
-        profile.Links.Methods.Type.Should().Be("application/hal+json");
-        profile.Links.Payments.Href.Should().Be("https://api.mollie.com/v2/payments?profileId=pfl_v9hTwCvYqw");
-        profile.Links.Payments.Type.Should().Be("application/hal+json");
-        profile.Links.Refunds.Href.Should().Be("https://api.mollie.com/v2/refunds?profileId=pfl_v9hTwCvYqw");
-        profile.Links.Refunds.Type.Should().Be("application/hal+json");
-        profile.Links.CheckoutPreviewUrl.Href.Should().Be("https://www.mollie.com/payscreen/preview/pfl_v9hTwCvYqw");
-        profile.Links.CheckoutPreviewUrl.Type.Should().Be("text/html");
-        profile.Links.Documentation.Href.Should().Be("https://docs.mollie.com/reference/v2/profiles-api/create-profile");
-        profile.Links.Documentation.Type.Should().Be("text/html");
+        profile.Resource.ShouldBe("profiles");
+        profile.Id.ShouldBe("pfl_v9hTwCvYqw");
+        profile.Mode.ShouldBe(Mode.Live);
+        profile.Name.ShouldBe("My website name");
+        profile.Email.ShouldBe("info@mywebsite.com");
+        profile.Website.ShouldBe("https://www.mywebsite.com");
+        profile.Phone.ShouldBe("+31208202070");
+        profile.BusinessCategory.ShouldBe("OTHER_MERCHANDISE");
+        profile.Status.ShouldBe(ProfileStatus.Verified);
+        profile.Review.Status.ShouldBe(ReviewStatus.Pending);
+        profile.CreatedAt.ShouldBe(DateTime.Parse("2018-03-20T09:28:37+00:00"));
+        profile.Links.ShouldNotBeNull();
+        profile.Links.Self.Href.ShouldBe("https://api.mollie.com/v2/profiles/pfl_v9hTwCvYqw");
+        profile.Links.Self.Type.ShouldBe("application/hal+json");
+        profile.Links.Dashboard.Href.ShouldBe("https://www.mollie.com/dashboard/org_123456789/settings/profiles/pfl_v9hTwCvYqw");
+        profile.Links.Dashboard.Type.ShouldBe("text/html");
+        profile.Links.Chargebacks.Href.ShouldBe("https://api.mollie.com/v2/chargebacks?profileId=pfl_v9hTwCvYqw");
+        profile.Links.Chargebacks.Type.ShouldBe("application/hal+json");
+        profile.Links.Methods.Href.ShouldBe("https://api.mollie.com/v2/methods?profileId=pfl_v9hTwCvYqw");
+        profile.Links.Methods.Type.ShouldBe("application/hal+json");
+        profile.Links.Payments.Href.ShouldBe("https://api.mollie.com/v2/payments?profileId=pfl_v9hTwCvYqw");
+        profile.Links.Payments.Type.ShouldBe("application/hal+json");
+        profile.Links.Refunds.Href.ShouldBe("https://api.mollie.com/v2/refunds?profileId=pfl_v9hTwCvYqw");
+        profile.Links.Refunds.Type.ShouldBe("application/hal+json");
+        profile.Links.CheckoutPreviewUrl.Href.ShouldBe("https://www.mollie.com/payscreen/preview/pfl_v9hTwCvYqw");
+        profile.Links.CheckoutPreviewUrl.Type.ShouldBe("text/html");
+        profile.Links.Documentation.Href.ShouldBe("https://docs.mollie.com/reference/v2/profiles-api/create-profile");
+        profile.Links.Documentation.Type.ShouldBe("text/html");
     }
 
     [Fact]
@@ -184,7 +184,7 @@ public class ProfileClientTests : BaseClientTests
         var exception = await Assert.ThrowsAsync<ArgumentException>(() => profileClient.UpdateProfileAsync(profileId, profileRequest));
 
         // Assert
-        exception.Message.Should().Be($"Required URL argument '{nameof(profileId)}' is null or empty");
+        exception.Message.ShouldBe($"Required URL argument '{nameof(profileId)}' is null or empty");
     }
 
     [Fact]
@@ -204,8 +204,8 @@ public class ProfileClientTests : BaseClientTests
 
         // Assert
         mockHttp.VerifyNoOutstandingRequest();
-        result.Resource.Should().Be("method");
-        result.Id.Should().Be(paymentMethod);
+        result.Resource.ShouldBe("method");
+        result.Id.ShouldBe(paymentMethod);
     }
 
     [Fact]
@@ -220,7 +220,7 @@ public class ProfileClientTests : BaseClientTests
         var exception = await Assert.ThrowsAsync<ArgumentException>(() => profileClient.EnablePaymentMethodAsync(string.Empty));
 
         // Assert
-        exception.Message.Should().Be($"Required URL argument 'paymentMethod' is null or empty");
+        exception.Message.ShouldBe($"Required URL argument 'paymentMethod' is null or empty");
     }
 
     [Fact]
@@ -254,7 +254,7 @@ public class ProfileClientTests : BaseClientTests
         var exception = await Assert.ThrowsAsync<ArgumentException>(() => profileClient.DisablePaymentMethodAsync(string.Empty));
 
         // Assert
-        exception.Message.Should().Be($"Required URL argument 'paymentMethod' is null or empty");
+        exception.Message.ShouldBe($"Required URL argument 'paymentMethod' is null or empty");
     }
 
     [Fact]
@@ -288,7 +288,7 @@ public class ProfileClientTests : BaseClientTests
         var exception = await Assert.ThrowsAsync<ArgumentException>(() => profileClient.DeleteProfileAsync(string.Empty));
 
         // Assert
-        exception.Message.Should().Be($"Required URL argument 'profileId' is null or empty");
+        exception.Message.ShouldBe($"Required URL argument 'profileId' is null or empty");
     }
 
     [Fact]
@@ -308,10 +308,10 @@ public class ProfileClientTests : BaseClientTests
 
         // Assert
         mockHttp.VerifyNoOutstandingRequest();
-        result.Resource.Should().Be("issuer");
-        result.Id.Should().Be(issuer);
-        result.Description.Should().Be("FestivalCadeau Giftcard");
-        result.Status.Should().Be("pending-issuer");
+        result.Resource.ShouldBe("issuer");
+        result.Id.ShouldBe(issuer);
+        result.Description.ShouldBe("FestivalCadeau Giftcard");
+        result.Status.ShouldBe("pending-issuer");
     }
 
     [Fact]
@@ -326,7 +326,7 @@ public class ProfileClientTests : BaseClientTests
         var exception = await Assert.ThrowsAsync<ArgumentException>(() => profileClient.EnableGiftCardIssuerAsync(string.Empty));
 
         // Assert
-        exception.Message.Should().Be($"Required URL argument 'issuer' is null or empty");
+        exception.Message.ShouldBe($"Required URL argument 'issuer' is null or empty");
     }
 
     [Fact]
@@ -360,20 +360,20 @@ public class ProfileClientTests : BaseClientTests
         var exception = await Assert.ThrowsAsync<ArgumentException>(() => profileClient.DisableGiftCardIssuerAsync(string.Empty));
 
         // Assert
-        exception.Message.Should().Be($"Required URL argument 'issuer' is null or empty");
+        exception.Message.ShouldBe($"Required URL argument 'issuer' is null or empty");
     }
 
     private void AssertDefaultProfileResponse(ProfileResponse result)
     {
-        result.Resource.Should().Be("profile");
-        result.Id.Should().Be("pfl_v9hTwCvYqw");
-        result.Mode.Should().Be(Mode.Test);
-        result.Name.Should().Be("My website name");
-        result.Email.Should().Be("info@mywebsite.com");
-        result.Website.Should().Be("https://www.mywebsite.com");
-        result.Phone.Should().Be("+31208202070");
-        result.BusinessCategory.Should().Be("OTHER_MERCHANDISE");
-        result.Status.Should().Be(ProfileStatus.Unverified);
+        result.Resource.ShouldBe("profile");
+        result.Id.ShouldBe("pfl_v9hTwCvYqw");
+        result.Mode.ShouldBe(Mode.Test);
+        result.Name.ShouldBe("My website name");
+        result.Email.ShouldBe("info@mywebsite.com");
+        result.Website.ShouldBe("https://www.mywebsite.com");
+        result.Phone.ShouldBe("+31208202070");
+        result.BusinessCategory.ShouldBe("OTHER_MERCHANDISE");
+        result.Status.ShouldBe(ProfileStatus.Unverified);
     }
 
     private const string defaultEnableGiftcardIssuerResponse = @"{

--- a/tests/Mollie.Tests.Unit/Client/RefundClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/RefundClientTests.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Mollie.Api.Client;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
-using FluentAssertions.Extensions;
+using Shouldly;
 using Mollie.Api.Models;
 using Mollie.Api.Models.Order.Request;
 using Mollie.Api.Models.Payment;
@@ -64,7 +64,7 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            refundResponse.Should().NotBeNull();
+            refundResponse.ShouldNotBeNull();
         }
 
         [Theory]
@@ -84,7 +84,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await refundClient.CreatePaymentRefundAsync(paymentId, refund));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'paymentId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'paymentId' is null or empty");
         }
 
         [Theory]
@@ -126,8 +126,8 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            refundResponse.ReverseRouting.Should().Be(reverseRouting);
-            refundResponse.RoutingReversals.Should().BeNull();
+            refundResponse.ReverseRouting.ShouldBe(reverseRouting);
+            refundResponse.RoutingReversals.ShouldBeNull();
         }
 
         [Fact]
@@ -186,8 +186,8 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            refundResponse.RoutingReversals.Should().BeEquivalentTo(refundRequest.RoutingReversals);
-            refundResponse.ReverseRouting.Should().BeNull();
+            refundResponse.RoutingReversals.ShouldBeEquivalentTo(refundRequest.RoutingReversals);
+            refundResponse.ReverseRouting.ShouldBeNull();
         }
 
         [Theory]
@@ -204,7 +204,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await refundClient.GetPaymentRefundListAsync(paymentId: paymentId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'paymentId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'paymentId' is null or empty");
         }
 
         [Theory]
@@ -221,7 +221,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await refundClient.GetPaymentRefundAsync(paymentId, "refund-id"));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'paymentId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'paymentId' is null or empty");
         }
 
         [Theory]
@@ -238,7 +238,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await refundClient.GetPaymentRefundAsync("payment-id", refundId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'refundId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'refundId' is null or empty");
         }
 
         [Theory]
@@ -255,7 +255,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await refundClient.CancelPaymentRefundAsync(paymentId, "refund-id"));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'paymentId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'paymentId' is null or empty");
         }
 
         [Theory]
@@ -272,7 +272,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await refundClient.CancelPaymentRefundAsync("payment-id", refundId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'refundId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'refundId' is null or empty");
         }
 
         [Theory]
@@ -323,14 +323,14 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            response.Resource.Should().Be("refund");
-            response.Id.Should().Be("re_4qqhO89gsT");
-            response.Description.Should().Be("description");
-            response.Status.Should().Be("pending");
-            response.CreatedAt!.Value.ToUniversalTime().Should().Be(DateTime.SpecifyKind(14.March(2018).At(17, 09, 02), DateTimeKind.Utc));
-            response.PaymentId.Should().Be("tr_WDqYK6vllg");
-            response.OrderId.Should().Be(orderId);
-            response.Lines.Should().HaveCount(1);
+            response.Resource.ShouldBe("refund");
+            response.Id.ShouldBe("re_4qqhO89gsT");
+            response.Description.ShouldBe("description");
+            response.Status.ShouldBe("pending");
+            response.CreatedAt!.Value.ToUniversalTime().ShouldBe(DateTime.SpecifyKind(new DateTime(2018, 3, 14, 17, 09, 02), DateTimeKind.Utc));
+            response.PaymentId.ShouldBe("tr_WDqYK6vllg");
+            response.OrderId.ShouldBe(orderId);
+            response.Lines.Count().ShouldBe(1);
         }
 
         [Theory]
@@ -351,7 +351,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await refundClient.CreateOrderRefundAsync(orderId, request));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'orderId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'orderId' is null or empty");
         }
 
         [Theory]
@@ -368,7 +368,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await refundClient.GetOrderRefundListAsync(orderId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'orderId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'orderId' is null or empty");
         }
 
         private const string defaultOrderJsonResponse = @"{

--- a/tests/Mollie.Tests.Unit/Client/SettlementClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/SettlementClientTests.cs
@@ -3,7 +3,7 @@ using Mollie.Api.Client;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Models.Capture.Response;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Settlement.Response;
@@ -25,29 +25,29 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then: Response should be parsed
             mockHttp.VerifyNoOutstandingExpectation();
-            listCaptureResponse.Should().NotBeNull();
-            listCaptureResponse.Count.Should().Be(1);
-            listCaptureResponse.Links.Self.Href.Should().Be("https://api.mollie.com/v2/settlements/stl_jDk30akdN/captures?limit=50");
-            listCaptureResponse.Links.Self.Type.Should().Be("application/hal+json");
-            listCaptureResponse.Links.Documentation.Href.Should().Be("https://docs.mollie.com/reference/v2/settlements-api/list-settlement-captures");
-            listCaptureResponse.Links.Documentation.Type.Should().Be("text/html");
+            listCaptureResponse.ShouldNotBeNull();
+            listCaptureResponse.Count.ShouldBe(1);
+            listCaptureResponse.Links.Self.Href.ShouldBe("https://api.mollie.com/v2/settlements/stl_jDk30akdN/captures?limit=50");
+            listCaptureResponse.Links.Self.Type.ShouldBe("application/hal+json");
+            listCaptureResponse.Links.Documentation.Href.ShouldBe("https://docs.mollie.com/reference/v2/settlements-api/list-settlement-captures");
+            listCaptureResponse.Links.Documentation.Type.ShouldBe("text/html");
             CaptureResponse captureResponse = listCaptureResponse.Items.First();
-            captureResponse.PaymentId.Should().Be(defaultPaymentId);
-            captureResponse.ShipmentId.Should().Be(defaultShipmentId);
-            captureResponse.SettlementId.Should().Be(defaultSettlementId);
-            captureResponse.Amount.Value.Should().Be(defaultAmountValue);
-            captureResponse.Amount.Currency.Should().Be(defaultAmountCurrency);
-            captureResponse.Links.Should().NotBeNull();
-            captureResponse.Links.Self.Href.Should().Be($"https://api.mollie.com/v2/payments/{defaultPaymentId}/captures/cpt_4qqhO89gsT");
-            captureResponse.Links.Self.Type.Should().Be("application/hal+json");
-            captureResponse.Links.Payment.Href.Should().Be($"https://api.mollie.com/v2/payments/{defaultPaymentId}");
-            captureResponse.Links.Payment.Type.Should().Be("application/hal+json");
-            captureResponse.Links.Shipment.Href.Should().Be($"https://api.mollie.com/v2/orders/ord_8wmqcHMN4U/shipments/shp_3wmsgCJN4U");
-            captureResponse.Links.Shipment.Type.Should().Be("application/hal+json");
-            captureResponse.Links.Settlement.Href.Should().Be($"https://api.mollie.com/v2/settlements/stl_jDk30akdN");
-            captureResponse.Links.Settlement.Type.Should().Be("application/hal+json");
-            captureResponse.Links.Documentation.Href.Should().Be("https://docs.mollie.com/reference/v2/captures-api/get-capture");
-            captureResponse.Links.Documentation.Type.Should().Be("text/html");
+            captureResponse.PaymentId.ShouldBe(defaultPaymentId);
+            captureResponse.ShipmentId.ShouldBe(defaultShipmentId);
+            captureResponse.SettlementId.ShouldBe(defaultSettlementId);
+            captureResponse.Amount.Value.ShouldBe(defaultAmountValue);
+            captureResponse.Amount.Currency.ShouldBe(defaultAmountCurrency);
+            captureResponse.Links.ShouldNotBeNull();
+            captureResponse.Links.Self.Href.ShouldBe($"https://api.mollie.com/v2/payments/{defaultPaymentId}/captures/cpt_4qqhO89gsT");
+            captureResponse.Links.Self.Type.ShouldBe("application/hal+json");
+            captureResponse.Links.Payment.Href.ShouldBe($"https://api.mollie.com/v2/payments/{defaultPaymentId}");
+            captureResponse.Links.Payment.Type.ShouldBe("application/hal+json");
+            captureResponse.Links.Shipment.Href.ShouldBe($"https://api.mollie.com/v2/orders/ord_8wmqcHMN4U/shipments/shp_3wmsgCJN4U");
+            captureResponse.Links.Shipment.Type.ShouldBe("application/hal+json");
+            captureResponse.Links.Settlement.Href.ShouldBe($"https://api.mollie.com/v2/settlements/stl_jDk30akdN");
+            captureResponse.Links.Settlement.Type.ShouldBe("application/hal+json");
+            captureResponse.Links.Documentation.Href.ShouldBe("https://docs.mollie.com/reference/v2/captures-api/get-capture");
+            captureResponse.Links.Documentation.Type.ShouldBe("text/html");
         }
 
         [Fact]
@@ -63,58 +63,58 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then: Response should be parsed
             mockHttp.VerifyNoOutstandingExpectation();
-            settlementResponse.Should().NotBeNull();
-            settlementResponse.Amount.Value.Should().Be(defaultAmountValue);
-            settlementResponse.Amount.Currency.Should().Be(defaultAmountCurrency);
-            settlementResponse.Periods.Count.Should().Be(1);
-            settlementResponse.Periods[2018][4].InvoiceId.Should().Be(defaultInvoiceId);
-            settlementResponse.Periods[2018][4].Revenue.Count.Should().Be(2);
-            settlementResponse.Periods[2018][4].Revenue[0].Description.Should().Be("iDEAL");
-            settlementResponse.Periods[2018][4].Revenue[0].Method.Should().Be("ideal");
-            settlementResponse.Periods[2018][4].Revenue[0].Count.Should().Be(6);
-            settlementResponse.Periods[2018][4].Revenue[0].AmountNet.Value.Should().Be("86.1000");
-            settlementResponse.Periods[2018][4].Revenue[0].AmountNet.Currency.Should().Be("EUR");
-            settlementResponse.Periods[2018][4].Revenue[0].AmountVat.Should().BeNull();
-            settlementResponse.Periods[2018][4].Revenue[0].AmountGross.Value.Should().Be("86.1000");
-            settlementResponse.Periods[2018][4].Revenue[0].AmountGross.Currency.Should().Be("EUR");
-            settlementResponse.Periods[2018][4].Revenue[1].Description.Should().Be("Refunds iDEAL");
-            settlementResponse.Periods[2018][4].Revenue[1].Method.Should().Be("refund");
-            settlementResponse.Periods[2018][4].Revenue[1].Count.Should().Be(2);
-            settlementResponse.Periods[2018][4].Revenue[1].AmountNet.Value.Should().Be("-43.2000");
-            settlementResponse.Periods[2018][4].Revenue[1].AmountNet.Currency.Should().Be("EUR");
-            settlementResponse.Periods[2018][4].Revenue[1].AmountVat.Should().BeNull();
-            settlementResponse.Periods[2018][4].Revenue[1].AmountGross.Value.Should().Be("43.2000");
-            settlementResponse.Periods[2018][4].Revenue[1].AmountGross.Currency.Should().Be("EUR");
-            settlementResponse.Periods[2018][4].Costs.Count.Should().Be(2);
-            settlementResponse.Periods[2018][4].Costs[0].Description.Should().Be("iDEAL");
-            settlementResponse.Periods[2018][4].Costs[0].Method.Should().Be("ideal");
-            settlementResponse.Periods[2018][4].Costs[0].Count.Should().Be(6);
-            settlementResponse.Periods[2018][4].Costs[0].Rate.Fixed.Value.Should().Be("0.3500");
-            settlementResponse.Periods[2018][4].Costs[0].Rate.Fixed.Currency.Should().Be("EUR");
-            settlementResponse.Periods[2018][4].Costs[0].Rate.Percentage.Should().BeNull();
-            settlementResponse.Periods[2018][4].Costs[0].AmountNet.Value.Should().Be("2.1000");
-            settlementResponse.Periods[2018][4].Costs[0].AmountNet.Currency.Should().Be("EUR");
-            settlementResponse.Periods[2018][4].Costs[0].AmountVat.Value.Should().Be("0.4410");
-            settlementResponse.Periods[2018][4].Costs[0].AmountVat.Currency.Should().Be("EUR");
-            settlementResponse.Periods[2018][4].Costs[0].AmountGross.Value.Should().Be("2.5410");
-            settlementResponse.Periods[2018][4].Costs[0].AmountGross.Currency.Should().Be("EUR");
-            settlementResponse.Periods[2018][4].Costs[1].Description.Should().Be("Refunds iDEAL");
-            settlementResponse.Periods[2018][4].Costs[1].Method.Should().Be("refund");
-            settlementResponse.Periods[2018][4].Costs[1].Count.Should().Be(2);
-            settlementResponse.Periods[2018][4].Costs[1].Rate.Fixed.Value.Should().Be("0.2500");
-            settlementResponse.Periods[2018][4].Costs[1].Rate.Fixed.Currency.Should().Be("EUR");
-            settlementResponse.Periods[2018][4].Costs[1].Rate.Percentage.Should().BeNull();
-            settlementResponse.Periods[2018][4].Costs[1].AmountNet.Value.Should().Be("0.5000");
-            settlementResponse.Periods[2018][4].Costs[1].AmountNet.Currency.Should().Be("EUR");
-            settlementResponse.Periods[2018][4].Costs[1].AmountVat.Value.Should().Be("0.1050");
-            settlementResponse.Periods[2018][4].Costs[1].AmountVat.Currency.Should().Be("EUR");
-            settlementResponse.Periods[2018][4].Costs[1].AmountGross.Value.Should().Be("0.6050");
-            settlementResponse.Periods[2018][4].Costs[1].AmountGross.Currency.Should().Be("EUR");
-            settlementResponse.Links.Should().NotBeNull();
-            settlementResponse.Links.Self.Href.Should().Be("https://api.mollie.com/v2/settlements/open");
-            settlementResponse.Links.Self.Type.Should().Be("application/hal+json");
-            settlementResponse.Links.Documentation.Href.Should().Be("https://docs.mollie.com/reference/v2/settlements-api/get-open-settlement");
-            settlementResponse.Links.Documentation.Type.Should().Be("text/html");
+            settlementResponse.ShouldNotBeNull();
+            settlementResponse.Amount.Value.ShouldBe(defaultAmountValue);
+            settlementResponse.Amount.Currency.ShouldBe(defaultAmountCurrency);
+            settlementResponse.Periods.Count.ShouldBe(1);
+            settlementResponse.Periods[2018][4].InvoiceId.ShouldBe(defaultInvoiceId);
+            settlementResponse.Periods[2018][4].Revenue.Count.ShouldBe(2);
+            settlementResponse.Periods[2018][4].Revenue[0].Description.ShouldBe("iDEAL");
+            settlementResponse.Periods[2018][4].Revenue[0].Method.ShouldBe("ideal");
+            settlementResponse.Periods[2018][4].Revenue[0].Count.ShouldBe(6);
+            settlementResponse.Periods[2018][4].Revenue[0].AmountNet.Value.ShouldBe("86.1000");
+            settlementResponse.Periods[2018][4].Revenue[0].AmountNet.Currency.ShouldBe("EUR");
+            settlementResponse.Periods[2018][4].Revenue[0].AmountVat.ShouldBeNull();
+            settlementResponse.Periods[2018][4].Revenue[0].AmountGross.Value.ShouldBe("86.1000");
+            settlementResponse.Periods[2018][4].Revenue[0].AmountGross.Currency.ShouldBe("EUR");
+            settlementResponse.Periods[2018][4].Revenue[1].Description.ShouldBe("Refunds iDEAL");
+            settlementResponse.Periods[2018][4].Revenue[1].Method.ShouldBe("refund");
+            settlementResponse.Periods[2018][4].Revenue[1].Count.ShouldBe(2);
+            settlementResponse.Periods[2018][4].Revenue[1].AmountNet.Value.ShouldBe("-43.2000");
+            settlementResponse.Periods[2018][4].Revenue[1].AmountNet.Currency.ShouldBe("EUR");
+            settlementResponse.Periods[2018][4].Revenue[1].AmountVat.ShouldBeNull();
+            settlementResponse.Periods[2018][4].Revenue[1].AmountGross.Value.ShouldBe("43.2000");
+            settlementResponse.Periods[2018][4].Revenue[1].AmountGross.Currency.ShouldBe("EUR");
+            settlementResponse.Periods[2018][4].Costs.Count.ShouldBe(2);
+            settlementResponse.Periods[2018][4].Costs[0].Description.ShouldBe("iDEAL");
+            settlementResponse.Periods[2018][4].Costs[0].Method.ShouldBe("ideal");
+            settlementResponse.Periods[2018][4].Costs[0].Count.ShouldBe(6);
+            settlementResponse.Periods[2018][4].Costs[0].Rate.Fixed.Value.ShouldBe("0.3500");
+            settlementResponse.Periods[2018][4].Costs[0].Rate.Fixed.Currency.ShouldBe("EUR");
+            settlementResponse.Periods[2018][4].Costs[0].Rate.Percentage.ShouldBeNull();
+            settlementResponse.Periods[2018][4].Costs[0].AmountNet.Value.ShouldBe("2.1000");
+            settlementResponse.Periods[2018][4].Costs[0].AmountNet.Currency.ShouldBe("EUR");
+            settlementResponse.Periods[2018][4].Costs[0].AmountVat.Value.ShouldBe("0.4410");
+            settlementResponse.Periods[2018][4].Costs[0].AmountVat.Currency.ShouldBe("EUR");
+            settlementResponse.Periods[2018][4].Costs[0].AmountGross.Value.ShouldBe("2.5410");
+            settlementResponse.Periods[2018][4].Costs[0].AmountGross.Currency.ShouldBe("EUR");
+            settlementResponse.Periods[2018][4].Costs[1].Description.ShouldBe("Refunds iDEAL");
+            settlementResponse.Periods[2018][4].Costs[1].Method.ShouldBe("refund");
+            settlementResponse.Periods[2018][4].Costs[1].Count.ShouldBe(2);
+            settlementResponse.Periods[2018][4].Costs[1].Rate.Fixed.Value.ShouldBe("0.2500");
+            settlementResponse.Periods[2018][4].Costs[1].Rate.Fixed.Currency.ShouldBe("EUR");
+            settlementResponse.Periods[2018][4].Costs[1].Rate.Percentage.ShouldBeNull();
+            settlementResponse.Periods[2018][4].Costs[1].AmountNet.Value.ShouldBe("0.5000");
+            settlementResponse.Periods[2018][4].Costs[1].AmountNet.Currency.ShouldBe("EUR");
+            settlementResponse.Periods[2018][4].Costs[1].AmountVat.Value.ShouldBe("0.1050");
+            settlementResponse.Periods[2018][4].Costs[1].AmountVat.Currency.ShouldBe("EUR");
+            settlementResponse.Periods[2018][4].Costs[1].AmountGross.Value.ShouldBe("0.6050");
+            settlementResponse.Periods[2018][4].Costs[1].AmountGross.Currency.ShouldBe("EUR");
+            settlementResponse.Links.ShouldNotBeNull();
+            settlementResponse.Links.Self.Href.ShouldBe("https://api.mollie.com/v2/settlements/open");
+            settlementResponse.Links.Self.Type.ShouldBe("application/hal+json");
+            settlementResponse.Links.Documentation.Href.ShouldBe("https://docs.mollie.com/reference/v2/settlements-api/get-open-settlement");
+            settlementResponse.Links.Documentation.Type.ShouldBe("text/html");
         }
 
         [Fact]
@@ -130,8 +130,8 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then: Response should be parsed
             mockHttp.VerifyNoOutstandingExpectation();
-            settlementResponse.Should().NotBeNull();
-            settlementResponse.Periods.Count.Should().Be(0);
+            settlementResponse.ShouldNotBeNull();
+            settlementResponse.Periods.Count.ShouldBe(0);
         }
 
         [Theory]
@@ -148,7 +148,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await settlementClient.GetSettlementAsync(settlementId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'settlementId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'settlementId' is null or empty");
         }
 
         [Theory]
@@ -165,7 +165,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await settlementClient.GetSettlementPaymentListAsync(settlementId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'settlementId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'settlementId' is null or empty");
         }
 
         [Theory]
@@ -182,7 +182,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await settlementClient.GetSettlementRefundListAsync(settlementId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'settlementId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'settlementId' is null or empty");
         }
 
         [Theory]
@@ -199,7 +199,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await settlementClient.GetSettlementChargebackListAsync(settlementId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'settlementId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'settlementId' is null or empty");
         }
 
         [Theory]
@@ -216,7 +216,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await settlementClient.GetSettlementCaptureListAsync(settlementId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'settlementId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'settlementId' is null or empty");
         }
 
 

--- a/tests/Mollie.Tests.Unit/Client/ShipmentClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/ShipmentClientTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Models;
 using Mollie.Api.Models.Shipment;
@@ -46,11 +46,11 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            shipmentResponse.Should().NotBeNull();
-            shipmentResponse.OrderId.Should().Be(orderId);
-            shipmentResponse.Tracking.Carrier.Should().Be(shipmentRequest.Tracking.Carrier);
-            shipmentResponse.Tracking.Code.Should().Be(shipmentRequest.Tracking.Code);
-            shipmentResponse.Tracking.Url.Should().Be(shipmentRequest.Tracking.Url);
+            shipmentResponse.ShouldNotBeNull();
+            shipmentResponse.OrderId.ShouldBe(orderId);
+            shipmentResponse.Tracking.Carrier.ShouldBe(shipmentRequest.Tracking.Carrier);
+            shipmentResponse.Tracking.Code.ShouldBe(shipmentRequest.Tracking.Code);
+            shipmentResponse.Tracking.Url.ShouldBe(shipmentRequest.Tracking.Url);
         }
 
         [Theory]
@@ -72,7 +72,7 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            shipmentResponse.Should().NotBeNull();
+            shipmentResponse.ShouldNotBeNull();
         }
 
         [Theory]
@@ -93,7 +93,7 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            shipmentListResponse.Should().NotBeNull();
+            shipmentListResponse.ShouldNotBeNull();
         }
 
         [Fact]
@@ -123,11 +123,11 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            shipmentResponse.Should().NotBeNull();
-            shipmentResponse.OrderId.Should().Be(orderId);
-            shipmentResponse.Tracking.Carrier.Should().Be(updateShipmentRequest.Tracking.Carrier);
-            shipmentResponse.Tracking.Code.Should().Be(updateShipmentRequest.Tracking.Code);
-            shipmentResponse.Tracking.Url.Should().Be(updateShipmentRequest.Tracking.Url);
+            shipmentResponse.ShouldNotBeNull();
+            shipmentResponse.OrderId.ShouldBe(orderId);
+            shipmentResponse.Tracking.Carrier.ShouldBe(updateShipmentRequest.Tracking.Carrier);
+            shipmentResponse.Tracking.Code.ShouldBe(updateShipmentRequest.Tracking.Code);
+            shipmentResponse.Tracking.Url.ShouldBe(updateShipmentRequest.Tracking.Url);
         }
 
         [Theory]
@@ -144,7 +144,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await shipmentClient.CreateShipmentAsync(orderId, new ShipmentRequest()));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'orderId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'orderId' is null or empty");
         }
 
         [Theory]
@@ -161,7 +161,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await shipmentClient.GetShipmentAsync(orderId, "shipment-id"));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'orderId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'orderId' is null or empty");
         }
 
         [Theory]
@@ -178,7 +178,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await shipmentClient.GetShipmentAsync("order-id", shipmentId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'shipmentId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'shipmentId' is null or empty");
         }
 
         [Theory]
@@ -195,7 +195,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await shipmentClient.GetShipmentListAsync(orderId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'orderId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'orderId' is null or empty");
         }
 
         [Theory]
@@ -219,7 +219,7 @@ namespace Mollie.Tests.Unit.Client {
                 await shipmentClient.UpdateShipmentAsync(orderId, "shipment-id", updateRequest));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'orderId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'orderId' is null or empty");
         }
 
         [Theory]
@@ -243,7 +243,7 @@ namespace Mollie.Tests.Unit.Client {
                 await shipmentClient.UpdateShipmentAsync("order-id", shipmentId, updateRequest));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'shipmentId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'shipmentId' is null or empty");
         }
 
         private const string DefaultShipmentJsonToReturn = @"{

--- a/tests/Mollie.Tests.Unit/Client/SubscriptionClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/SubscriptionClientTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Models;
 using Mollie.Api.Models.Subscription.Request;
@@ -31,7 +31,7 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            result.Should().NotBeNull();
+            result.ShouldNotBeNull();
         }
 
         [Theory]
@@ -53,7 +53,7 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            result.Should().NotBeNull();
+            result.ShouldNotBeNull();
         }
 
         [Theory]
@@ -75,7 +75,7 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            result.Should().NotBeNull();
+            result.ShouldNotBeNull();
         }
 
         [Fact]
@@ -120,7 +120,7 @@ namespace Mollie.Tests.Unit.Client {
 
             // Then
             mockHttp.VerifyNoOutstandingExpectation();
-            result.Should().NotBeNull();
+            result.ShouldNotBeNull();
         }
 
         [Theory]
@@ -137,7 +137,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await subscriptionClient.GetSubscriptionListAsync(customerId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'customerId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'customerId' is null or empty");
         }
 
         [Theory]
@@ -154,7 +154,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await subscriptionClient.GetSubscriptionAsync(customerId, "subscription-id"));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'customerId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'customerId' is null or empty");
         }
 
         [Theory]
@@ -171,7 +171,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await subscriptionClient.GetSubscriptionAsync("customer-Id", subscriptionId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'subscriptionId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'subscriptionId' is null or empty");
         }
 
         [Theory]
@@ -197,7 +197,7 @@ namespace Mollie.Tests.Unit.Client {
                 await subscriptionClient.CreateSubscriptionAsync(customerId, subscriptionRequest));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'customerId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'customerId' is null or empty");
         }
 
         [Theory]
@@ -214,7 +214,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await subscriptionClient.CancelSubscriptionAsync(customerId, "subscription-id"));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'customerId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'customerId' is null or empty");
         }
 
         [Theory]
@@ -231,7 +231,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await subscriptionClient.CancelSubscriptionAsync("customer-Id", subscriptionId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'subscriptionId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'subscriptionId' is null or empty");
         }
 
         [Theory]
@@ -248,7 +248,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await subscriptionClient.UpdateSubscriptionAsync(customerId, "subscription-id", new SubscriptionUpdateRequest()));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'customerId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'customerId' is null or empty");
         }
 
         [Theory]
@@ -265,7 +265,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await subscriptionClient.UpdateSubscriptionAsync("customer-Id", subscriptionId, new SubscriptionUpdateRequest()));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'subscriptionId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'subscriptionId' is null or empty");
         }
 
         [Theory]
@@ -282,7 +282,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await subscriptionClient.GetSubscriptionPaymentListAsync(customerId, "subscription-id"));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'customerId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'customerId' is null or empty");
         }
 
         [Theory]
@@ -299,7 +299,7 @@ namespace Mollie.Tests.Unit.Client {
             var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await subscriptionClient.GetSubscriptionPaymentListAsync("customer-Id", subscriptionId));
 
             // Then
-            exception.Message.Should().Be("Required URL argument 'subscriptionId' is null or empty");
+            exception.Message.ShouldBe("Required URL argument 'subscriptionId' is null or empty");
         }
 
         private const string DefaultSubscriptionJsonToReturn = @"{

--- a/tests/Mollie.Tests.Unit/Client/TerminalClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/TerminalClientTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Terminal.Response;
@@ -25,7 +25,7 @@ public class TerminalClientTests : BaseClientTests {
         var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await terminalClient.GetTerminalAsync(terminalId));
 
         // Then
-        exception.Message.Should().Be("Required URL argument 'terminalId' is null or empty");
+        exception.Message.ShouldBe("Required URL argument 'terminalId' is null or empty");
     }
 
     [Fact]
@@ -49,15 +49,15 @@ public class TerminalClientTests : BaseClientTests {
 
         // Then
         mockHttp.VerifyNoOutstandingExpectation();
-        response.Id.Should().Be(terminalId);
-        response.Description.Should().Be(description);
-        response.SerialNumber.Should().Be(serialNumber);
-        response.Brand.Should().Be(brand);
-        response.Model.Should().Be(model);
-        response.Links.Should().NotBeNull();
-        response.Links.Self.Should().NotBeNull();
-        response.Links.Self.Href.Should().Be($"https://api.mollie.com/v2/terminals/{terminalId}");
-        response.Links.Documentation.Should().NotBeNull();
+        response.Id.ShouldBe(terminalId);
+        response.Description.ShouldBe(description);
+        response.SerialNumber.ShouldBe(serialNumber);
+        response.Brand.ShouldBe(brand);
+        response.Model.ShouldBe(model);
+        response.Links.ShouldNotBeNull();
+        response.Links.Self.ShouldNotBeNull();
+        response.Links.Self.Href.ShouldBe($"https://api.mollie.com/v2/terminals/{terminalId}");
+        response.Links.Documentation.ShouldNotBeNull();
     }
 
     [Theory]
@@ -98,10 +98,10 @@ public class TerminalClientTests : BaseClientTests {
         ListResponse<TerminalResponse> response = await terminalClient.GetTerminalListAsync();
 
         // Then
-        response.Count.Should().Be(1);
-        response.Items.Count.Should().Be(response.Count);
-        response.Links.Should().NotBeNull();
-        response.Links.Self.Href.Should().NotBeNull();
+        response.Count.ShouldBe(1);
+        response.Items.Count.ShouldBe(response.Count);
+        response.Links.ShouldNotBeNull();
+        response.Links.Self.Href.ShouldNotBeNull();
     }
 
     private string CreateTerminalListJsonResponse() {

--- a/tests/Mollie.Tests.Unit/Client/WalletClientTest.cs
+++ b/tests/Mollie.Tests.Unit/Client/WalletClientTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Client;
 using Mollie.Api.Models.Wallet.Request;
 using Xunit;
@@ -37,13 +37,13 @@ public class WalletClientTest : BaseClientTests {
         var response = await walletClient.RequestApplePayPaymentSessionAsync(request);
 
         // Assert
-        response.EpochTimestamp.Should().Be(DateTimeOffset.FromUnixTimeMilliseconds(1555507053169).UtcDateTime);
-        response.ExpiresAt.Should().Be(DateTimeOffset.FromUnixTimeMilliseconds(1555510653169).UtcDateTime);
-        response.MerchantSessionIdentifier.Should().Be("SSH2EAF8AFAEAA94DEEA898162A5DAFD36E_916523AAED1343F5BC5815E12BEE9250AFFDC1A17C46B0DE5A943F0F94927C24");
-        response.Nonce.Should().Be("0206b8db");
-        response.MerchantIdentifier.Should().Be("BD62FEB196874511C22DB28A9E14A89E3534C93194F73EA417EC566368D391EB");
-        response.DomainName.Should().Be("pay.example.org");
-        response.DisplayName.Should().Be("Chuck Norris's Store");
-        response.Signature.Should().Be("308006092a864886f7...8cc030ad3000000000000");
+        response.EpochTimestamp.ShouldBe(DateTimeOffset.FromUnixTimeMilliseconds(1555507053169).UtcDateTime);
+        response.ExpiresAt.ShouldBe(DateTimeOffset.FromUnixTimeMilliseconds(1555510653169).UtcDateTime);
+        response.MerchantSessionIdentifier.ShouldBe("SSH2EAF8AFAEAA94DEEA898162A5DAFD36E_916523AAED1343F5BC5815E12BEE9250AFFDC1A17C46B0DE5A943F0F94927C24");
+        response.Nonce.ShouldBe("0206b8db");
+        response.MerchantIdentifier.ShouldBe("BD62FEB196874511C22DB28A9E14A89E3534C93194F73EA417EC566368D391EB");
+        response.DomainName.ShouldBe("pay.example.org");
+        response.DisplayName.ShouldBe("Chuck Norris's Store");
+        response.Signature.ShouldBe("308006092a864886f7...8cc030ad3000000000000");
     }
 }

--- a/tests/Mollie.Tests.Unit/DependencyInjectionTests.cs
+++ b/tests/Mollie.Tests.Unit/DependencyInjectionTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
 using System.Reflection;
-using FluentAssertions;
+using Shouldly;
 using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api;
 using Mollie.Api.Client.Abstract;
@@ -23,10 +23,10 @@ public class DependencyInjectionTests
             options.ClientSecret = "client-secret";
             options.RetryPolicy = MollieHttpRetryPolicies.TransientHttpErrorRetryPolicy();
         });
-        
+
         // Act
         var serviceProvider = serviceCollection.BuildServiceProvider();
-        
+
         // Assert
         var assembly = Assembly.GetAssembly(typeof(IPaymentClient));
         var apiClientInterfaces = assembly
@@ -37,7 +37,7 @@ public class DependencyInjectionTests
             if (apiClientInterface != typeof(IBaseMollieClient))
             {
                 var apiClientImplementation = serviceProvider.GetService(apiClientInterface);
-                apiClientImplementation.Should().NotBeNull();
+                apiClientImplementation.ShouldNotBeNull();
             }
         }
     }

--- a/tests/Mollie.Tests.Unit/Extensions/DictionaryExtensionsTests.cs
+++ b/tests/Mollie.Tests.Unit/Extensions/DictionaryExtensionsTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Extensions;
 using Xunit;
 
@@ -22,7 +22,7 @@ namespace Mollie.Tests.Unit.Extensions
             var result = parameters.ToQueryString();
 
             // Assert
-            result.Should().Be(expected);
+            result.ShouldBe(expected);
         }
 
         [Fact]
@@ -36,7 +36,7 @@ namespace Mollie.Tests.Unit.Extensions
             var result = parameters.ToQueryString();
 
             // Assert
-            result.Should().Be(expected);
+            result.ShouldBe(expected);
         }
 
         [Fact]
@@ -51,8 +51,8 @@ namespace Mollie.Tests.Unit.Extensions
             parameters.AddValueIfNotNullOrEmpty(parameterName, parameterValue);
 
             // Assert
-            parameters.Should().NotBeEmpty();
-            parameters[parameterName].Should().Be(parameterValue);
+            parameters.ShouldNotBeEmpty();
+            parameters[parameterName].ShouldBe(parameterValue);
         }
 
         [Fact]
@@ -65,9 +65,9 @@ namespace Mollie.Tests.Unit.Extensions
             parameters.AddValueIfNotNullOrEmpty("include", "");
 
             // Assert
-            parameters.Should().BeEmpty();
+            parameters.ShouldBeEmpty();
         }
-        
+
         [Fact]
         public void AddValueIfTrue_ValueIsTrue_ValueIsAdded()
         {
@@ -79,8 +79,8 @@ namespace Mollie.Tests.Unit.Extensions
             parameters.AddValueIfTrue(parameterName, true);
 
             // Assert
-            parameters.Should().NotBeEmpty();
-            parameters[parameterName].Should().Be(bool.TrueString.ToLower());
+            parameters.ShouldNotBeEmpty();
+            parameters[parameterName].ShouldBe(bool.TrueString.ToLower());
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace Mollie.Tests.Unit.Extensions
             parameters.AddValueIfTrue("testmode", false);
 
             // Assert
-            parameters.Should().BeEmpty();
+            parameters.ShouldBeEmpty();
         }
     }
 }

--- a/tests/Mollie.Tests.Unit/Framework/Factories/BalanceReportResponseFactoryTests.cs
+++ b/tests/Mollie.Tests.Unit/Framework/Factories/BalanceReportResponseFactoryTests.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Framework.Factories;
 using Mollie.Api.Models.Balance.Response.BalanceReport;
 using Mollie.Api.Models.Balance.Response.BalanceReport.Specific.StatusBalance;
@@ -20,7 +20,7 @@ namespace Mollie.Tests.Unit.Framework.Factories {
             var result = factory.Create(grouping);
 
             // Then
-            result.Should().BeOfType(expectedType);
+            result.ShouldBeOfType(expectedType);
         }
     }
 }

--- a/tests/Mollie.Tests.Unit/Framework/Factories/BalanceTransactionFactoryTests.cs
+++ b/tests/Mollie.Tests.Unit/Framework/Factories/BalanceTransactionFactoryTests.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Framework.Factories;
 using Mollie.Api.Models.Balance.Response.BalanceTransaction;
 using Mollie.Api.Models.Balance.Response.BalanceTransaction.Specific;
@@ -34,7 +34,7 @@ namespace Mollie.Tests.Unit.Framework.Factories {
             var result = sut.Create(type);
 
             // Then
-            result.Should().BeOfType(expectedType);
+            result.ShouldBeOfType(expectedType);
         }
     }
 }

--- a/tests/Mollie.Tests.Unit/Framework/Factories/PaymentResponseFactoryTests.cs
+++ b/tests/Mollie.Tests.Unit/Framework/Factories/PaymentResponseFactoryTests.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Framework.Factories;
 using Mollie.Api.Models.Payment;
 using Mollie.Api.Models.Payment.Response;
@@ -51,7 +51,7 @@ namespace Mollie.Tests.Unit.Framework.Factories {
             var result = sut.Create(paymentMethod);
 
             // Then
-            result.Should().BeOfType(expectedType);
+            result.ShouldBeOfType(expectedType);
         }
     }
 }

--- a/tests/Mollie.Tests.Unit/Framework/JsonConverterServiceTests.cs
+++ b/tests/Mollie.Tests.Unit/Framework/JsonConverterServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using Mollie.Api.Framework;
 using Mollie.Api.Models;
 using Mollie.Api.Models.Payment.Request;
@@ -22,8 +22,8 @@ namespace Mollie.Tests.Unit.Framework {
             // When: We serialize the JSON
             string jsonValue = jsonConverterService.Serialize(paymentRequest);
 
-            // Then:            
-            jsonValue.Should().Be(expectedJsonValue);
+            // Then:
+            jsonValue.ShouldBe(expectedJsonValue);
         }
 
         [Fact]
@@ -40,8 +40,8 @@ namespace Mollie.Tests.Unit.Framework {
             // When: We deserialize the JSON
             PaymentResponse payments = jsonConverterService.Deserialize<PaymentResponse>(paymentJson);
 
-            // Then: 
-            payments.Metadata.Should().Be(metadataJson);
+            // Then:
+            payments.Metadata.ShouldBe(metadataJson);
         }
 
         [Fact]
@@ -54,8 +54,8 @@ namespace Mollie.Tests.Unit.Framework {
             // When: We deserialize the JSON
             PaymentResponse payments = jsonConverterService.Deserialize<PaymentResponse>(paymentJson);
 
-            // Then: 
-            payments.Metadata.Should().Be(metadataJson);
+            // Then:
+            payments.Metadata.ShouldBe(metadataJson);
         }
 
         [Fact]
@@ -68,8 +68,8 @@ namespace Mollie.Tests.Unit.Framework {
             // When: We deserialize the JSON
             PaymentResponse payments = jsonConverterService.Deserialize<PaymentResponse>(paymentJson);
 
-            // Then: 
-            payments.Metadata.Should().BeNull();
+            // Then:
+            payments.Metadata.ShouldBeNull();
         }
     }
 }

--- a/tests/Mollie.Tests.Unit/Models/AmountTests.cs
+++ b/tests/Mollie.Tests.Unit/Models/AmountTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using Mollie.Api.Models;
 using Xunit;
 
@@ -13,9 +13,9 @@ namespace Mollie.Tests.Unit.Models {
         public void CreateAmount_DecimalIsConverted_ValueHasCorrectFormat(string currency, decimal value, string expectedResult) {
             // Arrange & act
             Amount amount = new Amount(currency, value);
-            
+
             // Assert
-            amount.Value.Should().Be(expectedResult);
+            amount.Value.ShouldBe(expectedResult);
         }
     }
 }

--- a/tests/Mollie.Tests.Unit/Models/Payment/Request/PaymentRequestTests.cs
+++ b/tests/Mollie.Tests.Unit/Models/Payment/Request/PaymentRequestTests.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using FluentAssertions;
+using Shouldly;
 using Mollie.Api.Models;
 using Mollie.Api.Models.Payment;
 using Mollie.Api.Models.Payment.Request;
@@ -32,8 +32,8 @@ public class PaymentRequestTests {
                 break;
         }
 
-        paymentRequest.Should().BeOfType(expectedType);
-        paymentRequest.Amount.Should().Be(amount);
-        paymentRequest.Description.Should().Be(description);
+        paymentRequest.ShouldBeOfType(expectedType);
+        paymentRequest.Amount.ShouldBe(amount);
+        paymentRequest.Description.ShouldBe(description);
     }
 }

--- a/tests/Mollie.Tests.Unit/Mollie.Tests.Unit.csproj
+++ b/tests/Mollie.Tests.Unit/Mollie.Tests.Unit.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Replace FluentAssertions with Shouldly, because version 8 and higher of FluentAssertions is no longer free and requires a license.