### PR TITLE
Add support for the Clients API

### DIFF
--- a/src/Mollie.Api/Client/Abstract/IClientClient.cs
+++ b/src/Mollie.Api/Client/Abstract/IClientClient.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using Mollie.Api.Models.Client.Response;
+using Mollie.Api.Models.List.Response;
+
+namespace Mollie.Api.Client.Abstract {
+    public interface IClientClient : IBaseMollieClient
+    {
+        Task<ClientResponse> GetClientAsync(
+            string clientId, bool embedOrganization = false, bool embedOnboarding = false);
+
+        Task<ListResponse<ClientResponse>> GetClientListAsync(
+            string? from = null, int? limit = null, bool embedOrganization = false, bool embedOnboarding = false);
+    }
+}

--- a/src/Mollie.Api/Client/ClientClient.cs
+++ b/src/Mollie.Api/Client/ClientClient.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Mollie.Api.Client.Abstract;
+using Mollie.Api.Extensions;
+using Mollie.Api.Framework.Authentication.Abstract;
+using Mollie.Api.Models.Client.Response;
+using Mollie.Api.Models.List.Response;
+
+namespace Mollie.Api.Client {
+    public class ClientClient : OauthBaseMollieClient, IClientClient {
+        public ClientClient(string oauthAccessToken, HttpClient? httpClient = null)
+            : base(oauthAccessToken, httpClient)
+        {
+        }
+
+        public ClientClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(mollieSecretManager, httpClient)
+        {
+        }
+
+        public async Task<ClientResponse> GetClientAsync(string clientId, bool embedOrganization = false, bool embedOnboarding = false) {
+            ValidateRequiredUrlParameter(nameof(clientId), clientId);
+            var queryParameters = BuildQueryParameters(embedOrganization, embedOnboarding);
+            return await GetAsync<ClientResponse>($"clients/{clientId}{queryParameters.ToQueryString()}").ConfigureAwait(false);
+        }
+
+        public async Task<ListResponse<ClientResponse>> GetClientListAsync(string? from = null, int? limit = null, bool embedOrganization = false, bool embedOnboarding = false) {
+            var queryParameters = BuildQueryParameters(embedOrganization, embedOnboarding);
+            return await GetListAsync<ListResponse<ClientResponse>>($"clients", from, limit, queryParameters).ConfigureAwait(false);
+        }
+
+        private Dictionary<string, string> BuildQueryParameters(bool embedOrganization = false, bool embedOnboarding = false) {
+            var result = new Dictionary<string, string>();
+            result.AddValueIfNotNullOrEmpty("embed", BuildEmbedParameter(embedOrganization, embedOnboarding));
+            return result;
+        }
+
+        private string BuildEmbedParameter(bool embedOrganization = false, bool embedOnboarding = false) {
+            var includeList = new List<string>();
+            includeList.AddValueIfTrue("organization", embedOrganization);
+            includeList.AddValueIfTrue("onboarding", embedOnboarding);
+            return includeList.ToIncludeParameter();
+        }
+    }
+}

--- a/src/Mollie.Api/DependencyInjection.cs
+++ b/src/Mollie.Api/DependencyInjection.cs
@@ -69,6 +69,8 @@ namespace Mollie.Api {
                 new ClientLinkClient(mollieOptions.ClientId, provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IWalletClient, WalletClient>(services, (httpClient, provider) =>
                 new WalletClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IClientClient, ClientClient>(services, (httpClient, provider) =>
+                new ClientClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
 
             return services;
         }

--- a/src/Mollie.Api/Models/Client/Response/ClientCommisionResponse.cs
+++ b/src/Mollie.Api/Models/Client/Response/ClientCommisionResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace Mollie.Api.Models.Client.Response {
+    public record ClientCommisionResponse {
+        /// <summary>
+        /// The commission count.
+        /// </summary>
+        public int Count { get; set; }
+    }
+}

--- a/src/Mollie.Api/Models/Client/Response/ClientCommissionResponse.cs
+++ b/src/Mollie.Api/Models/Client/Response/ClientCommissionResponse.cs
@@ -1,5 +1,5 @@
 ﻿namespace Mollie.Api.Models.Client.Response {
-    public record ClientCommisionResponse {
+    public record ClientCommissionResponse {
         /// <summary>
         /// The commission count.
         /// </summary>

--- a/src/Mollie.Api/Models/Client/Response/ClientEmbeddedResponse.cs
+++ b/src/Mollie.Api/Models/Client/Response/ClientEmbeddedResponse.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Mollie.Api.Models.Onboarding.Response;
+using Mollie.Api.Models.Organization;
+
+namespace Mollie.Api.Models.Client.Response {
+    public record ClientEmbeddedResponse {
+
+        public OrganizationResponse? Organization { get; set; }
+
+        public IEnumerable<OnboardingStatusResponse>? Onboarding { get; set; }
+
+    }
+}

--- a/src/Mollie.Api/Models/Client/Response/ClientEmbeddedResponse.cs
+++ b/src/Mollie.Api/Models/Client/Response/ClientEmbeddedResponse.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Mollie.Api.Models.Onboarding.Response;
 using Mollie.Api.Models.Organization;
 
@@ -7,7 +6,7 @@ namespace Mollie.Api.Models.Client.Response {
 
         public OrganizationResponse? Organization { get; set; }
 
-        public IEnumerable<OnboardingStatusResponse>? Onboarding { get; set; }
+        public OnboardingStatusResponse? Onboarding { get; set; }
 
     }
 }

--- a/src/Mollie.Api/Models/Client/Response/ClientResponse.cs
+++ b/src/Mollie.Api/Models/Client/Response/ClientResponse.cs
@@ -16,7 +16,7 @@ namespace Mollie.Api.Models.Client.Response {
         /// <summary>
         /// The commission object.
         /// </summary>
-        public ClientCommisionResponse? Commision { get; set; }
+        public ClientCommissionResponse? Commission { get; set; }
 
         /// <summary>
         /// The date and time the client organization was created.

--- a/src/Mollie.Api/Models/Client/Response/ClientResponse.cs
+++ b/src/Mollie.Api/Models/Client/Response/ClientResponse.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Mollie.Api.Models.Client.Response {
+    public record ClientResponse {
+        /// <summary>
+        /// Indicates the response contains a client object. Will always contain the string client for this resource type.
+        /// </summary>
+        public required string Resource { get; set; }
+
+        /// <summary>
+        /// The identifier uniquely referring to this client. Example: org_12345678.
+        /// </summary>
+        public required string Id { get; set; }
+
+        /// <summary>
+        /// The commission object.
+        /// </summary>
+        public ClientCommisionResponse? Commision { get; set; }
+
+        /// <summary>
+        /// The date and time the client organization was created.
+        /// </summary>
+        public required DateTime OrganizationCreatedAt { get; set; }
+
+        [JsonProperty("_embedded")]
+        public ClientEmbeddedResponse? Embedded { get; set; }
+
+        /// <summary>
+        /// An object with several URL objects relevant to the order line. Every URL object will contain an href and a type field.
+        /// </summary>
+        [JsonProperty("_links")]
+        public required ClientResponseLinks Links { get; set; }
+    }
+}

--- a/src/Mollie.Api/Models/Client/Response/ClientResponseLinks.cs
+++ b/src/Mollie.Api/Models/Client/Response/ClientResponseLinks.cs
@@ -1,0 +1,22 @@
+using Mollie.Api.Models.Onboarding.Response;
+using Mollie.Api.Models.Organization;
+using Mollie.Api.Models.Url;
+
+namespace Mollie.Api.Models.Client.Response {
+    public record ClientResponseLinks {
+        /// <summary>
+        /// The API resource URL of the client itself.
+        /// </summary>
+        public required UrlObjectLink<ClientResponse> Self { get; set; }
+
+        /// <summary>
+        /// A link pointing to the product page in your web shop of the product sold.
+        /// </summary>
+        public required UrlObjectLink<OrganizationResponse> Organization { get; set; }
+
+        /// <summary>
+        /// The API resource URL of the client's onboarding status.
+        /// </summary>
+        public required UrlObjectLink<OnboardingStatusResponse> Onboarding { get; set; }
+    }
+}


### PR DESCRIPTION
Our organization needs to use the Clients API and I saw you didn't support it yet so I tried to implement it into your package.

A lot of copy-paste from the base implementation 😄 

Not really fond of the name IClientClient and ClientClient but Mollie decided to name it Clients...
I've excluded the capabilities API since it is in Beta and can be changed.