### PR TITLE
Add the option to append a string to the user agent

### DIFF
--- a/src/Mollie.Api/Client/BalanceClient.cs
+++ b/src/Mollie.Api/Client/BalanceClient.cs
@@ -13,13 +13,16 @@ using Mollie.Api.Models.Balance.Response.BalanceReport;
 using Mollie.Api.Models.Balance.Response.BalanceTransaction;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class BalanceClient : BaseMollieClient, IBalanceClient {
         public BalanceClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public BalanceClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public BalanceClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<BalanceResponse> GetBalanceAsync(string balanceId, CancellationToken cancellationToken = default) {

--- a/src/Mollie.Api/Client/BaseMollieClient.cs
+++ b/src/Mollie.Api/Client/BaseMollieClient.cs
@@ -58,7 +58,9 @@ namespace Mollie.Api.Client {
             _createdHttpClient = httpClient == null;
             _httpClient = httpClient ?? new HttpClient();
             _mollieSecretManager = new DefaultMollieSecretManager(string.Empty);
-            _options = new();
+            _options = new() {
+                ApiKey = string.Empty
+            };
         }
 
         public IDisposable WithIdempotencyKey(string value) {

--- a/src/Mollie.Api/Client/BaseMollieClient.cs
+++ b/src/Mollie.Api/Client/BaseMollieClient.cs
@@ -40,9 +40,7 @@ namespace Mollie.Api.Client {
             _httpClient = httpClient ?? new HttpClient();
             _mollieSecretManager = new DefaultMollieSecretManager(apiKey);
             _options = new MollieClientOptions {
-                ApiKey = apiKey,
-                ClientId = string.Empty,
-                ClientSecret = string.Empty,
+                ApiKey = apiKey
             };
         }
 
@@ -60,11 +58,7 @@ namespace Mollie.Api.Client {
             _createdHttpClient = httpClient == null;
             _httpClient = httpClient ?? new HttpClient();
             _mollieSecretManager = new DefaultMollieSecretManager(string.Empty);
-            _options = new MollieClientOptions {
-                ApiKey = string.Empty,
-                ClientId = string.Empty,
-                ClientSecret = string.Empty,
-            };
+            _options = new();
         }
 
         public IDisposable WithIdempotencyKey(string value) {
@@ -184,7 +178,13 @@ namespace Mollie.Api.Client {
         private string GetUserAgent() {
             const string packageName = "Mollie.Api.NET";
             string versionNumber = typeof(BaseMollieClient).GetTypeInfo().Assembly.GetName().Version.ToString();
-            return $"{packageName}/{versionNumber}";
+            string userAgent = $"{packageName}/{versionNumber}";
+
+            if (!string.IsNullOrEmpty(_options.CustomUserAgent)) {
+                userAgent = $"{userAgent} {_options.CustomUserAgent}";
+            }
+
+            return userAgent;
         }
 
         private MollieErrorMessage ParseMollieErrorMessage(HttpStatusCode responseStatusCode, string responseBody) {

--- a/src/Mollie.Api/Client/BaseMollieClient.cs
+++ b/src/Mollie.Api/Client/BaseMollieClient.cs
@@ -14,6 +14,7 @@ using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Framework.Idempotency;
 using Mollie.Api.Models.Error;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 using Newtonsoft.Json;
 
 namespace Mollie.Api.Client {
@@ -21,6 +22,7 @@ namespace Mollie.Api.Client {
         public const string ApiEndPoint = "https://api.mollie.com/v2/";
         private readonly string _apiEndpoint = ApiEndPoint;
         private readonly IMollieSecretManager _mollieSecretManager;
+        private readonly MollieClientOptions _options;
         private readonly HttpClient _httpClient;
         private readonly JsonConverterService _jsonConverterService;
 
@@ -37,13 +39,19 @@ namespace Mollie.Api.Client {
             _createdHttpClient = httpClient == null;
             _httpClient = httpClient ?? new HttpClient();
             _mollieSecretManager = new DefaultMollieSecretManager(apiKey);
+            _options = new MollieClientOptions {
+                ApiKey = apiKey,
+                ClientId = string.Empty,
+                ClientSecret = string.Empty,
+            };
         }
 
-        protected BaseMollieClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) {
+        protected BaseMollieClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) {
             _jsonConverterService = new JsonConverterService();
             _createdHttpClient = httpClient == null;
             _httpClient = httpClient ?? new HttpClient();
             _mollieSecretManager = mollieSecretManager;
+            _options = options;
         }
 
         protected BaseMollieClient(HttpClient? httpClient = null, string apiEndpoint = ApiEndPoint) {
@@ -52,6 +60,11 @@ namespace Mollie.Api.Client {
             _createdHttpClient = httpClient == null;
             _httpClient = httpClient ?? new HttpClient();
             _mollieSecretManager = new DefaultMollieSecretManager(string.Empty);
+            _options = new MollieClientOptions {
+                ApiKey = string.Empty,
+                ClientId = string.Empty,
+                ClientSecret = string.Empty,
+            };
         }
 
         public IDisposable WithIdempotencyKey(string value) {

--- a/src/Mollie.Api/Client/CapabilityClient.cs
+++ b/src/Mollie.Api/Client/CapabilityClient.cs
@@ -1,10 +1,12 @@
 ﻿using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.Capability.Response;
 using Mollie.Api.Models.List.Response;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client;
 
@@ -14,8 +16,9 @@ public class CapabilityClient : BaseMollieClient, ICapabilityClient {
     {
     }
 
-    public CapabilityClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
-        : base(mollieSecretManager, httpClient)
+    [ActivatorUtilitiesConstructor]
+    public CapabilityClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+        : base(options, mollieSecretManager, httpClient)
     {
     }
 

--- a/src/Mollie.Api/Client/CaptureClient.cs
+++ b/src/Mollie.Api/Client/CaptureClient.cs
@@ -10,6 +10,7 @@ using Mollie.Api.Models.Capture.Request;
 using Mollie.Api.Models.Capture.Response;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client
 {
@@ -17,7 +18,9 @@ namespace Mollie.Api.Client
         public CaptureClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public CaptureClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public CaptureClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<CaptureResponse> GetCaptureAsync(

--- a/src/Mollie.Api/Client/ChargebackClient.cs
+++ b/src/Mollie.Api/Client/ChargebackClient.cs
@@ -2,19 +2,23 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.Chargeback.Response;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class ChargebackClient : BaseMollieClient, IChargebackClient {
         public ChargebackClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public ChargebackClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public ChargebackClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<ChargebackResponse> GetChargebackAsync(string paymentId, string chargebackId, bool testmode = false, CancellationToken cancellationToken = default) {

--- a/src/Mollie.Api/Client/ClientClient.cs
+++ b/src/Mollie.Api/Client/ClientClient.cs
@@ -2,11 +2,13 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.Client.Response;
 using Mollie.Api.Models.List.Response;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class ClientClient : OauthBaseMollieClient, IClientClient {
@@ -15,8 +17,9 @@ namespace Mollie.Api.Client {
         {
         }
 
-        public ClientClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
-            : base(mollieSecretManager, httpClient)
+        [ActivatorUtilitiesConstructor]
+        public ClientClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient)
         {
         }
 

--- a/src/Mollie.Api/Client/ClientLinkClient.cs
+++ b/src/Mollie.Api/Client/ClientLinkClient.cs
@@ -8,6 +8,8 @@ using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.ClientLink.Request;
 using Mollie.Api.Models.ClientLink.Response;
 using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class ClientLinkClient : OauthBaseMollieClient, IClientLinkClient
@@ -20,13 +22,14 @@ namespace Mollie.Api.Client {
             _clientId = clientId;
         }
 
-        public ClientLinkClient(string? clientId, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
-            : base(mollieSecretManager, httpClient) {
-            if (string.IsNullOrWhiteSpace(clientId)) {
-                throw new ArgumentNullException(nameof(clientId));
+        [ActivatorUtilitiesConstructor]
+        public ClientLinkClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
+            if (string.IsNullOrWhiteSpace(options.ClientId)) {
+                throw new ArgumentNullException(nameof(options.ClientId));
             }
 
-            _clientId = clientId!;
+            _clientId = options.ClientId!;
         }
 
         public async Task<ClientLinkResponse> CreateClientLinkAsync(ClientLinkRequest request, CancellationToken cancellationToken = default)

--- a/src/Mollie.Api/Client/ConnectClient.cs
+++ b/src/Mollie.Api/Client/ConnectClient.cs
@@ -5,10 +5,12 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Models.Connect.Request;
 using Mollie.Api.Models.Connect.Response;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class ConnectClient : BaseMollieClient, IConnectClient {
@@ -29,6 +31,20 @@ namespace Mollie.Api.Client {
 
             _clientSecret = clientSecret!;
             _clientId = clientId!;
+        }
+
+        [ActivatorUtilitiesConstructor]
+        public ConnectClient(MollieClientOptions options, HttpClient? httpClient = null): base(httpClient, ConnectClient.TokenEndPoint) {
+            if (string.IsNullOrWhiteSpace(options.ClientId)) {
+                throw new ArgumentNullException(nameof(options.ClientId));
+            }
+
+            if (string.IsNullOrWhiteSpace(options.ClientSecret)) {
+                throw new ArgumentNullException(nameof(options.ClientSecret));
+            }
+
+            _clientSecret = options.ClientSecret!;
+            _clientId = options.ClientId!;
         }
 
         public string GetAuthorizationUrl(

--- a/src/Mollie.Api/Client/CustomerClient.cs
+++ b/src/Mollie.Api/Client/CustomerClient.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
@@ -12,13 +13,16 @@ using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Payment.Request;
 using Mollie.Api.Models.Payment.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class CustomerClient : BaseMollieClient, ICustomerClient {
         public CustomerClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public CustomerClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public CustomerClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<CustomerResponse> CreateCustomerAsync(

--- a/src/Mollie.Api/Client/InvoiceClient.cs
+++ b/src/Mollie.Api/Client/InvoiceClient.cs
@@ -3,19 +3,23 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.Invoice.Response;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class InvoiceClient : OauthBaseMollieClient, IInvoiceClient {
         public InvoiceClient(string oauthAccessToken, HttpClient? httpClient = null) : base(oauthAccessToken, httpClient) {
         }
 
-        public InvoiceClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public InvoiceClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<InvoiceResponse> GetInvoiceAsync(

--- a/src/Mollie.Api/Client/MandateClient.cs
+++ b/src/Mollie.Api/Client/MandateClient.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
@@ -10,13 +11,16 @@ using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Mandate.Request;
 using Mollie.Api.Models.Mandate.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class MandateClient : BaseMollieClient, IMandateClient {
         public MandateClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public MandateClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public MandateClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<MandateResponse> GetMandateAsync(

--- a/src/Mollie.Api/Client/OauthBaseMollieClient.cs
+++ b/src/Mollie.Api/Client/OauthBaseMollieClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using Mollie.Api.Framework.Authentication.Abstract;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class OauthBaseMollieClient : BaseMollieClient {
@@ -9,8 +10,8 @@ namespace Mollie.Api.Client {
             ValidateApiKeyIsOauthAccesstoken(oauthAccessToken);
         }
 
-        protected OauthBaseMollieClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
-            : base(mollieSecretManager, httpClient) {
+        protected OauthBaseMollieClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
             ValidateApiKeyIsOauthAccesstoken(mollieSecretManager.GetBearerToken());
         }
 

--- a/src/Mollie.Api/Client/OnboardingClient.cs
+++ b/src/Mollie.Api/Client/OnboardingClient.cs
@@ -5,13 +5,17 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Mollie.Api.Framework.Authentication.Abstract;
 using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class OnboardingClient : BaseMollieClient, IOnboardingClient {
         public OnboardingClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public OnboardingClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public OnboardingClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<OnboardingStatusResponse> GetOnboardingStatusAsync(

--- a/src/Mollie.Api/Client/OrderClient.cs
+++ b/src/Mollie.Api/Client/OrderClient.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
@@ -12,13 +13,16 @@ using Mollie.Api.Models.Order.Request.ManageOrderLines;
 using Mollie.Api.Models.Order.Response;
 using Mollie.Api.Models.Payment.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class OrderClient : BaseMollieClient, IOrderClient {
         public OrderClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public OrderClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public OrderClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<OrderResponse> CreateOrderAsync(

--- a/src/Mollie.Api/Client/OrganizationClient.cs
+++ b/src/Mollie.Api/Client/OrganizationClient.cs
@@ -1,18 +1,22 @@
 ﻿using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Organization;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class OrganizationClient : OauthBaseMollieClient, IOrganizationClient {
         public OrganizationClient(string oauthAccessToken, HttpClient? httpClient = null) : base(oauthAccessToken, httpClient) {
         }
 
-        public OrganizationClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public OrganizationClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<OrganizationResponse> GetCurrentOrganizationAsync(CancellationToken cancellationToken = default) {

--- a/src/Mollie.Api/Client/PaymentClient.cs
+++ b/src/Mollie.Api/Client/PaymentClient.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
@@ -10,13 +11,16 @@ using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Payment.Request;
 using Mollie.Api.Models.Payment.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class PaymentClient : BaseMollieClient, IPaymentClient {
 
 	    public PaymentClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) { }
 
-        public PaymentClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public PaymentClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<PaymentResponse> CreatePaymentAsync(

--- a/src/Mollie.Api/Client/PaymentLinkClient.cs
+++ b/src/Mollie.Api/Client/PaymentLinkClient.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
@@ -11,6 +12,7 @@ using Mollie.Api.Models.Payment.Response;
 using Mollie.Api.Models.PaymentLink.Request;
 using Mollie.Api.Models.PaymentLink.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client
 {
@@ -18,7 +20,9 @@ namespace Mollie.Api.Client
     {
         public PaymentLinkClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) { }
 
-        public PaymentLinkClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public PaymentLinkClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<PaymentLinkResponse> CreatePaymentLinkAsync(

--- a/src/Mollie.Api/Client/PaymentMethodClient.cs
+++ b/src/Mollie.Api/Client/PaymentMethodClient.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
@@ -10,6 +11,7 @@ using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Payment;
 using Mollie.Api.Models.PaymentMethod.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client
 {
@@ -18,7 +20,9 @@ namespace Mollie.Api.Client
         public PaymentMethodClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public PaymentMethodClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public PaymentMethodClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<PaymentMethodResponse> GetPaymentMethodAsync(

--- a/src/Mollie.Api/Client/PermissionClient.cs
+++ b/src/Mollie.Api/Client/PermissionClient.cs
@@ -1,18 +1,22 @@
 ﻿using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Permission.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class PermissionClient : OauthBaseMollieClient, IPermissionClient {
         public PermissionClient(string oauthAccessToken, HttpClient? httpClient = null) : base(oauthAccessToken, httpClient) {
         }
 
-        public PermissionClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public PermissionClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<PermissionResponse> GetPermissionAsync(

--- a/src/Mollie.Api/Client/ProfileClient.cs
+++ b/src/Mollie.Api/Client/ProfileClient.cs
@@ -1,6 +1,7 @@
 ﻿﻿using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.List.Response;
@@ -8,13 +9,16 @@ using Mollie.Api.Models.PaymentMethod.Response;
 using Mollie.Api.Models.Profile.Request;
 using Mollie.Api.Models.Profile.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class ProfileClient : BaseMollieClient, IProfileClient {
         public ProfileClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public ProfileClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public ProfileClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<ProfileResponse> CreateProfileAsync(

--- a/src/Mollie.Api/Client/RefundClient.cs
+++ b/src/Mollie.Api/Client/RefundClient.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
@@ -11,13 +12,16 @@ using Mollie.Api.Models.Order.Response;
 using Mollie.Api.Models.Refund.Request;
 using Mollie.Api.Models.Refund.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class RefundClient : BaseMollieClient, IRefundClient {
         public RefundClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public RefundClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public RefundClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<RefundResponse> CreatePaymentRefundAsync(

--- a/src/Mollie.Api/Client/SettlementClient.cs
+++ b/src/Mollie.Api/Client/SettlementClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.Capture.Response;
@@ -10,13 +11,16 @@ using Mollie.Api.Models.Payment.Response;
 using Mollie.Api.Models.Refund.Response;
 using Mollie.Api.Models.Settlement.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class SettlementClient : BaseMollieClient, ISettlementClient {
         public SettlementClient(string oauthAccessToken, HttpClient? httpClient = null) : base(oauthAccessToken, httpClient) {
         }
 
-        public SettlementClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public SettlementClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<SettlementResponse> GetSettlementAsync(

--- a/src/Mollie.Api/Client/ShipmentClient.cs
+++ b/src/Mollie.Api/Client/ShipmentClient.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
@@ -9,6 +10,7 @@ using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Shipment.Request;
 using Mollie.Api.Models.Shipment.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client
 {
@@ -16,7 +18,9 @@ namespace Mollie.Api.Client
         public ShipmentClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public ShipmentClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public ShipmentClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<ShipmentResponse> CreateShipmentAsync(

--- a/src/Mollie.Api/Client/SubscriptionClient.cs
+++ b/src/Mollie.Api/Client/SubscriptionClient.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
@@ -11,13 +12,16 @@ using Mollie.Api.Models.Payment.Response;
 using Mollie.Api.Models.Subscription.Request;
 using Mollie.Api.Models.Subscription.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class SubscriptionClient : BaseMollieClient, ISubscriptionClient {
         public SubscriptionClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public SubscriptionClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public SubscriptionClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<ListResponse<SubscriptionResponse>> GetSubscriptionListAsync(

--- a/src/Mollie.Api/Client/TerminalClient.cs
+++ b/src/Mollie.Api/Client/TerminalClient.cs
@@ -2,19 +2,23 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Terminal.Response;
 using Mollie.Api.Models.Url;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class TerminalClient : BaseMollieClient, ITerminalClient
     {
         public TerminalClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) { }
 
-        public TerminalClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public TerminalClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<TerminalResponse> GetTerminalAsync(

--- a/src/Mollie.Api/Client/WalletClient.cs
+++ b/src/Mollie.Api/Client/WalletClient.cs
@@ -1,17 +1,21 @@
 ﻿using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Framework.Authentication.Abstract;
 using Mollie.Api.Models.Wallet.Request;
 using Mollie.Api.Models.Wallet.Response;
+using Mollie.Api.Options;
 
 namespace Mollie.Api.Client {
     public class WalletClient : BaseMollieClient, IWalletClient {
         public WalletClient(string apiKey, HttpClient? httpClient = null) : base(apiKey, httpClient) {
         }
 
-        public WalletClient(IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null) : base(mollieSecretManager, httpClient) {
+        [ActivatorUtilitiesConstructor]
+        public WalletClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+            : base(options, mollieSecretManager, httpClient) {
         }
 
         public async Task<ApplePayPaymentSessionResponse> RequestApplePayPaymentSessionAsync(

--- a/src/Mollie.Api/DependencyInjection.cs
+++ b/src/Mollie.Api/DependencyInjection.cs
@@ -29,6 +29,7 @@ namespace Mollie.Api {
                 ApiKey = mollieOptions.ApiKey,
                 ClientId = mollieOptions.ClientId,
                 ClientSecret = mollieOptions.ClientSecret,
+                CustomUserAgent = mollieOptions.CustomUserAgent
             };
             services.AddSingleton(mollieClientOptions);
 

--- a/src/Mollie.Api/DependencyInjection.cs
+++ b/src/Mollie.Api/DependencyInjection.cs
@@ -25,66 +25,48 @@ namespace Mollie.Api {
                     new DefaultMollieSecretManager(mollieOptions.ApiKey));
             }
 
-            RegisterMollieApiClient<IBalanceClient, BalanceClient>(services, (httpClient, provider) =>
-                new BalanceClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<ICaptureClient, CaptureClient>(services, (httpClient, provider) =>
-                new CaptureClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IChargebackClient, ChargebackClient>(services, (httpClient, provider) =>
-                new ChargebackClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IConnectClient, ConnectClient>(services, (httpClient, _) =>
-                new ConnectClient(mollieOptions.ClientId, mollieOptions.ClientSecret, httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<ICustomerClient, CustomerClient>(services, (httpClient, provider) =>
-                new CustomerClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IInvoiceClient, InvoiceClient>(services, (httpClient, provider) =>
-                new InvoiceClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IMandateClient, MandateClient>(services, (httpClient, provider) =>
-                new MandateClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IOnboardingClient, OnboardingClient>(services, (httpClient, provider) =>
-                new OnboardingClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IOrderClient, OrderClient>(services,(httpClient, provider) =>
-                new OrderClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IOrganizationClient, OrganizationClient>(services, (httpClient, provider) =>
-                new OrganizationClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IPaymentClient, PaymentClient>(services, (httpClient, provider) =>
-                new PaymentClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IPaymentLinkClient, PaymentLinkClient>(services, (httpClient, provider) =>
-                new PaymentLinkClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IPaymentMethodClient, PaymentMethodClient>(services, (httpClient, provider) =>
-                new PaymentMethodClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IPermissionClient, PermissionClient>(services, (httpClient, provider) =>
-                new PermissionClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IProfileClient, ProfileClient>(services, (httpClient, provider) =>
-                new ProfileClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IRefundClient, RefundClient>(services, (httpClient, provider) =>
-                new RefundClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<ISettlementClient, SettlementClient>(services, (httpClient, provider) =>
-                new SettlementClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IShipmentClient, ShipmentClient>(services, (httpClient, provider) =>
-                new ShipmentClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<ISubscriptionClient, SubscriptionClient>(services, (httpClient, provider) =>
-                new SubscriptionClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<ITerminalClient, TerminalClient>(services, (httpClient, provider) =>
-                new TerminalClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IClientLinkClient, ClientLinkClient>(services, (httpClient, provider) =>
-                new ClientLinkClient(mollieOptions.ClientId, provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IWalletClient, WalletClient>(services, (httpClient, provider) =>
-                new WalletClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<IClientClient, ClientClient>(services, (httpClient, provider) =>
-                new ClientClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
-            RegisterMollieApiClient<ICapabilityClient, CapabilityClient>(services, (httpClient, provider) =>
-                new CapabilityClient(provider.GetRequiredService<IMollieSecretManager>(), httpClient), mollieOptions.RetryPolicy);
+            MollieClientOptions mollieClientOptions = new() {
+                ApiKey = mollieOptions.ApiKey,
+                ClientId = mollieOptions.ClientId,
+                ClientSecret = mollieOptions.ClientSecret,
+            };
+            services.AddSingleton(mollieClientOptions);
+
+            RegisterMollieApiClient<IBalanceClient, BalanceClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<ICaptureClient, CaptureClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IChargebackClient, ChargebackClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IConnectClient, ConnectClient>(services,  mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<ICustomerClient, CustomerClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IInvoiceClient, InvoiceClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IMandateClient, MandateClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IOnboardingClient, OnboardingClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IOrderClient, OrderClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IOrganizationClient, OrganizationClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IPaymentClient, PaymentClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IPaymentLinkClient, PaymentLinkClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IPaymentMethodClient, PaymentMethodClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IPermissionClient, PermissionClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IProfileClient, ProfileClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IRefundClient, RefundClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<ISettlementClient, SettlementClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IShipmentClient, ShipmentClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<ISubscriptionClient, SubscriptionClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<ITerminalClient, TerminalClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IClientLinkClient, ClientLinkClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IWalletClient, WalletClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IClientClient, ClientClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<ICapabilityClient, CapabilityClient>(services, mollieOptions.RetryPolicy);
 
             return services;
         }
 
         static void RegisterMollieApiClient<TInterface, TImplementation>(
             IServiceCollection services,
-            Func<HttpClient, IServiceProvider, TImplementation> factory,
             IAsyncPolicy<HttpResponseMessage>? retryPolicy = null)
             where TInterface : class
             where TImplementation : class, TInterface {
 
-            IHttpClientBuilder clientBuilder = services.AddHttpClient<TInterface, TImplementation>(factory);
+            IHttpClientBuilder clientBuilder = services.AddHttpClient<TInterface, TImplementation>();
             if (retryPolicy != null) {
                 clientBuilder.AddPolicyHandler(retryPolicy);
             }

--- a/src/Mollie.Api/Options/MollieClientOptions.cs
+++ b/src/Mollie.Api/Options/MollieClientOptions.cs
@@ -7,8 +7,8 @@ public class MollieClientOptions {
     public required string ApiKey { get; init; } = string.Empty;
 
     /// <summary>
-    /// The default user agent is "Mollie.Api.NET {version}". When this property is set, the custom user agent will be
-    /// appended to the default user agent.
+    /// (Optional) The default user agent is "Mollie.Api.NET {version}". When this property is set, the custom user
+    /// agent will be appended to the default user agent.
     /// </summary>
     public string? CustomUserAgent { get; init; }
 

--- a/src/Mollie.Api/Options/MollieClientOptions.cs
+++ b/src/Mollie.Api/Options/MollieClientOptions.cs
@@ -4,22 +4,22 @@ public class MollieClientOptions {
     /// <summary>
     /// Your API-key or OAuth token
     /// </summary>
-    public string ApiKey { get; set; } = string.Empty;
+    public required string ApiKey { get; init; } = string.Empty;
 
     /// <summary>
     /// The default user agent is "Mollie.Api.NET {version}". When this property is set, the custom user agent will be
     /// appended to the default user agent.
     /// </summary>
-    public string? CustomUserAgent { get; set; } = null;
+    public string? CustomUserAgent { get; init; }
 
     /// <summary>
     /// (Optional) ClientId used by Connect API
     /// </summary>
-    public string? ClientId { get; set; } = string.Empty;
+    public string? ClientId { get; init; }
 
     /// <summary>
     /// (Optional) ClientSecret used by Connect API
     /// </summary>
     /// <returns></returns>
-    public string? ClientSecret { get; set; } = string.Empty;
+    public string? ClientSecret { get; init; }
 }

--- a/src/Mollie.Api/Options/MollieClientOptions.cs
+++ b/src/Mollie.Api/Options/MollieClientOptions.cs
@@ -7,6 +7,12 @@ public class MollieClientOptions {
     public string ApiKey { get; set; } = string.Empty;
 
     /// <summary>
+    /// The default user agent is "Mollie.Api.NET {version}". When this property is set, the custom user agent will be
+    /// appended to the default user agent.
+    /// </summary>
+    public string? CustomUserAgent { get; set; } = null;
+
+    /// <summary>
     /// (Optional) ClientId used by Connect API
     /// </summary>
     public string? ClientId { get; set; } = string.Empty;

--- a/src/Mollie.Api/Options/MollieClientOptions.cs
+++ b/src/Mollie.Api/Options/MollieClientOptions.cs
@@ -1,0 +1,19 @@
+namespace Mollie.Api.Options;
+
+public class MollieClientOptions {
+    /// <summary>
+    /// Your API-key or OAuth token
+    /// </summary>
+    public string ApiKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// (Optional) ClientId used by Connect API
+    /// </summary>
+    public string? ClientId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// (Optional) ClientSecret used by Connect API
+    /// </summary>
+    /// <returns></returns>
+    public string? ClientSecret { get; set; } = string.Empty;
+}

--- a/src/Mollie.Api/Options/MollieOptions.cs
+++ b/src/Mollie.Api/Options/MollieOptions.cs
@@ -27,7 +27,13 @@ namespace Mollie.Api.Options {
         public IAsyncPolicy<HttpResponseMessage>? RetryPolicy { get; set; }
 
         /// <summary>
-        /// A custom secret manager that you can override to implement advanced multi-tenant scenario's
+        /// (Optional) The default user agent is "Mollie.Api.NET {version}". When this property is set, the custom user
+        /// agent will be appended to the default user agent.
+        /// </summary>
+        public string? CustomUserAgent { get; init; }
+
+        /// <summary>
+        /// (Optional) A custom secret manager that you can override to implement advanced multi-tenant scenario's
         /// </summary>
         public Type? CustomMollieSecretManager { get; private set; }
 


### PR DESCRIPTION
Mollie has requested me to add a feature that allows library users to append a custom string to the `User-Agent` header that is sent with every request. Previously, we always sent the following string as the `User-Agent`: `Mollie.Api.NET/{versionNumber}`. 

It is now possible to append a custom user agent string, by setting the `MollieOptions.CustomUserAgent` property. When this property is set, the value of the `CustomUserAgent` is appended to the default user agent. For example, when the `CustomUserAgent` property is set to `my-custom-user-agent`, the `User-Agent` value will be `Mollie.Api.NET/{versionNumber} my-custom-user-agent`.