### PR TITLE
Add support for the StatusReason field in PaymentResponse

### DIFF
--- a/src/Mollie.Api/Models/Payment/Response/PaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentResponse.cs
@@ -34,6 +34,11 @@ namespace Mollie.Api.Models.Payment.Response {
         public required string Status { get; set; }
 
         /// <summary>
+        /// This object offers details about the status of a payment. Currently it is only available for point-of-sale payments.
+        /// </summary>
+        public StatusReason? StatusReason { get; set; }
+
+        /// <summary>
         /// Whether or not the payment can be canceled.
         /// </summary>
         public bool? IsCancelable { get; set; }

--- a/src/Mollie.Api/Models/Payment/Response/StatusReason.cs
+++ b/src/Mollie.Api/Models/Payment/Response/StatusReason.cs
@@ -1,0 +1,13 @@
+﻿namespace Mollie.Api.Models.Payment.Response;
+
+public record StatusReason {
+    /// <summary>
+    /// A machine-readable code that indicates the reason for the payment's status.
+    /// </summary>
+    public required string Code { get; init; }
+
+    /// <summary>
+    /// A machine-readable code that indicates the reason for the payment's status.
+    /// </summary>
+    public required string Message { get; init; }
+}

--- a/tests/Mollie.Tests.Integration/Api/CustomerTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/CustomerTests.cs
@@ -89,6 +89,7 @@ public class CustomerTests : BaseMollieApiTestClass, IDisposable {
         await _customerClient.DeleteCustomerAsync(customerIdToDelete);
 
         // Then: Make sure its deleted
+        await Task.Delay(TimeSpan.FromSeconds(1)); // TODO: Improve this using a retry mechanism
         MollieApiException apiException = await Assert.ThrowsAsync<MollieApiException>(() => _customerClient.GetCustomerAsync(customerIdToDelete));
         apiException.Details.Status.ShouldBe((int)HttpStatusCode.Gone);
     }
@@ -101,6 +102,7 @@ public class CustomerTests : BaseMollieApiTestClass, IDisposable {
         CustomerResponse createdCustomer = await CreateCustomer(name, email);
 
         // When: We try to retrieve the customer by Url object
+        await Task.Delay(TimeSpan.FromSeconds(1)); // TODO: Improve this using a retry mechanism
         CustomerResponse retrievedCustomer = await _customerClient.GetCustomerAsync(createdCustomer.Links.Self);
 
         // Then: Make sure it's retrieved

--- a/tests/Mollie.Tests.Integration/Api/CustomerTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/CustomerTests.cs
@@ -102,7 +102,7 @@ public class CustomerTests : BaseMollieApiTestClass, IDisposable {
         CustomerResponse createdCustomer = await CreateCustomer(name, email);
 
         // When: We try to retrieve the customer by Url object
-        CustomerResponse retrievedCustomer = await _customerClient.GetCustomerAsync(createdCustomer.Links.Self);
+        CustomerResponse retrievedCustomer = await ExecuteWithRetry(() => _customerClient.GetCustomerAsync(createdCustomer.Links.Self));
 
         // Then: Make sure it's retrieved
         retrievedCustomer.Name.ShouldBe(createdCustomer.Name);

--- a/tests/Mollie.Tests.Integration/Api/CustomerTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/CustomerTests.cs
@@ -88,8 +88,8 @@ public class CustomerTests : BaseMollieApiTestClass, IDisposable {
         string customerIdToDelete = response.Items.First().Id;
         await _customerClient.DeleteCustomerAsync(customerIdToDelete);
 
-        // Then: Make sure its deleted
-        await Task.Delay(TimeSpan.FromSeconds(1)); // TODO: Improve this using a retry mechanism
+        // Then: Make sure its deleted after one second
+        await Task.Delay(TimeSpan.FromSeconds(1));
         MollieApiException apiException = await Assert.ThrowsAsync<MollieApiException>(() => _customerClient.GetCustomerAsync(customerIdToDelete));
         apiException.Details.Status.ShouldBe((int)HttpStatusCode.Gone);
     }
@@ -102,7 +102,6 @@ public class CustomerTests : BaseMollieApiTestClass, IDisposable {
         CustomerResponse createdCustomer = await CreateCustomer(name, email);
 
         // When: We try to retrieve the customer by Url object
-        await Task.Delay(TimeSpan.FromSeconds(1)); // TODO: Improve this using a retry mechanism
         CustomerResponse retrievedCustomer = await _customerClient.GetCustomerAsync(createdCustomer.Links.Self);
 
         // Then: Make sure it's retrieved

--- a/tests/Mollie.Tests.Integration/Api/RefundTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/RefundTests.cs
@@ -91,7 +91,8 @@ public class RefundTests : BaseMollieApiTestClass, IDisposable {
         // If: We create a payment
         PaymentResponse payment = await CreatePayment();
 
-        // When: Retrieve refund list for this payment
+        // When: Retrieve refund list for this payment after one second
+        var test = await ExecuteWithRetry(() => _refundClient.GetPaymentRefundListAsync(payment.Id));
         ListResponse<RefundResponse> refundList = await _refundClient.GetPaymentRefundListAsync(payment.Id);
 
         // Then

--- a/tests/Mollie.Tests.Integration/Api/SubscriptionTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/SubscriptionTests.cs
@@ -112,18 +112,19 @@ public class SubscriptionTests : BaseMollieApiTestClass, IDisposable {
 
     [Fact]
     public async Task CanCancelSubscription() {
-        // Given
+        // Given: We have a customer with a mandate
         string customerId = await GetFirstCustomerWithValidMandate();
         ListResponse<SubscriptionResponse> subscriptions = await _subscriptionClient.GetSubscriptionListAsync(customerId);
 
-        // When
+        // When: That customer has a subscription that we can cancel
         SubscriptionResponse subscriptionToCancel = subscriptions.Items
             .FirstOrDefault(s => s.Status != SubscriptionStatus.Canceled);
         if (subscriptionToCancel != null) {
             await _subscriptionClient.CancelSubscriptionAsync(customerId, subscriptionToCancel.Id);
-            SubscriptionResponse cancelledSubscription = await _subscriptionClient.GetSubscriptionAsync(customerId, subscriptionToCancel.Id);
 
-            // Then
+            // Then: Make sure its canceled after one second
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            SubscriptionResponse cancelledSubscription = await _subscriptionClient.GetSubscriptionAsync(customerId, subscriptionToCancel.Id);
             cancelledSubscription.Status.ShouldBe(SubscriptionStatus.Canceled);
         }
     }

--- a/tests/Mollie.Tests.Integration/Framework/BaseMollieApiTestClass.cs
+++ b/tests/Mollie.Tests.Integration/Framework/BaseMollieApiTestClass.cs
@@ -1,14 +1,19 @@
 ﻿using System;
 using System.Globalization;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Mollie.Api.Client;
 using Mollie.Api.Options;
 
 namespace Mollie.Tests.Integration.Framework {
     public abstract class BaseMollieApiTestClass {
         protected readonly string DefaultRedirectUrl = "http://mysite.com";
         protected readonly string DefaultWebhookUrl = "http://mysite.com/webhook";
-        private readonly MollieOptions Configuration = ConfigurationFactory.GetConfiguration().GetSection("Mollie").Get<MollieOptions>();
+
+        private readonly MollieOptions Configuration =
+            ConfigurationFactory.GetConfiguration().GetSection("Mollie").Get<MollieOptions>();
+
         protected string ApiKey => Configuration.ApiKey;
         protected string ClientId => Configuration.ClientId ?? "client-id";
         protected string ClientSecret => Configuration.ClientSecret ?? "client-secret";
@@ -35,7 +40,36 @@ namespace Mollie.Tests.Integration.Framework {
         }
 
         protected bool IsJsonResultEqual(string json1, string json2) {
-            return string.Compare(json1, json2, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreSymbols) == 0;
+            return string.Compare(json1, json2, CultureInfo.CurrentCulture,
+                CompareOptions.IgnoreCase | CompareOptions.IgnoreSymbols) == 0;
+        }
+
+        protected async Task<TResult> ExecuteWithRetry<TResult>(Func<Task<TResult>> apiAction, int numberOfRetries = 3) {
+            MollieApiException exception = null;
+            for (int i = 0; i < numberOfRetries; i++) {
+                try {
+                    return await apiAction.Invoke();
+                } catch (MollieApiException ex) {
+                    exception = ex;
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                }
+            }
+
+            throw exception!;
+        }
+
+        protected async Task ExecuteWithRetry(Func<Task> apiAction, int numberOfRetries = 3) {
+            MollieApiException exception = null;
+            for (int i = 0; i < numberOfRetries; i++) {
+                try {
+                    await apiAction.Invoke();
+                } catch (MollieApiException ex) {
+                    exception = ex;
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                }
+            }
+
+            throw exception!;
         }
     }
 }

--- a/tests/Mollie.Tests.Integration/Framework/MollieIntegrationTestHttpRetryPolicies.cs
+++ b/tests/Mollie.Tests.Integration/Framework/MollieIntegrationTestHttpRetryPolicies.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Client;
@@ -10,7 +11,7 @@ public static class MollieIntegrationTestHttpRetryPolicies {
 
     public static IAsyncPolicy<HttpResponseMessage> TooManyRequestRetryPolicy() {
         var retryPolicy = Policy<HttpResponseMessage>
-            .Handle<MollieApiException>(x => x.Details.Status == 429)
+            .Handle<MollieApiException>(x => x.Details.Status == (int)HttpStatusCode.TooManyRequests)
             .OrResult(r =>  r?.Headers?.RetryAfter != null)
             .WaitAndRetryAsync(
                 3,
@@ -22,6 +23,14 @@ public static class MollieIntegrationTestHttpRetryPolicies {
                     return Task.CompletedTask;
                 }
             );
+
+        return retryPolicy;
+    }
+
+    public static IAsyncPolicy<HttpResponseMessage> NotFoundRetryPolicy() {
+        var retryPolicy = Policy<HttpResponseMessage>
+            .Handle<MollieApiException>(x => x.Details.Status == (int)HttpStatusCode.NotFound)
+            .WaitAndRetryAsync(3, _ => TimeSpan.FromMilliseconds(500));
 
         return retryPolicy;
     }

--- a/tests/Mollie.Tests.Integration/Framework/MollieIntegrationTestHttpRetryPolicies.cs
+++ b/tests/Mollie.Tests.Integration/Framework/MollieIntegrationTestHttpRetryPolicies.cs
@@ -26,12 +26,4 @@ public static class MollieIntegrationTestHttpRetryPolicies {
 
         return retryPolicy;
     }
-
-    public static IAsyncPolicy<HttpResponseMessage> NotFoundRetryPolicy() {
-        var retryPolicy = Policy<HttpResponseMessage>
-            .Handle<MollieApiException>(x => x.Details.Status == (int)HttpStatusCode.NotFound)
-            .WaitAndRetryAsync(3, _ => TimeSpan.FromMilliseconds(500));
-
-        return retryPolicy;
-    }
 }

--- a/tests/Mollie.Tests.Integration/Startup.cs
+++ b/tests/Mollie.Tests.Integration/Startup.cs
@@ -22,9 +22,7 @@ public class Startup
                 options.ApiKey = context.Configuration["Mollie:ApiKey"]!;
                 options.ClientId = context.Configuration["Mollie:ClientId"]!;
                 options.ClientSecret = context.Configuration["Mollie:ClientSecret"]!;
-                options.RetryPolicy = Policy.WrapAsync(
-                    MollieIntegrationTestHttpRetryPolicies.TooManyRequestRetryPolicy(),
-                    MollieIntegrationTestHttpRetryPolicies.NotFoundRetryPolicy());
+                options.RetryPolicy = MollieIntegrationTestHttpRetryPolicies.TooManyRequestRetryPolicy();
             });
         });
 }

--- a/tests/Mollie.Tests.Integration/Startup.cs
+++ b/tests/Mollie.Tests.Integration/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Mollie.Api;
 using Mollie.Tests.Integration.Framework;
+using Polly;
 
 namespace Mollie.Tests.Integration;
 
@@ -21,7 +22,9 @@ public class Startup
                 options.ApiKey = context.Configuration["Mollie:ApiKey"]!;
                 options.ClientId = context.Configuration["Mollie:ClientId"]!;
                 options.ClientSecret = context.Configuration["Mollie:ClientSecret"]!;
-                options.RetryPolicy = MollieIntegrationTestHttpRetryPolicies.TooManyRequestRetryPolicy();
+                options.RetryPolicy = Policy.WrapAsync(
+                    MollieIntegrationTestHttpRetryPolicies.TooManyRequestRetryPolicy(),
+                    MollieIntegrationTestHttpRetryPolicies.NotFoundRetryPolicy());
             });
         });
 }


### PR DESCRIPTION
Add support for the new `StatusReason` field on the `PaymentResponse` class, as described here: https://docs.mollie.com/reference/status-reasons