### PR TITLE
Add support for the AllowedMethods property on PaymentLinkRequest/Response

### DIFF
--- a/src/Mollie.Api/Models/PaymentLink/Request/PaymentLinkRequest.cs
+++ b/src/Mollie.Api/Models/PaymentLink/Request/PaymentLinkRequest.cs
@@ -1,20 +1,21 @@
 ﻿using Mollie.Api.JsonConverters;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 
 namespace Mollie.Api.Models.PaymentLink.Request {
     public record PaymentLinkRequest
     {
         /// <summary>
-        /// The amount that you want to charge, e.g. {"currency":"EUR", "value":"1000.00"} if you would want to charge €1000.00.
-        /// </summary>
-        public Amount? Amount { get; set; }
-
-        /// <summary>
         /// This description will also be used as the payment description and will be shown to your customer on their card or bank
         /// statement when possible.
         /// </summary>
         public required string Description { get; set; }
+
+        /// <summary>
+        /// The amount that you want to charge, e.g. {"currency":"EUR", "value":"1000.00"} if you would want to charge €1000.00.
+        /// </summary>
+        public Amount? Amount { get; set; }
 
         /// <summary>
         /// Optional - The URL your customer will be redirected to after completing the payment process.
@@ -27,15 +28,22 @@ namespace Mollie.Api.Models.PaymentLink.Request {
         public string? WebhookUrl { get; set; }
 
         /// <summary>
+        ///	Oauth only - The website profile’s unique identifier, for example pfl_3RkSN1zuPE. This field is mandatory.
+        /// </summary>
+        public string? ProfileId { get; set; }
+
+        /// <summary>
         /// The expiry date of the payment link in ISO 8601 format. For example: 2021-12-24T12:00:16+01:00.
         /// </summary>
         [JsonConverter(typeof(Iso8601DateTimeConverter))]
         public DateTime? ExpiresAt { get; set; }
 
         /// <summary>
-        ///	Oauth only - The website profile’s unique identifier, for example pfl_3RkSN1zuPE. This field is mandatory.
+        /// An array of payment methods that are allowed to be used for this payment link. When this parameter is not
+        /// provided or is an empty array, all enabled payment methods will be available.
+        /// See the Mollie.Api.Models.Payment.PaymentMethod class for a full list of known values.
         /// </summary>
-        public string? ProfileId { get; set; }
+        public IEnumerable<string>? AllowedMethods { get; set; }
 
         /// <summary>
         ///	Oauth only - Optional – 	Set this to true to only retrieve payment links made in test mode. By default, only live payment links are returned.

--- a/src/Mollie.Api/Models/PaymentLink/Request/PaymentLinkUpdateRequest.cs
+++ b/src/Mollie.Api/Models/PaymentLink/Request/PaymentLinkUpdateRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace Mollie.Api.Models.PaymentLink.Request;
+﻿using System.Collections.Generic;
+
+namespace Mollie.Api.Models.PaymentLink.Request;
 
 public record PaymentLinkUpdateRequest {
     /// <summary>
@@ -13,4 +15,11 @@ public record PaymentLinkUpdateRequest {
     /// Whether the payment link is archived. Customers will not be able to complete payments on archived payment links.
     /// </summary>
     public required bool Archived { get; init; }
+
+    /// <summary>
+    /// An array of payment methods that are allowed to be used for this payment link. When this parameter is not
+    /// provided or is an empty array, all enabled payment methods will be available.
+    /// See the Mollie.Api.Models.Payment.PaymentMethod class for a full list of known values.
+    /// </summary>
+    public IEnumerable<string>? AllowedMethods { get; set; }
 }

--- a/src/Mollie.Api/Models/PaymentLink/Response/PaymentLinkResponse.cs
+++ b/src/Mollie.Api/Models/PaymentLink/Response/PaymentLinkResponse.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Mollie.Api.Models.PaymentLink.Response
@@ -17,20 +18,15 @@ namespace Mollie.Api.Models.PaymentLink.Response
         public required string Id { get; set; }
 
         /// <summary>
-        ///A short description of the payment link. The description is visible in the Dashboard and will be shown on the
-        ///customer’s bank or card statement when possible. This description will eventual been used as payment description.
-        /// </summary>
-        public required string Description { get; set; }
-
-        /// <summary>
         /// The mode used to create this payment link. Mode determines whether a payment link is real (live mode) or a test payment link.
         /// </summary>
         public Mode Mode { get; set; }
 
         /// <summary>
-        /// The identifier referring to the profile this payment link was created on. For example, pfl_QkEhN94Ba.
+        ///A short description of the payment link. The description is visible in the Dashboard and will be shown on the
+        ///customer’s bank or card statement when possible. This description will eventual been used as payment description.
         /// </summary>
-        public string? ProfileId { get; set; }
+        public required string Description { get; set; }
 
         /// <summary>
         /// The amount of the payment link, e.g. {"currency":"EUR", "value":"100.00"} for a €100.00 payment link.
@@ -53,6 +49,11 @@ namespace Mollie.Api.Models.PaymentLink.Response
         public string? WebhookUrl { get; set; }
 
         /// <summary>
+        /// The identifier referring to the profile this payment link was created on. For example, pfl_QkEhN94Ba.
+        /// </summary>
+        public string? ProfileId { get; set; }
+
+        /// <summary>
         /// The payment link’s date and time of creation, in ISO 8601 format.
         /// </summary>
         public DateTime? CreatedAt { get; set; }
@@ -71,6 +72,13 @@ namespace Mollie.Api.Models.PaymentLink.Response
         /// The expiry date and time of the payment link, in ISO 8601 format.
         /// </summary>
         public DateTime? ExpiresAt { get; set; }
+
+        /// <summary>
+        /// An array of payment methods that are allowed to be used for this payment link. When this parameter is not
+        /// provided or is an empty array, all enabled payment methods will be available.
+        /// See the Mollie.Api.Models.Payment.PaymentMethod class for a full list of known values.
+        /// </summary>
+        public IEnumerable<string>? AllowedMethods { get; set; }
 
         /// <summary>
         /// An object with several URL objects relevant to the payment. Every URL object will contain an href and a type field.

--- a/tests/Mollie.Tests.Integration/Api/PaymentLinkTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/PaymentLinkTests.cs
@@ -6,6 +6,7 @@ using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Models;
 using Mollie.Api.Models.List.Response;
+using Mollie.Api.Models.Payment;
 using Mollie.Api.Models.PaymentLink.Request;
 using Mollie.Api.Models.PaymentLink.Response;
 using Mollie.Tests.Integration.Framework;
@@ -83,6 +84,39 @@ public class PaymentLinkTests : BaseMollieApiTestClass, IDisposable {
             response.ExpiresAt.ShouldBe(expiresAtWithoutMs);
             response.Description.ShouldBe(paymentLinkRequest.Description);
             response.RedirectUrl.ShouldBe(paymentLinkRequest.RedirectUrl);
+        });
+
+        verifyPaymentLinkResponse(createdPaymentLinkResponse);
+        verifyPaymentLinkResponse(retrievePaymentLinkResponse);
+    }
+
+
+    [Fact]
+    public async Task CanCreatePaymentLinkWithSpecificPaymentMethods() {
+        // Given: We create a new payment link
+        PaymentLinkRequest paymentLinkRequest = new() {
+            Description = "Test",
+            Amount = new Amount(Currency.EUR, 50),
+            WebhookUrl = DefaultWebhookUrl,
+            RedirectUrl = DefaultRedirectUrl,
+            ExpiresAt = DateTime.Now.AddDays(1),
+            AllowedMethods = [PaymentMethod.Ideal, PaymentMethod.CreditCard]
+        };
+        var createdPaymentLinkResponse = await _paymentLinkClient.CreatePaymentLinkAsync(paymentLinkRequest);
+
+        // When: We retrieve it
+        var retrievePaymentLinkResponse = await _paymentLinkClient.GetPaymentLinkAsync(createdPaymentLinkResponse.Id);
+
+        // Then: We expect a payment link with the expected properties
+        var verifyPaymentLinkResponse = new Action<PaymentLinkResponse>(response => {
+            var expiresAtWithoutMs = paymentLinkRequest.ExpiresAt.Value.Truncate(TimeSpan.FromSeconds(1));
+
+            response.Amount.ShouldBe(paymentLinkRequest.Amount);
+            response.ExpiresAt.ShouldBe(expiresAtWithoutMs);
+            response.Description.ShouldBe(paymentLinkRequest.Description);
+            response.RedirectUrl.ShouldBe(paymentLinkRequest.RedirectUrl);
+            response.Archived.ShouldBeFalse();
+            response.AllowedMethods.ShouldBe(paymentLinkRequest.AllowedMethods);
         });
 
         verifyPaymentLinkResponse(createdPaymentLinkResponse);

--- a/tests/Mollie.Tests.Integration/Api/PaymentLinkTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/PaymentLinkTests.cs
@@ -138,7 +138,8 @@ public class PaymentLinkTests : BaseMollieApiTestClass, IDisposable {
         // When: We update the payment link
         PaymentLinkUpdateRequest paymentLinkUpdateRequest = new() {
             Description = "Updated description",
-            Archived = true
+            Archived = true,
+            AllowedMethods = [PaymentMethod.CreditCard]
         };
         var updatedPaymentLinkResponse = await _paymentLinkClient.UpdatePaymentLinkAsync(
             createdPaymentLinkResponse.Id,
@@ -147,6 +148,7 @@ public class PaymentLinkTests : BaseMollieApiTestClass, IDisposable {
         // Then: We expect the payment link to be updated
         updatedPaymentLinkResponse.Description.ShouldBe(paymentLinkUpdateRequest.Description);
         updatedPaymentLinkResponse.Archived.ShouldBe(paymentLinkUpdateRequest.Archived);
+        updatedPaymentLinkResponse.AllowedMethods.ShouldBe(paymentLinkUpdateRequest.AllowedMethods);
     }
 
     [Fact]


### PR DESCRIPTION
Mollie added a feature where you can customize which payment methods are available when creating a payment link