### PR TITLE
Add support for custom base URL's in MollieOptions

### DIFF
--- a/src/Mollie.Api/Client/BaseMollieClient.cs
+++ b/src/Mollie.Api/Client/BaseMollieClient.cs
@@ -19,8 +19,9 @@ using Newtonsoft.Json;
 
 namespace Mollie.Api.Client {
     public abstract class BaseMollieClient : IDisposable {
-        public const string ApiEndPoint = "https://api.mollie.com/v2/";
-        private readonly string _apiEndpoint = ApiEndPoint;
+        public const string DefaultBaseApiEndPoint = "https://api.mollie.com/v2/";
+
+        private readonly string _apiEndpoint = DefaultBaseApiEndPoint;
         private readonly IMollieSecretManager _mollieSecretManager;
         private readonly MollieClientOptions _options;
         private readonly HttpClient _httpClient;
@@ -50,9 +51,10 @@ namespace Mollie.Api.Client {
             _httpClient = httpClient ?? new HttpClient();
             _mollieSecretManager = mollieSecretManager;
             _options = options;
+            _apiEndpoint = options.ApiBaseUrl;
         }
 
-        protected BaseMollieClient(HttpClient? httpClient = null, string apiEndpoint = ApiEndPoint) {
+        protected BaseMollieClient(HttpClient? httpClient = null, string apiEndpoint = DefaultBaseApiEndPoint) {
             _apiEndpoint = apiEndpoint;
             _jsonConverterService = new JsonConverterService();
             _createdHttpClient = httpClient == null;

--- a/src/Mollie.Api/DependencyInjection.cs
+++ b/src/Mollie.Api/DependencyInjection.cs
@@ -29,7 +29,10 @@ namespace Mollie.Api {
                 ApiKey = mollieOptions.ApiKey,
                 ClientId = mollieOptions.ClientId,
                 ClientSecret = mollieOptions.ClientSecret,
-                CustomUserAgent = mollieOptions.CustomUserAgent
+                CustomUserAgent = mollieOptions.CustomUserAgent,
+                ApiBaseUrl = mollieOptions.ApiBaseUrl,
+                ConnectTokenEndPoint = mollieOptions.ConnectTokenEndPoint,
+                ConnectOAuthAuthorizeEndPoint = mollieOptions.ConnectOAuthAuthorizeEndPoint
             };
             services.AddSingleton(mollieClientOptions);
 

--- a/src/Mollie.Api/Options/MollieClientOptions.cs
+++ b/src/Mollie.Api/Options/MollieClientOptions.cs
@@ -1,3 +1,5 @@
+using Mollie.Api.Client;
+
 namespace Mollie.Api.Options;
 
 public class MollieClientOptions {
@@ -22,4 +24,19 @@ public class MollieClientOptions {
     /// </summary>
     /// <returns></returns>
     public string? ClientSecret { get; init; }
+
+    /// <summary>
+    /// The base URL for all API requests. Can be overridden for testing purposes.
+    /// </summary>
+    public string ApiBaseUrl { get; init; } = BaseMollieClient.DefaultBaseApiEndPoint;
+
+    /// <summary>
+    /// The authorize endpoint for the Connect client. Can be overridden for testing purposes.
+    /// </summary>
+    public string ConnectOAuthAuthorizeEndPoint { get; init; } = ConnectClient.DefaultAuthorizeEndpoint;
+
+    /// <summary>
+    /// The token endpoint for the Connect client. Can be overridden for testing purposes.
+    /// </summary>
+    public string ConnectTokenEndPoint { get; init; } = ConnectClient.DefaultTokenEndpoint;
 }

--- a/src/Mollie.Api/Options/MollieOptions.cs
+++ b/src/Mollie.Api/Options/MollieOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using Mollie.Api.Client;
 using Mollie.Api.Framework.Authentication.Abstract;
 using Polly;
 
@@ -20,6 +21,21 @@ namespace Mollie.Api.Options {
         /// </summary>
         /// <returns></returns>
         public string? ClientSecret { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The base URL for all API requests. Can be overridden for testing purposes.
+        /// </summary>
+        public string ApiBaseUrl { get; init; } = BaseMollieClient.DefaultBaseApiEndPoint;
+
+        /// <summary>
+        /// The authorize endpoint for the Connect client. Can be overridden for testing purposes.
+        /// </summary>
+        public string ConnectOAuthAuthorizeEndPoint { get; init; } = ConnectClient.DefaultAuthorizeEndpoint;
+
+        /// <summary>
+        /// The token endpoint for the Connect client. Can be overridden for testing purposes.
+        /// </summary>
+        public string ConnectTokenEndPoint { get; init; } = ConnectClient.DefaultTokenEndpoint;
 
         /// <summary>
         /// (Optional) Polly retry policy for failed requests

--- a/src/Mollie.Api/Options/MollieOptions.cs
+++ b/src/Mollie.Api/Options/MollieOptions.cs
@@ -25,17 +25,17 @@ namespace Mollie.Api.Options {
         /// <summary>
         /// The base URL for all API requests. Can be overridden for testing purposes.
         /// </summary>
-        public string ApiBaseUrl { get; init; } = BaseMollieClient.DefaultBaseApiEndPoint;
+        public string ApiBaseUrl { get; set; } = BaseMollieClient.DefaultBaseApiEndPoint;
 
         /// <summary>
         /// The authorize endpoint for the Connect client. Can be overridden for testing purposes.
         /// </summary>
-        public string ConnectOAuthAuthorizeEndPoint { get; init; } = ConnectClient.DefaultAuthorizeEndpoint;
+        public string ConnectOAuthAuthorizeEndPoint { get; set; } = ConnectClient.DefaultAuthorizeEndpoint;
 
         /// <summary>
         /// The token endpoint for the Connect client. Can be overridden for testing purposes.
         /// </summary>
-        public string ConnectTokenEndPoint { get; init; } = ConnectClient.DefaultTokenEndpoint;
+        public string ConnectTokenEndPoint { get; set; } = ConnectClient.DefaultTokenEndpoint;
 
         /// <summary>
         /// (Optional) Polly retry policy for failed requests

--- a/tests/Mollie.Tests.Unit/Client/BalanceClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/BalanceClientTests.cs
@@ -20,7 +20,7 @@ namespace Mollie.Tests.Unit.Client {
           // Given: We request a specific balance
           var getBalanceResponseFactory = new GetBalanceResponseFactory();
           var getBalanceResponse = getBalanceResponseFactory.CreateGetBalanceResponse();
-          string expectedUrl = $"{BaseMollieClient.ApiEndPoint}balances/{getBalanceResponseFactory.BalanceId}";
+          string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}balances/{getBalanceResponseFactory.BalanceId}";
           var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, expectedUrl, getBalanceResponse);
           HttpClient httpClient = mockHttp.ToHttpClient();
           BalanceClient balanceClient = new BalanceClient("api-key", httpClient);
@@ -78,7 +78,7 @@ namespace Mollie.Tests.Unit.Client {
           // Given: We request the primary balance
           var getBalanceResponseFactory = new GetBalanceResponseFactory();
           var getBalanceResponse = getBalanceResponseFactory.CreateGetBalanceResponse();
-          string expectedUrl = $"{BaseMollieClient.ApiEndPoint}balances/primary";
+          string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}balances/primary";
           var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, expectedUrl, getBalanceResponse);
           HttpClient httpClient = mockHttp.ToHttpClient();
           BalanceClient balanceClient = new BalanceClient("api-key", httpClient);
@@ -111,7 +111,7 @@ namespace Mollie.Tests.Unit.Client {
       [Fact]
       public async Task ListBalancesAsync_DefaultBehaviour_ResponseIsParsed() {
           // Given: We request a list of balances
-          string expectedUrl = $"{BaseMollieClient.ApiEndPoint}balances";
+          string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}balances";
           var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, expectedUrl, DefaultListBalancesResponse);
           HttpClient httpClient = mockHttp.ToHttpClient();
           BalanceClient balanceClient = new BalanceClient("api-key", httpClient);
@@ -134,7 +134,7 @@ namespace Mollie.Tests.Unit.Client {
           DateTime until = new DateTime(2022, 11, 30);
           string grouping = ReportGrouping.TransactionCategories;
 
-          string expectedUrl = $"{BaseMollieClient.ApiEndPoint}balances/{balanceId}/report" +
+          string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}balances/{balanceId}/report" +
                                $"?from={from.ToString("yyyy-MM-dd")}&until={until.ToString("yyyy-MM-dd")}&grouping={grouping}";
           var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, expectedUrl, DefaultGetBalanceReportTransactionCategoriesResponse);
           HttpClient httpClient = mockHttp.ToHttpClient();
@@ -194,7 +194,7 @@ namespace Mollie.Tests.Unit.Client {
           DateTime until = new DateTime(2022, 11, 30);
           string grouping = ReportGrouping.StatusBalances;
 
-          string expectedUrl = $"{BaseMollieClient.ApiEndPoint}balances/{balanceId}/report" +
+          string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}balances/{balanceId}/report" +
                                $"?from={from.ToString("yyyy-MM-dd")}&until={until.ToString("yyyy-MM-dd")}&grouping={grouping}";
           var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, expectedUrl, DefaultGetBalanceReportStatusBalancesResponse);
           HttpClient httpClient = mockHttp.ToHttpClient();
@@ -228,7 +228,7 @@ namespace Mollie.Tests.Unit.Client {
       public async Task ListBalanceTransactionsAsync_StatusBalances_ResponseIsParsed() {
           // Given
           string balanceId = "bal_CKjKwQdjCwCSArXFAJNFH";
-          string expectedUrl = $"{BaseMollieClient.ApiEndPoint}balances/{balanceId}/transactions";
+          string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}balances/{balanceId}/transactions";
           var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, expectedUrl, DefaultListBalanceTransactionsResponse);
           HttpClient httpClient = mockHttp.ToHttpClient();
           BalanceClient balanceClient = new BalanceClient("api-key", httpClient);
@@ -275,7 +275,7 @@ namespace Mollie.Tests.Unit.Client {
       [Fact]
       public async Task ListPrimaryBalanceTransactionsAsync_StatusBalances_ResponseIsParsed() {
           // Given
-          string expectedUrl = $"{BaseMollieClient.ApiEndPoint}balances/primary/transactions";
+          string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}balances/primary/transactions";
           var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, expectedUrl, DefaultListBalanceTransactionsResponse);
           HttpClient httpClient = mockHttp.ToHttpClient();
           BalanceClient balanceClient = new BalanceClient("api-key", httpClient);

--- a/tests/Mollie.Tests.Unit/Client/BaseMollieClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/BaseMollieClientTests.cs
@@ -32,7 +32,7 @@ public class BaseMollieClientTests : BaseClientTests {
     ""status"": {errorStatus},
     ""title"": ""Error""
 }}";
-        const string expectedUrl = $"{BaseMollieClient.ApiEndPoint}payments";
+        const string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}payments";
         var mockHttp = CreateMockHttpMessageHandler(
             HttpMethod.Post,
             expectedUrl,
@@ -57,7 +57,7 @@ public class BaseMollieClientTests : BaseClientTests {
     public async Task HttpResponseStatusCodeIsNotSuccesfull_ResponseBodyContainsHtml_MollieApiExceptionIsThrown() {
         // Arrange
         string responseBody = "<html><body>Whoops!</body></html>";
-        const string expectedUrl = $"{BaseMollieClient.ApiEndPoint}payments";
+        const string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}payments";
         var mockHttp = CreateMockHttpMessageHandler(
             HttpMethod.Post,
             expectedUrl,
@@ -84,7 +84,7 @@ public class BaseMollieClientTests : BaseClientTests {
         // Arrange
         const string customUserAgent = "my-user-agent";
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Get,$"{BaseMollieClient.ApiEndPoint}methods")
+        mockHttp.Expect(HttpMethod.Get,$"{BaseMollieClient.DefaultBaseApiEndPoint}methods")
             .With(request => {
                 var userAgent = request.Headers.UserAgent.ToArray();
                 userAgent.ShouldNotBeNull();
@@ -114,7 +114,7 @@ public class BaseMollieClientTests : BaseClientTests {
     public async Task NoustomUserAgentIsSetInOptions_UserAgentIsAppendedToDefaultUserAgent() {
         // Arrange
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Get,$"{BaseMollieClient.ApiEndPoint}methods")
+        mockHttp.Expect(HttpMethod.Get,$"{BaseMollieClient.DefaultBaseApiEndPoint}methods")
             .With(request => {
                 var userAgent = request.Headers.UserAgent.ToArray();
                 userAgent.ShouldNotBeNull();

--- a/tests/Mollie.Tests.Unit/Client/BaseMollieClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/BaseMollieClientTests.cs
@@ -111,7 +111,7 @@ public class BaseMollieClientTests : BaseClientTests {
     }
 
     [Fact]
-    public async Task NoustomUserAgentIsSetInOptions_UserAgentIsAppendedToDefaultUserAgent() {
+    public async Task NoCustomUserAgentIsSetInOptions_UserAgentIsAppendedToDefaultUserAgent() {
         // Arrange
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.Expect(HttpMethod.Get,$"{BaseMollieClient.DefaultBaseApiEndPoint}methods")
@@ -129,6 +129,27 @@ public class BaseMollieClientTests : BaseClientTests {
             CustomUserAgent = null,
             ApiKey = "api-key"
         };
+        var secretManager = new DefaultMollieSecretManager(mollieClientOptions.ApiKey);
+        using var paymentMethodClient = new PaymentMethodClient(mollieClientOptions, secretManager, httpClient);
+
+        // Act
+        await paymentMethodClient.GetPaymentMethodListAsync();
+
+        // Assert
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task CustomApiBaseUrlIsSetInOptions_RequestsAreRoutedToCustomApiUrl() {
+        // Arrange
+        var mockHttp = new MockHttpMessageHandler();
+        var mollieClientOptions = new MollieClientOptions {
+            ApiKey = "api-key",
+            ApiBaseUrl = "https://custom-api-base.mollie.com/v2/"
+        };
+        mockHttp.Expect(HttpMethod.Get,$"{mollieClientOptions.ApiBaseUrl}methods")
+            .Respond("application/json", DefaultPaymentMethodJsonResponse);
+        HttpClient httpClient = mockHttp.ToHttpClient();
         var secretManager = new DefaultMollieSecretManager(mollieClientOptions.ApiKey);
         using var paymentMethodClient = new PaymentMethodClient(mollieClientOptions, secretManager, httpClient);
 

--- a/tests/Mollie.Tests.Unit/Client/CapabilityClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/CapabilityClientTests.cs
@@ -17,7 +17,7 @@ public class CapabilityClientTests {
     {
         // Arrange
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Get,$"{BaseMollieClient.ApiEndPoint}capabilities")
+        mockHttp.Expect(HttpMethod.Get,$"{BaseMollieClient.DefaultBaseApiEndPoint}capabilities")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", DefaultListCapabilitiesResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();

--- a/tests/Mollie.Tests.Unit/Client/CaptureClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/CaptureClientTests.cs
@@ -73,7 +73,7 @@ namespace Mollie.Tests.Unit.Client {
             // Given: We make a request to retrieve a capture
             const string paymentId = "payment-id";
             const string captureId = "capture-id";
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}/captures/{captureId}{expectedQueryString}", defaultCaptureJsonResponse);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}/captures/{captureId}{expectedQueryString}", defaultCaptureJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             CaptureClient captureClient = new CaptureClient("abcde", httpClient);
 
@@ -90,7 +90,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetCapturesListAsync_CorrectQueryParametersAreAdded(bool testmode, string expectedQueryString) {
             // Given: We make a request to retrieve a capture
             const string paymentId = "payment-id";
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}/captures{expectedQueryString}", defaultCaptureJsonResponse);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}/captures{expectedQueryString}", defaultCaptureJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             CaptureClient captureClient = new CaptureClient("abcde", httpClient);
 
@@ -104,7 +104,7 @@ namespace Mollie.Tests.Unit.Client {
         [Fact]
         public async Task GetCaptureAsync_DefaultBehaviour_ResponseIsParsed() {
             // Given: We request a capture with a payment id and capture id
-            string expectedUrl = $"{BaseMollieClient.ApiEndPoint}payments/{defaultPaymentId}/captures/{defaultCaptureId}";
+            string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{defaultPaymentId}/captures/{defaultCaptureId}";
             var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, expectedUrl, defaultCaptureJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             CaptureClient captureClient = new CaptureClient("api-key", httpClient);
@@ -126,7 +126,7 @@ namespace Mollie.Tests.Unit.Client {
         [Fact]
         public async Task GetCapturesListAsync_DefaultBehaviour_ResponseIsParsed() {
             // Given: We request a list of captures
-            string expectedUrl = $"{BaseMollieClient.ApiEndPoint}payments/{defaultPaymentId}/captures";
+            string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{defaultPaymentId}/captures";
             var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, expectedUrl, defaultCaptureListJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             CaptureClient captureClient = new CaptureClient("api-key", httpClient);
@@ -237,7 +237,7 @@ namespace Mollie.Tests.Unit.Client {
             };
             var mockHttp = CreateMockHttpMessageHandler(
                 HttpMethod.Post,
-                $"{BaseMollieClient.ApiEndPoint}payments/{defaultPaymentId}/captures",
+                $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{defaultPaymentId}/captures",
                 defaultCaptureJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             CaptureClient captureClient = new CaptureClient("abcde", httpClient);

--- a/tests/Mollie.Tests.Unit/Client/ChargebackClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/ChargebackClientTests.cs
@@ -52,7 +52,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetChargebackAsync_ResponseIsDeserializedInExpectedFormat() {
             // Given: we retrieve the chargeback by id and payment id
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}*")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}*")
                 .Respond("application/json", defaultGetChargebacksResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             ChargebackClient chargebackClient = new ChargebackClient("abcde", httpClient);
@@ -74,7 +74,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetOrderRefundListAsync_QueryParameterOptions_CorrectParametersAreAdded(bool testmode, string expectedQueryString) {
             // Given: we retrieve the chargeback by id and payment id
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}payments/{defaultPaymentId}/chargebacks/{defaultChargebackId}{expectedQueryString}")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{defaultPaymentId}/chargebacks/{defaultChargebackId}{expectedQueryString}")
                 .Respond("application/json", defaultGetChargebacksResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             ChargebackClient chargebackClient = new ChargebackClient("abcde", httpClient);
@@ -94,7 +94,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetChargebacksListAsync_FromLimitTestmodeQueryParameterOptions_CorrectParametersAreAdded(string? from, int? limit, bool testmode, string expectedQueryString) {
             // Given: we retrieve the chargeback by id and payment id
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}payments/{defaultPaymentId}/chargebacks{expectedQueryString}")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{defaultPaymentId}/chargebacks{expectedQueryString}")
                 .Respond("application/json", defaultGetChargebacksResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             ChargebackClient chargebackClient = new ChargebackClient("abcde", httpClient);
@@ -113,7 +113,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetChargebacksListAsync_ProfileTestModeQueryParameterOptions_CorrectParametersAreAdded(string? profileId, bool testmode, string expectedQueryString) {
             // Given: we retrieve the chargeback by id and payment id
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}chargebacks{expectedQueryString}")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}chargebacks{expectedQueryString}")
                 .Respond("application/json", defaultGetChargebacksResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             ChargebackClient chargebackClient = new ChargebackClient("abcde", httpClient);

--- a/tests/Mollie.Tests.Unit/Client/ClientClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/ClientClientTests.cs
@@ -29,7 +29,7 @@ public class ClientClientTests : BaseClientTests {
         // Arrange
         const string clientId = "org_12345678";
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Get,$"{BaseMollieClient.ApiEndPoint}clients/{clientId}")
+        mockHttp.Expect(HttpMethod.Get,$"{BaseMollieClient.DefaultBaseApiEndPoint}clients/{clientId}")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", DefaultGetClientResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -67,7 +67,7 @@ public class ClientClientTests : BaseClientTests {
         // Arrange
         const string clientId = "org_12345678";
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Get,$"{BaseMollieClient.ApiEndPoint}clients/{clientId}{expectedQueryString}")
+        mockHttp.Expect(HttpMethod.Get,$"{BaseMollieClient.DefaultBaseApiEndPoint}clients/{clientId}{expectedQueryString}")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", DefaultGetClientResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -91,7 +91,7 @@ public class ClientClientTests : BaseClientTests {
         string? from, int? limit, bool embedOrganization, bool embedOnboarding, bool embedCapabilities, string expectedQueryString) {
         // Given: We retrieve a list of clients
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.When($"{BaseMollieClient.ApiEndPoint}clients{expectedQueryString}")
+        mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}clients{expectedQueryString}")
             .Respond("application/json", DefaultGetClientListResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         using var clientClient = new ClientClient("access_1234", httpClient);
@@ -110,7 +110,7 @@ public class ClientClientTests : BaseClientTests {
     {
         // Arrange
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Get,$"{BaseMollieClient.ApiEndPoint}clients")
+        mockHttp.Expect(HttpMethod.Get,$"{BaseMollieClient.DefaultBaseApiEndPoint}clients")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", DefaultGetClientListResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();

--- a/tests/Mollie.Tests.Unit/Client/ClientLinkClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/ClientLinkClientTests.cs
@@ -21,7 +21,7 @@ public class ClientLinkClientTests : BaseClientTests
         const string clientLinkUrl = "myurl";
         string clientLinkResponseJson = CreateClientLinkResponseJson(clientLinkId, clientLinkUrl);
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.When( HttpMethod.Post, $"{BaseMollieClient.ApiEndPoint}client-links")
+        mockHttp.When( HttpMethod.Post, $"{BaseMollieClient.DefaultBaseApiEndPoint}client-links")
             .Respond("application/json", clientLinkResponseJson);
         HttpClient httpClient = mockHttp.ToHttpClient();
         ClientLinkClient clientLinkClient = new ClientLinkClient("clientId", "access_1234", httpClient);

--- a/tests/Mollie.Tests.Unit/Client/CustomerClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/CustomerClientTests.cs
@@ -20,7 +20,7 @@ namespace Mollie.Tests.Unit.Client {
             const string customerId = "customer-id";
 
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}{expectedUrl}")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}{expectedUrl}")
                 .Respond("application/json", DefaultCustomerJsonToReturn);
             HttpClient httpClient = mockHttp.ToHttpClient();
             var customerClient = new CustomerClient("abcde", httpClient);
@@ -41,7 +41,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetCustomerListAsync_TestModeParameterCase_QueryStringOnlyContainsTestModeParameterIfTrue(string? from, int? limit, bool testmode, string expectedQueryString) {
             // Given: We retrieve a list of customers
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}customers{expectedQueryString}")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}customers{expectedQueryString}")
                 .Respond("application/json", DefaultCustomerJsonToReturn);
             HttpClient httpClient = mockHttp.ToHttpClient();
             var customerClient = new CustomerClient("abcde", httpClient);
@@ -64,7 +64,7 @@ namespace Mollie.Tests.Unit.Client {
             // Given: We retrieve a list of customers
             const string customerId = "customer-id";
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}customers/{customerId}/payments{expectedQueryString}")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}customers/{customerId}/payments{expectedQueryString}")
                 .Respond("application/json", DefaultCustomerJsonToReturn);
             HttpClient httpClient = mockHttp.ToHttpClient();
             var customerClient = new CustomerClient("abcde", httpClient);
@@ -82,7 +82,7 @@ namespace Mollie.Tests.Unit.Client {
             // Given: We make a request to retrieve a payment with embedded refunds
             const string customerId = "customer-id";
             string expectedContent = "\"testmode\":true";
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Delete, $"{BaseMollieClient.ApiEndPoint}customers/{customerId}", DefaultCustomerJsonToReturn, expectedContent);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Delete, $"{BaseMollieClient.DefaultBaseApiEndPoint}customers/{customerId}", DefaultCustomerJsonToReturn, expectedContent);
             HttpClient httpClient = mockHttp.ToHttpClient();
             var customerClient = new CustomerClient("abcde", httpClient);
 

--- a/tests/Mollie.Tests.Unit/Client/InvoiceClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/InvoiceClientTests.cs
@@ -15,7 +15,7 @@ public class InvoiceClientTests : BaseClientTests
         // Given
         const string invoiceId = "inv_xBEbP9rvAq";
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.When($"{BaseMollieClient.ApiEndPoint}invoices/{invoiceId}")
+        mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}invoices/{invoiceId}")
             .Respond("application/json", defaultInvoice);
         HttpClient httpClient = mockHttp.ToHttpClient();
         using InvoiceClient invoiceClient = new InvoiceClient("access_abcde", httpClient);
@@ -43,7 +43,7 @@ public class InvoiceClientTests : BaseClientTests
         string? reference, int? year, string? from, int? limit, string expectedQueryString) {
         // Given: We retrieve a list of customers
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.When($"{BaseMollieClient.ApiEndPoint}invoices{expectedQueryString}")
+        mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}invoices{expectedQueryString}")
             .Respond("application/json", defaultInvoiceList);
         HttpClient httpClient = mockHttp.ToHttpClient();
         using InvoiceClient invoiceClient = new InvoiceClient("access_abcde", httpClient);

--- a/tests/Mollie.Tests.Unit/Client/MandateClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/MandateClientTests.cs
@@ -19,7 +19,7 @@ namespace Mollie.Tests.Unit.Client {
             const string mandateId = "mandate-id";
 
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}{expectedUrl}")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}{expectedUrl}")
                 .Respond("application/json", DefaultMandateJsonToReturn);
             HttpClient httpClient = mockHttp.ToHttpClient();
             MandateClient mandateClient = new MandateClient("abcde", httpClient);
@@ -42,7 +42,7 @@ namespace Mollie.Tests.Unit.Client {
             // Given: We retrieve a list of mandates
             const string customerId = "customer-id";
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}customers/{customerId}/mandates{expectedQueryString}")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}customers/{customerId}/mandates{expectedQueryString}")
                 .Respond("application/json", DefaultMandateJsonToReturn);
             HttpClient httpClient = mockHttp.ToHttpClient();
             MandateClient mandateClient = new MandateClient("abcde", httpClient);
@@ -63,7 +63,7 @@ namespace Mollie.Tests.Unit.Client {
             string expectedContent = "\"testmode\":true";
             var mockHttp = CreateMockHttpMessageHandler(
                 HttpMethod.Delete,
-                $"{BaseMollieClient.ApiEndPoint}customers/{customerId}/mandates/{mandateId}",
+                $"{BaseMollieClient.DefaultBaseApiEndPoint}customers/{customerId}/mandates/{mandateId}",
                 DefaultMandateJsonToReturn,
                 expectedContent);
             HttpClient httpClient = mockHttp.ToHttpClient();

--- a/tests/Mollie.Tests.Unit/Client/OnboardingClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/OnboardingClientTests.cs
@@ -27,7 +27,7 @@ namespace Mollie.Tests.Unit.Client {
         [Fact]
         public async Task GetOnboardingStatusAsync_DefaultBehaviour_ResponseIsParsed() {
             // Given: We request the onboarding status
-            string expectedUrl = $"{BaseMollieClient.ApiEndPoint}onboarding/me";
+            string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}onboarding/me";
             var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, expectedUrl, defaultOnboardingStatusJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             OnboardingClient onboardingClient = new OnboardingClient("api-key", httpClient);
@@ -47,7 +47,7 @@ namespace Mollie.Tests.Unit.Client {
         [Fact]
         public async Task SubmitOnboardingDataAsync_DefaultBehaviour_RequestIsParsed() {
             // Given: We submit an onboarding status request
-            string expectedUrl = $"{BaseMollieClient.ApiEndPoint}onboarding/me";
+            string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}onboarding/me";
             SubmitOnboardingDataRequest submitOnboardingDataRequest = new SubmitOnboardingDataRequest() {
                 Organization = new OnboardingOrganizationRequest() {
                     Name = defaultName,

--- a/tests/Mollie.Tests.Unit/Client/OrderClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/OrderClientTests.cs
@@ -21,7 +21,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetOrderAsync_NoEmbedParameters_QueryStringIsEmpty() {
             // Given: We make a request to retrieve a order without wanting any extra data
             const string orderId = "abcde";
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}orders/{orderId}", defaultOrderJsonResponse);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}orders/{orderId}", defaultOrderJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             OrderClient orderClient = new OrderClient("abcde", httpClient);
 
@@ -36,7 +36,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetOrderAsync_SingleEmbedParameters_QueryStringContainsEmbedParameter() {
             // Given: We make a request to retrieve a order with a single embed parameter
             const string orderId = "abcde";
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}orders/{orderId}?embed=payments", defaultOrderJsonResponse);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}orders/{orderId}?embed=payments", defaultOrderJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             OrderClient orderClient = new OrderClient("abcde", httpClient);
 
@@ -51,7 +51,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetOrderAsync_MultipleEmbedParameters_QueryStringContainsMultipleParameters() {
             // Given: We make a request to retrieve a order with a single embed parameter
             const string orderId = "abcde";
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}orders/{orderId}?embed=payments,refunds,shipments", defaultOrderJsonResponse);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}orders/{orderId}?embed=payments,refunds,shipments", defaultOrderJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             OrderClient orderClient = new OrderClient("abcde", httpClient);
 
@@ -66,7 +66,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetOrderAsync_WithTestModeParameter_QueryStringContainsTestModeParameter() {
             // Given: We make a request to retrieve a order with a single embed parameter
             const string orderId = "abcde";
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}orders/{orderId}?testmode=true", defaultOrderJsonResponse);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}orders/{orderId}?testmode=true", defaultOrderJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             OrderClient orderClient = new OrderClient("abcde", httpClient);
 
@@ -93,7 +93,7 @@ namespace Mollie.Tests.Unit.Client {
             SortDirection? sortDirection,
             string expectedQueryString) {
             // Given: We make a request to retrieve the list of orders
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}orders{expectedQueryString}", defaultOrderJsonResponse);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}orders{expectedQueryString}", defaultOrderJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             OrderClient orderClient = new OrderClient("abcde", httpClient);
 
@@ -111,7 +111,7 @@ namespace Mollie.Tests.Unit.Client {
             orderRequest.Method = PaymentMethod.Ideal;
             string expectedPaymentMethodJson = $"\"method\":[\"{PaymentMethod.Ideal}";
             const string jsonResponse = defaultOrderJsonResponse;
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.ApiEndPoint}orders", jsonResponse, expectedPaymentMethodJson);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.DefaultBaseApiEndPoint}orders", jsonResponse, expectedPaymentMethodJson);
             HttpClient httpClient = mockHttp.ToHttpClient();
             OrderClient orderClient = new OrderClient("abcde", httpClient);
 
@@ -134,7 +134,7 @@ namespace Mollie.Tests.Unit.Client {
             };
             string expectedPaymentMethodJson = $"\"method\":[\"{PaymentMethod.Ideal}\",\"{PaymentMethod.CreditCard}\",\"{PaymentMethod.DirectDebit}\"]";
             const string jsonResponse = defaultOrderJsonResponse;
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.ApiEndPoint}orders", jsonResponse, expectedPaymentMethodJson);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.DefaultBaseApiEndPoint}orders", jsonResponse, expectedPaymentMethodJson);
             HttpClient httpClient = mockHttp.ToHttpClient();
             OrderClient orderClient = new OrderClient("abcde", httpClient);
 
@@ -157,7 +157,7 @@ namespace Mollie.Tests.Unit.Client {
                 }
             };
             const string orderId = "order-id";
-            string url = $"{BaseMollieClient.ApiEndPoint}orders/{orderId}/payments";
+            string url = $"{BaseMollieClient.DefaultBaseApiEndPoint}orders/{orderId}/payments";
             string expectedPaymentMethodJson = $"\"method\":[\"{PaymentMethod.Ideal}\"]";
             var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, url, defaultPaymentJsonResponse, expectedPaymentMethodJson);
             HttpClient httpClient = mockHttp.ToHttpClient();
@@ -184,7 +184,7 @@ namespace Mollie.Tests.Unit.Client {
                 }
             };
             const string orderId = "order-id";
-            string url = $"{BaseMollieClient.ApiEndPoint}orders/{orderId}/payments";
+            string url = $"{BaseMollieClient.DefaultBaseApiEndPoint}orders/{orderId}/payments";
             string expectedPaymentMethodJson = $"\"method\":[\"{PaymentMethod.Ideal}\",\"{PaymentMethod.CreditCard}\",\"{PaymentMethod.DirectDebit}\"]";
             var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, url, defaultPaymentJsonResponse, expectedPaymentMethodJson);
             HttpClient httpClient = mockHttp.ToHttpClient();

--- a/tests/Mollie.Tests.Unit/Client/OrganizationClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/OrganizationClientTests.cs
@@ -15,7 +15,7 @@ public class OrganizationClientTests : BaseClientTests
     {
         // Arrange
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.When($"{BaseMollieClient.ApiEndPoint}organizations/me")
+        mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}organizations/me")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", defaultOrganizationResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -34,7 +34,7 @@ public class OrganizationClientTests : BaseClientTests
         // Arrange
         const string organizationId = "organization-id";
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.When($"{BaseMollieClient.ApiEndPoint}organizations/{organizationId}")
+        mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}organizations/{organizationId}")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", defaultOrganizationResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -52,7 +52,7 @@ public class OrganizationClientTests : BaseClientTests
     {
         // Arrange
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.When($"{BaseMollieClient.ApiEndPoint}organizations")
+        mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}organizations")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", defaultOrganizationListResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();

--- a/tests/Mollie.Tests.Unit/Client/PaymentClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/PaymentClientTests.cs
@@ -32,10 +32,10 @@ public class PaymentClientTests : BaseClientTests {
         const string customIdempotencyKey2 = "my-idempotency-key-2";
         const string jsonToReturnInMockResponse = defaultPaymentJsonResponse;
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Post, $"{BaseMollieClient.ApiEndPoint}*")
+        mockHttp.Expect(HttpMethod.Post, $"{BaseMollieClient.DefaultBaseApiEndPoint}*")
             .WithHeaders("Idempotency-Key", customIdempotencyKey1)
             .Respond("application/json", jsonToReturnInMockResponse);
-        mockHttp.Expect(HttpMethod.Post, $"{BaseMollieClient.ApiEndPoint}*")
+        mockHttp.Expect(HttpMethod.Post, $"{BaseMollieClient.DefaultBaseApiEndPoint}*")
             .WithHeaders("Idempotency-Key", customIdempotencyKey2)
             .Respond("application/json", jsonToReturnInMockResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -66,7 +66,7 @@ public class PaymentClientTests : BaseClientTests {
         const string jsonToReturnInMockResponse = defaultPaymentJsonResponse;
 
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.When($"{BaseMollieClient.ApiEndPoint}*")
+        mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}*")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", jsonToReturnInMockResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -118,7 +118,7 @@ public class PaymentClientTests : BaseClientTests {
                 ""description"":""Description"",
                 ""method"":""ideal"",
                 ""redirectUrl"":""http://www.mollie.com""}";
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.ApiEndPoint}payments", jsonResponse, expectedPaymentMethodJson);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments", jsonResponse, expectedPaymentMethodJson);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -153,7 +153,7 @@ public class PaymentClientTests : BaseClientTests {
                 ""description"":""Description"",
                 ""method"": null,
                 ""redirectUrl"":""http://www.mollie.com""}";
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.ApiEndPoint}payments", expectedJsonResponse, expectedPaymentMethodJson);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments", expectedJsonResponse, expectedPaymentMethodJson);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -206,7 +206,7 @@ public class PaymentClientTests : BaseClientTests {
                         ""releaseDate"": ""2022-01-14""
                     }
                 ]}";
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.ApiEndPoint}payments", expectedJsonResponse, expectedRoutingInformation);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments", expectedJsonResponse, expectedRoutingInformation);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -228,7 +228,7 @@ public class PaymentClientTests : BaseClientTests {
             RedirectUrl = "http://www.mollie.com",
             Method = PaymentMethod.Ideal
         };
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.ApiEndPoint}payments?include=details.qrCode", defaultPaymentJsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments?include=details.qrCode", defaultPaymentJsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -243,7 +243,7 @@ public class PaymentClientTests : BaseClientTests {
     public async Task GetPaymentAsync_NoIncludeParameters_RequestIsDeserializedInExpectedFormat() {
         // Given: We make a request to retrieve a payment without wanting any extra data
         const string paymentId = "tr_WDqYK6vllg";
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}", defaultPaymentJsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}", defaultPaymentJsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -321,7 +321,7 @@ public class PaymentClientTests : BaseClientTests {
             }
         }";
 
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}", jsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}", jsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -383,7 +383,7 @@ public class PaymentClientTests : BaseClientTests {
                 ""failureReason"": ""failure-reason""
             }
         }";
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}", jsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}", jsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -461,7 +461,7 @@ public class PaymentClientTests : BaseClientTests {
                 ""fileReference"": ""file-reference""
             }
         }";
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.ApiEndPoint}payments", jsonResponse, jsonRequest);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments", jsonResponse, jsonRequest);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -526,7 +526,7 @@ public class PaymentClientTests : BaseClientTests {
             }
         }";
         var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get,
-            $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}", jsonResponse);
+            $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}", jsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -635,7 +635,7 @@ public class PaymentClientTests : BaseClientTests {
                 ""wallet"": ""applepay""
             }
         }";
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.ApiEndPoint}payments", jsonResponse, jsonRequest);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments", jsonResponse, jsonRequest);
         HttpClient httpClient = mockHttp.ToHttpClient();
         PaymentClient paymentClient = new("abcde", httpClient);
 
@@ -720,7 +720,7 @@ public class PaymentClientTests : BaseClientTests {
                 ""RemainderMethod"": ""ideal""
             }
         }";
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.ApiEndPoint}payments", jsonResponse, jsonRequest);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments", jsonResponse, jsonRequest);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -768,7 +768,7 @@ public class PaymentClientTests : BaseClientTests {
                 ""consumerBic"": ""consumer-bic""
             }
         }";
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}", jsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}", jsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -807,7 +807,7 @@ public class PaymentClientTests : BaseClientTests {
             }
         }";
 
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}", jsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}", jsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -846,7 +846,7 @@ public class PaymentClientTests : BaseClientTests {
             }
         }";
 
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}", jsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}", jsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -885,7 +885,7 @@ public class PaymentClientTests : BaseClientTests {
             }
         }";
 
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}", jsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}", jsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -941,7 +941,7 @@ public class PaymentClientTests : BaseClientTests {
             }
         }";
         var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get,
-            $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}?include=details.qrCode",
+            $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}?include=details.qrCode",
             jsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
@@ -963,7 +963,7 @@ public class PaymentClientTests : BaseClientTests {
     public async Task GetPaymentAsync_IncludeRemainderDetails_QueryStringContainsIncludeRemainderDetailsParameter() {
         // Given: We make a request to retrieve a payment without wanting any extra data
         const string paymentId = "abcde";
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}?include=details.remainderDetails", defaultPaymentJsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}?include=details.remainderDetails", defaultPaymentJsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -977,7 +977,7 @@ public class PaymentClientTests : BaseClientTests {
     [Fact]
     public async Task GetPaymentListAsync_IncludeQrCode_QueryStringContainsIncludeQrCodeParameter() {
         // Given: We make a request to retrieve a payment without wanting any extra data
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments?include=details.qrCode", defaultPaymentJsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments?include=details.qrCode", defaultPaymentJsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -993,7 +993,7 @@ public class PaymentClientTests : BaseClientTests {
     {
         // Given: We make a request to retrieve a payment with embedded refunds
         const string paymentId = "abcde";
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}?embed=refunds", defaultPaymentJsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}?embed=refunds", defaultPaymentJsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -1008,7 +1008,7 @@ public class PaymentClientTests : BaseClientTests {
     public async Task GetPaymentListAsync_EmbedRefunds_QueryStringContainsEmbedRefundsParameter()
     {
         // Given: We make a request to retrieve a payment with embedded refunds
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments?embed=refunds", defaultPaymentJsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments?embed=refunds", defaultPaymentJsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -1024,7 +1024,7 @@ public class PaymentClientTests : BaseClientTests {
     {
         // Given: We make a request to retrieve a payment with embedded refunds
         const string paymentId = "abcde";
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}?embed=chargebacks", defaultPaymentJsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}?embed=chargebacks", defaultPaymentJsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -1039,7 +1039,7 @@ public class PaymentClientTests : BaseClientTests {
     public async Task GetPaymentListAsync_EmbedChargebacks_QueryStringContainsEmbedChargebacksParameter()
     {
         // Given: We make a request to retrieve a payment with embedded refunds
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments?embed=chargebacks", defaultPaymentJsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments?embed=chargebacks", defaultPaymentJsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -1057,7 +1057,7 @@ public class PaymentClientTests : BaseClientTests {
     public async Task GetPaymentListAsync_AddSortDirection_QueryStringContainsSortDirection(SortDirection? sortDirection, string expectedQueryString)
     {
         // Given: We make a request to retrieve a payment with embedded refunds
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}payments{expectedQueryString}", defaultPaymentJsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments{expectedQueryString}", defaultPaymentJsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -1073,7 +1073,7 @@ public class PaymentClientTests : BaseClientTests {
         // Given: We make a request to retrieve a payment with embedded refunds
         const string paymentId = "payment-id";
         string expectedContent = "\"testmode\":true";
-        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Delete, $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}", defaultPaymentJsonResponse, expectedContent);
+        var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Delete, $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}", defaultPaymentJsonResponse, expectedContent);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);
 
@@ -1109,7 +1109,7 @@ public class PaymentClientTests : BaseClientTests {
         const string paymentId = "abcde";
         var mockHttp = CreateMockHttpMessageHandler(
             HttpMethod.Post,
-            $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}/release-authorization?testmode=true",
+            $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}/release-authorization?testmode=true",
             string.Empty);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var paymentClient = new PaymentClient("abcde", httpClient);

--- a/tests/Mollie.Tests.Unit/Client/PaymentLinkClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/PaymentLinkClientTests.cs
@@ -33,7 +33,7 @@ namespace Mollie.Tests.Unit.Client {
                 ExpiresAt = DateTime.Now.AddDays(1)
             };
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}*")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}*")
                 .Respond("application/json", _defaultPaymentLinkJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             PaymentLinkClient paymentLinkClient = new PaymentLinkClient("api-key", httpClient);
@@ -50,7 +50,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetPaymentLinkAsync_ResponseIsDeserializedInExpectedFormat() {
             // Given: we retrieve a payment link
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}*")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}*")
                 .Respond("application/json", _defaultPaymentLinkJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             PaymentLinkClient paymentLinkClient = new PaymentLinkClient("api-key", httpClient);
@@ -93,7 +93,7 @@ namespace Mollie.Tests.Unit.Client {
             // Given: We make a request to delete a payment link
             var mockHttp = CreateMockHttpMessageHandler(
                 HttpMethod.Delete,
-                $"{BaseMollieClient.ApiEndPoint}payment-links/{DefaultPaymentLinkId}{expectedQueryString}",
+                $"{BaseMollieClient.DefaultBaseApiEndPoint}payment-links/{DefaultPaymentLinkId}{expectedQueryString}",
                 _defaultPaymentLinkPaymentsJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             var paymentLinkClient = new PaymentLinkClient("access_abcde", httpClient);
@@ -121,7 +121,7 @@ namespace Mollie.Tests.Unit.Client {
             // Given: We make a request to retrieve the list of payment links
             var mockHttp = CreateMockHttpMessageHandler(
                 HttpMethod.Get,
-                $"{BaseMollieClient.ApiEndPoint}payment-links/{DefaultPaymentLinkId}/payments{expectedQueryString}",
+                $"{BaseMollieClient.DefaultBaseApiEndPoint}payment-links/{DefaultPaymentLinkId}/payments{expectedQueryString}",
                 _defaultPaymentLinkPaymentsJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             var paymentLinkClient = new PaymentLinkClient("access_abcde", httpClient);
@@ -138,7 +138,7 @@ namespace Mollie.Tests.Unit.Client {
             // Given: We make a request to retrieve the list of payment links
             var mockHttp = CreateMockHttpMessageHandler(
                 HttpMethod.Get,
-                $"{BaseMollieClient.ApiEndPoint}payment-links/{DefaultPaymentLinkId}/payments",
+                $"{BaseMollieClient.DefaultBaseApiEndPoint}payment-links/{DefaultPaymentLinkId}/payments",
                 _defaultPaymentLinkPaymentsJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             var paymentLinkClient = new PaymentLinkClient("abcde", httpClient);

--- a/tests/Mollie.Tests.Unit/Client/PaymentMethodClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/PaymentMethodClientTests.cs
@@ -25,7 +25,7 @@ namespace Mollie.Tests.Unit.Client {
         [Fact]
         public async Task GetAllPaymentMethodListAsync_NoAmountParameter_QueryStringIsEmpty() {
             // Given: We make a request to retrieve all payment methods without any parameters
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}methods/all", defaultPaymentMethodJsonResponse);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}methods/all", defaultPaymentMethodJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             PaymentMethodClient paymentMethodClient = new PaymentMethodClient("abcde", httpClient);
 
@@ -39,7 +39,7 @@ namespace Mollie.Tests.Unit.Client {
         [Fact]
         public async Task GetAllPaymentMethodListAsync_AmountParameterIsAdded_QueryStringContainsAmount() {
             // Given: We make a request to retrieve all payment methods with a amount parameter
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}methods/all?amount[value]=100.00&amount[currency]=EUR", defaultPaymentMethodJsonResponse);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}methods/all?amount[value]=100.00&amount[currency]=EUR", defaultPaymentMethodJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             PaymentMethodClient paymentMethodClient = new PaymentMethodClient("abcde", httpClient);
 
@@ -54,7 +54,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetAllPaymentMethodListAsync_ProfileIdParameterIsSpecified_QueryStringContainsProfileIdParameter() {
             // Given: We make a request to retrieve all payment methods with a profile id parameter
             var profileId = "myProfileId";
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}methods/all?profileId={profileId}", defaultPaymentMethodJsonResponse);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}methods/all?profileId={profileId}", defaultPaymentMethodJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             PaymentMethodClient paymentMethodClient = new PaymentMethodClient("abcde", httpClient);
 
@@ -69,7 +69,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetPaymentMethodListAsync_IncludeWalletsParameterIsSpecified_QueryStringContainsIncludeWalletsParameter() {
             // Given: We make a request to retrieve the payment methods with a includeWallets parameter
             var includeWalletsValue = "includeWalletsValue";
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}methods?includeWallets={includeWalletsValue}", defaultPaymentMethodJsonResponse);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}methods?includeWallets={includeWalletsValue}", defaultPaymentMethodJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             PaymentMethodClient paymentMethodClient = new PaymentMethodClient("abcde", httpClient);
 

--- a/tests/Mollie.Tests.Unit/Client/PermissionClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/PermissionClientTests.cs
@@ -16,7 +16,7 @@ public class PermissionClientTests : BaseClientTests
         // Arrange
         const string permissionId = "payments.read";
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}permissions/{permissionId}")
+        mockHttp.Expect(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}permissions/{permissionId}")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", defaultGetPermissionResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -58,7 +58,7 @@ public class PermissionClientTests : BaseClientTests
     {
         // Arrange
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}permissions")
+        mockHttp.Expect(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}permissions")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", defaultListPermissionsResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();

--- a/tests/Mollie.Tests.Unit/Client/ProfileClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/ProfileClientTests.cs
@@ -31,7 +31,7 @@ public class ProfileClientTests : BaseClientTests
             BusinessCategory = "OTHER_MERCHANDISE"
         };
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Post, $"{BaseMollieClient.ApiEndPoint}profiles")
+        mockHttp.Expect(HttpMethod.Post, $"{BaseMollieClient.DefaultBaseApiEndPoint}profiles")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", defaultProfileJsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -53,7 +53,7 @@ public class ProfileClientTests : BaseClientTests
         // Arrange
         const string profileId = "profile-id";
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Get,$"{BaseMollieClient.ApiEndPoint}profiles/{profileId}")
+        mockHttp.Expect(HttpMethod.Get,$"{BaseMollieClient.DefaultBaseApiEndPoint}profiles/{profileId}")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", defaultProfileJsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -72,7 +72,7 @@ public class ProfileClientTests : BaseClientTests
     {
         // Arrange
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}profiles/me")
+        mockHttp.Expect(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}profiles/me")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", defaultProfileJsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -91,7 +91,7 @@ public class ProfileClientTests : BaseClientTests
     {
         // Arrange
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}profiles")
+        mockHttp.Expect(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}profiles")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", defaultGetProfileListJsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -148,7 +148,7 @@ public class ProfileClientTests : BaseClientTests
             BusinessCategory = "OTHER_MERCHANDISE"
         };
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Patch, $"{BaseMollieClient.ApiEndPoint}profiles/{profileId}")
+        mockHttp.Expect(HttpMethod.Patch, $"{BaseMollieClient.DefaultBaseApiEndPoint}profiles/{profileId}")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", defaultProfileJsonResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -192,7 +192,7 @@ public class ProfileClientTests : BaseClientTests
         // Arrange
         const string paymentMethod = PaymentMethod.Ideal;
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Post,$"{BaseMollieClient.ApiEndPoint}profiles/me/methods/{paymentMethod}")
+        mockHttp.Expect(HttpMethod.Post,$"{BaseMollieClient.DefaultBaseApiEndPoint}profiles/me/methods/{paymentMethod}")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", defaultPaymentMethodResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -228,7 +228,7 @@ public class ProfileClientTests : BaseClientTests
         // Arrange
         const string paymentMethod = PaymentMethod.Ideal;
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Delete, $"{BaseMollieClient.ApiEndPoint}profiles/me/methods/{paymentMethod}")
+        mockHttp.Expect(HttpMethod.Delete, $"{BaseMollieClient.DefaultBaseApiEndPoint}profiles/me/methods/{paymentMethod}")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond(HttpStatusCode.NoContent);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -262,7 +262,7 @@ public class ProfileClientTests : BaseClientTests
         // Arrange
         const string profileId = "profile-id";
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Delete, $"{BaseMollieClient.ApiEndPoint}profiles/{profileId}")
+        mockHttp.Expect(HttpMethod.Delete, $"{BaseMollieClient.DefaultBaseApiEndPoint}profiles/{profileId}")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond(HttpStatusCode.NoContent);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -296,7 +296,7 @@ public class ProfileClientTests : BaseClientTests
         // Arrange
         const string issuer = "festivalcadeau";
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Post,$"{BaseMollieClient.ApiEndPoint}profiles/me/methods/giftcard/issuers/{issuer}")
+        mockHttp.Expect(HttpMethod.Post,$"{BaseMollieClient.DefaultBaseApiEndPoint}profiles/me/methods/giftcard/issuers/{issuer}")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", defaultEnableGiftcardIssuerResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -334,7 +334,7 @@ public class ProfileClientTests : BaseClientTests
         // Arrange
         const string issuer = "festivalcadeau";
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Delete, $"{BaseMollieClient.ApiEndPoint}profiles/me/methods/giftcard/issuers/{issuer}")
+        mockHttp.Expect(HttpMethod.Delete, $"{BaseMollieClient.DefaultBaseApiEndPoint}profiles/me/methods/giftcard/issuers/{issuer}")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond(HttpStatusCode.NoContent);
         HttpClient httpClient = mockHttp.ToHttpClient();

--- a/tests/Mollie.Tests.Unit/Client/RefundClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/RefundClientTests.cs
@@ -55,7 +55,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetRefundAsync_TestModeParameterCase_QueryStringOnlyContainsTestModeParameterIfTrue(string expectedUrl, bool? testModeParameter) {
             // Given: We make a request to retrieve a payment without wanting any extra data
             bool testMode = testModeParameter ?? false;
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}{expectedUrl}", defaultGetRefundResponse);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}{expectedUrl}", defaultGetRefundResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             RefundClient refundClient = new RefundClient("abcde", httpClient);
 
@@ -117,7 +117,7 @@ namespace Mollie.Tests.Unit.Client {
 }}";
             var mockHttp = CreateMockHttpMessageHandler(
                 HttpMethod.Post,
-                $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}/refunds",
+                $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}/refunds",
                 expectedJsonResponse,
                 expectedRoutingInformation);
             HttpClient httpClient = mockHttp.ToHttpClient();
@@ -177,7 +177,7 @@ namespace Mollie.Tests.Unit.Client {
 }}";
             var mockHttp = CreateMockHttpMessageHandler(
                 HttpMethod.Post,
-                $"{BaseMollieClient.ApiEndPoint}payments/{paymentId}/refunds",
+                $"{BaseMollieClient.DefaultBaseApiEndPoint}payments/{paymentId}/refunds",
                 expectedJsonResponse,
                 expectedRoutingInformation);
             HttpClient httpClient = mockHttp.ToHttpClient();
@@ -295,7 +295,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetOrderRefundListAsync_QueryParameterOptions_CorrectParametersAreAdded(string? from, int? limit, bool testmode, string expectedQueryString) {
             // Given: We make a request to retrieve the list of orders
             const string orderId = "abcde";
-            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.ApiEndPoint}orders/{orderId}/refunds{expectedQueryString}", defaultOrderJsonResponse);
+            var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, $"{BaseMollieClient.DefaultBaseApiEndPoint}orders/{orderId}/refunds{expectedQueryString}", defaultOrderJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             RefundClient refundClient = new RefundClient("api-key", httpClient);
 
@@ -325,7 +325,7 @@ namespace Mollie.Tests.Unit.Client {
                 },
                 Metadata = "my-metadata"
             };
-            string url = $"{BaseMollieClient.ApiEndPoint}orders/{orderId}/refunds";
+            string url = $"{BaseMollieClient.DefaultBaseApiEndPoint}orders/{orderId}/refunds";
             var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Post, url, defaultOrderRefundJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             RefundClient refundClient = new RefundClient("api-key", httpClient);

--- a/tests/Mollie.Tests.Unit/Client/SettlementClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/SettlementClientTests.cs
@@ -15,7 +15,7 @@ namespace Mollie.Tests.Unit.Client {
         [Fact]
         public async Task ListSettlementCaptures_DefaultBehaviour_ResponseIsParsed() {
             // Given: We request a list of captures
-            string expectedUrl = $"{BaseMollieClient.ApiEndPoint}settlements/{defaultSettlementId}/captures";
+            string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}settlements/{defaultSettlementId}/captures";
             var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, expectedUrl, defaultCaptureListJsonResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             SettlementClient settlementClient = new SettlementClient("api-key", httpClient);
@@ -53,7 +53,7 @@ namespace Mollie.Tests.Unit.Client {
         [Fact]
         public async Task GetOpenSettlement_DefaultBehaviour_ResponseIsParsed() {
             // Given: We request a list of captures
-            string expectedUrl = $"{BaseMollieClient.ApiEndPoint}settlements/open";
+            string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}settlements/open";
             var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, expectedUrl, defaultGetSettlementResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             SettlementClient settlementClient = new SettlementClient("api-key", httpClient);
@@ -120,7 +120,7 @@ namespace Mollie.Tests.Unit.Client {
         [Fact]
         public async Task GetOpenSettlement_ResponseWithEmptyPeriods_ResponseIsParsed() {
             // Given: We request a list of captures
-            string expectedUrl = $"{BaseMollieClient.ApiEndPoint}settlements/open";
+            string expectedUrl = $"{BaseMollieClient.DefaultBaseApiEndPoint}settlements/open";
             var mockHttp = CreateMockHttpMessageHandler(HttpMethod.Get, expectedUrl, emptyPeriodsSettlementResponse);
             HttpClient httpClient = mockHttp.ToHttpClient();
             SettlementClient settlementClient = new SettlementClient("api-key", httpClient);

--- a/tests/Mollie.Tests.Unit/Client/ShipmentClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/ShipmentClientTests.cs
@@ -35,7 +35,7 @@ namespace Mollie.Tests.Unit.Client {
             const string expectedPartialRequest = @"{""tracking"":{""carrier"":""tracking-carrier"",""code"":""tracking-code"",""url"":""tracking-url""},""lines"":[{""id"":""shipment-line-id"",""quantity"":1,""amount"":{""currency"":""EUR"",""value"":""50.00""}}],""testmode"":true}";
             var mockHttp = CreateMockHttpMessageHandler(
                 HttpMethod.Post,
-                $"{BaseMollieClient.ApiEndPoint}orders/{orderId}/shipments",
+                $"{BaseMollieClient.DefaultBaseApiEndPoint}orders/{orderId}/shipments",
                 DefaultShipmentJsonToReturn,
                 expectedPartialRequest);
             HttpClient httpClient = mockHttp.ToHttpClient();
@@ -62,7 +62,7 @@ namespace Mollie.Tests.Unit.Client {
             const string shipmentId = "shipment-id";
 
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}{expectedUrl}")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}{expectedUrl}")
                 .Respond("application/json", DefaultShipmentJsonToReturn);
             HttpClient httpClient = mockHttp.ToHttpClient();
             ShipmentClient shipmentClient = new ShipmentClient("abcde", httpClient);
@@ -83,7 +83,7 @@ namespace Mollie.Tests.Unit.Client {
             const string orderId = "order-id";
 
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}{expectedUrl}")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}{expectedUrl}")
                 .Respond("application/json", DefaultShipmentJsonToReturn);
             HttpClient httpClient = mockHttp.ToHttpClient();
             ShipmentClient shipmentClient = new ShipmentClient("abcde", httpClient);
@@ -112,7 +112,7 @@ namespace Mollie.Tests.Unit.Client {
             const string expectedPartialRequest = @"{""tracking"":{""carrier"":""tracking-carrier"",""code"":""tracking-code"",""url"":""tracking-url""},""testmode"":true}";
             var mockHttp = CreateMockHttpMessageHandler(
                 HttpMethod.Patch,
-                $"{BaseMollieClient.ApiEndPoint}orders/{orderId}/shipments/{shipmentId}",
+                $"{BaseMollieClient.DefaultBaseApiEndPoint}orders/{orderId}/shipments/{shipmentId}",
                 DefaultShipmentJsonToReturn,
                 expectedPartialRequest);
             HttpClient httpClient = mockHttp.ToHttpClient();

--- a/tests/Mollie.Tests.Unit/Client/SubscriptionClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/SubscriptionClientTests.cs
@@ -21,7 +21,7 @@ namespace Mollie.Tests.Unit.Client {
             const string customerId = "customer-id";
 
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}customers/customer-id/subscriptions{expectedQueryString}")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}customers/customer-id/subscriptions{expectedQueryString}")
                 .Respond("application/json", DefaultSubscriptionJsonToReturn);
             HttpClient httpClient = mockHttp.ToHttpClient();
             var subscriptionClient = new SubscriptionClient("abcde", httpClient);
@@ -43,7 +43,7 @@ namespace Mollie.Tests.Unit.Client {
         public async Task GetAllSubscriptionList_TestModeParameterCase_QueryStringOnlyContainsTestModeParameterIfTrue(string? from, int? limit, string? profileId, bool testmode, string expectedQueryString) {
             // Given: We retrieve a list of subscriptions
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}subscriptions{expectedQueryString}")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}subscriptions{expectedQueryString}")
                 .Respond("application/json", DefaultSubscriptionJsonToReturn);
             HttpClient httpClient = mockHttp.ToHttpClient();
             var subscriptionClient = new SubscriptionClient("abcde", httpClient);
@@ -65,7 +65,7 @@ namespace Mollie.Tests.Unit.Client {
             const string subscriptionId = "subscription-id";
 
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}{expectedUrl}")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}{expectedUrl}")
                 .Respond("application/json", DefaultSubscriptionJsonToReturn);
             HttpClient httpClient = mockHttp.ToHttpClient();
             var subscriptionClient = new SubscriptionClient("abcde", httpClient);
@@ -87,7 +87,7 @@ namespace Mollie.Tests.Unit.Client {
             string expectedContent = "\"testmode\":true";
             var mockHttp = CreateMockHttpMessageHandler(
                 HttpMethod.Delete,
-                $"{BaseMollieClient.ApiEndPoint}customers/{customerId}/subscriptions/{subscriptionId}",
+                $"{BaseMollieClient.DefaultBaseApiEndPoint}customers/{customerId}/subscriptions/{subscriptionId}",
                 DefaultSubscriptionJsonToReturn,
                 expectedContent);
             HttpClient httpClient = mockHttp.ToHttpClient();
@@ -110,7 +110,7 @@ namespace Mollie.Tests.Unit.Client {
             const string customerId = "customer-id";
             const string subscriptionId = "subscription-id";
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When($"{BaseMollieClient.ApiEndPoint}customers/{customerId}/subscriptions/{subscriptionId}/payments{expectedQueryString}")
+            mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}customers/{customerId}/subscriptions/{subscriptionId}/payments{expectedQueryString}")
                 .Respond("application/json", DefaultSubscriptionJsonToReturn);
             HttpClient httpClient = mockHttp.ToHttpClient();
             var subscriptionClient = new SubscriptionClient("abcde", httpClient);

--- a/tests/Mollie.Tests.Unit/Client/TerminalClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/TerminalClientTests.cs
@@ -40,7 +40,7 @@ public class TerminalClientTests : BaseClientTests {
         const string model = "model";
         string jsonToReturnInMockResponse = CreateTerminalJsonResponse(terminalId, description, serialNumber, brand, model);
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.When($"{BaseMollieClient.ApiEndPoint}terminals/{terminalId}")
+        mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}terminals/{terminalId}")
             .With(request => request.Headers.Contains("Idempotency-Key"))
             .Respond("application/json", jsonToReturnInMockResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
@@ -73,7 +73,7 @@ public class TerminalClientTests : BaseClientTests {
         string jsonToReturnInMockResponse = CreateTerminalListJsonResponse();
         var mockHttp = CreateMockHttpMessageHandler(
             HttpMethod.Get,
-            $"{BaseMollieClient.ApiEndPoint}terminals{expectedQueryString}",
+            $"{BaseMollieClient.DefaultBaseApiEndPoint}terminals{expectedQueryString}",
             jsonToReturnInMockResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var terminalClient = new TerminalClient("abcde", httpClient);
@@ -91,7 +91,7 @@ public class TerminalClientTests : BaseClientTests {
         string jsonToReturnInMockResponse = CreateTerminalListJsonResponse();
         var mockHttp = CreateMockHttpMessageHandler(
             HttpMethod.Get,
-            $"{BaseMollieClient.ApiEndPoint}terminals",
+            $"{BaseMollieClient.DefaultBaseApiEndPoint}terminals",
             jsonToReturnInMockResponse);
         HttpClient httpClient = mockHttp.ToHttpClient();
         var terminalClient = new TerminalClient("abcde", httpClient);

--- a/tests/Mollie.Tests.Unit/Client/WalletClientTest.cs
+++ b/tests/Mollie.Tests.Unit/Client/WalletClientTest.cs
@@ -29,7 +29,7 @@ public class WalletClientTest : BaseClientTests {
         };
         var mockHttp = CreateMockHttpMessageHandler(
             HttpMethod.Post,
-            $"{BaseMollieClient.ApiEndPoint}wallets/applepay/sessions",
+            $"{BaseMollieClient.DefaultBaseApiEndPoint}wallets/applepay/sessions",
             defaultApplePayPaymentSessionResponse);
         using var walletClient = new WalletClient("abcde", mockHttp.ToHttpClient());
 


### PR DESCRIPTION
Added support to set a custom base URL through the `MollieOptions` object. This allows you to use tools like WireMock and send requests to a custom URL. This also applies to the `TokenEndpoint` and `AuthorizeEndpoint` URL's of the `ConnectClient`. 

Example usage:
```
services.AddMollieApi(options => {
	options.ApiKey = context.Configuration["Mollie:ApiKey"]!;
	options.ClientId = context.Configuration["Mollie:ClientId"]!;
	options.ClientSecret = context.Configuration["Mollie:ClientSecret"]!;
	options.RetryPolicy = MollieIntegrationTestHttpRetryPolicies.TooManyRequestRetryPolicy();
	options.ApiBaseUrl = "https://my-custom-base-url.mollie.com/v2/";
	options.ConnectTokenEndPoint = "https://my-custom-connect-token-endpoint.mollie.com/oauth2/";
	options.ConnectOAuthAuthorizeEndPoint = "https://my-custom-authorize-endpoint.mollie.com/oauth2/authorize";
});
```

Replaces #421 