### PR TITLE
Add a implicit conversion from Amount? to decimal?

### DIFF
--- a/src/Mollie.Api/Models/Amount.cs
+++ b/src/Mollie.Api/Models/Amount.cs
@@ -47,13 +47,12 @@ namespace Mollie.Api.Models {
         public static implicit operator decimal(Amount amount)
             => decimal.TryParse(amount.Value, NumberStyles.Number, CultureInfo.InvariantCulture, out var a) ? a : throw new InvalidCastException($"Cannot convert {amount.Value} to decimal");
 
-        public static implicit operator decimal?(Amount? amount) {
-            if (amount == null) {
-                return null;
-            }
-
-            return (decimal)amount;
-        }
+        /// <summary>
+        /// Implicit cast operator from Amount? to decimal?.
+        /// </summary>
+        /// <param name="amount"></param>
+        public static implicit operator decimal?(Amount? amount)
+            => amount == null ? null : (decimal)amount;
 
         private static string ConvertDecimalAmountToStringAmount(string currency, decimal value) {
             if (CurrenciesWithAlternativeDecimalPrecision.TryGetValue(currency, out string? format)) {

--- a/src/Mollie.Api/Models/Amount.cs
+++ b/src/Mollie.Api/Models/Amount.cs
@@ -47,9 +47,16 @@ namespace Mollie.Api.Models {
         public static implicit operator decimal(Amount amount)
             => decimal.TryParse(amount.Value, NumberStyles.Number, CultureInfo.InvariantCulture, out var a) ? a : throw new InvalidCastException($"Cannot convert {amount.Value} to decimal");
 
+        public static implicit operator decimal?(Amount? amount) {
+            if (amount == null) {
+                return null;
+            }
+
+            return (decimal)amount;
+        }
+
         private static string ConvertDecimalAmountToStringAmount(string currency, decimal value) {
-            if (CurrenciesWithAlternativeDecimalPrecision.ContainsKey(currency)) {
-                string format = CurrenciesWithAlternativeDecimalPrecision[currency];
+            if (CurrenciesWithAlternativeDecimalPrecision.TryGetValue(currency, out string? format)) {
                 return value.ToString(format, CultureInfo.InvariantCulture);
             }
 

--- a/tests/Mollie.Tests.Integration/Mollie.Tests.Integration.csproj
+++ b/tests/Mollie.Tests.Integration/Mollie.Tests.Integration.csproj
@@ -6,6 +6,7 @@
     <IsPackable>false</IsPackable>
 
     <UserSecretsId>51f1afd9-6752-484d-845c-119df206c6e7</UserSecretsId>
+    <Nullable>true</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Mollie.Tests.Integration/Mollie.Tests.Integration.csproj
+++ b/tests/Mollie.Tests.Integration/Mollie.Tests.Integration.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
 
     <UserSecretsId>51f1afd9-6752-484d-845c-119df206c6e7</UserSecretsId>
-    <Nullable>true</Nullable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Mollie.Tests.Unit/Models/AmountTests.cs
+++ b/tests/Mollie.Tests.Unit/Models/AmountTests.cs
@@ -1,5 +1,6 @@
 ﻿using Shouldly;
 using Mollie.Api.Models;
+using Mollie.Api.Models.Payment.Response;
 using Xunit;
 
 namespace Mollie.Tests.Unit.Models {
@@ -12,10 +13,48 @@ namespace Mollie.Tests.Unit.Models {
         [InlineData("ISK", 52.40, "52")]
         public void CreateAmount_DecimalIsConverted_ValueHasCorrectFormat(string currency, decimal value, string expectedResult) {
             // Arrange & act
-            Amount amount = new Amount(currency, value);
+            var amount = new Amount(currency, value);
 
             // Assert
             amount.Value.ShouldBe(expectedResult);
+        }
+
+        [Fact]
+        public void Amount_ConvertedToDecimal_IsEqualToOriginalValue() {
+            // Arrange
+            decimal originalValue = 50.25m;
+            var amount = new Amount(Currency.EUR, originalValue);
+
+            // Act
+            decimal convertedValue = amount;
+
+            // Assert
+            convertedValue.ShouldBe(originalValue);
+        }
+
+        [Fact]
+        public void NullableAmount_ConvertedToNullableDecimal_IsEqualToOriginalValue() {
+            // Arrange
+            decimal originalValue = 50.25m;
+            Amount? amount = new(Currency.EUR, originalValue);
+
+            // Act
+            decimal? convertedValue = amount;
+
+            // Assert
+            convertedValue.ShouldBe(originalValue);
+        }
+
+        [Fact]
+        public void NullAmount_ConvertedToNullableDecimal_IsNull() {
+            // Arrange
+            Amount? amount = null;
+
+            // Act
+            decimal? convertedValue = amount;
+
+            // Assert
+            convertedValue.ShouldBeNull();
         }
     }
 }

--- a/tests/Mollie.Tests.Unit/Mollie.Tests.Unit.csproj
+++ b/tests/Mollie.Tests.Unit/Mollie.Tests.Unit.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Converting a nullable `Amount?` to a decimal wasn't supported out of the box, which made code more convulated then necessary.  Now, the following code is valid without having to do any null checking yourself or parsing the `Amount.Value` property:
``` C#
Amount? amountChargedBack = paymentResponse.AmountChargedBack;
decimal? amount = amountChargedBack;
```
