### PR TITLE
Remove init from MollieClientOptions properties

### DIFF
--- a/src/Mollie.Api/Options/MollieClientOptions.cs
+++ b/src/Mollie.Api/Options/MollieClientOptions.cs
@@ -6,37 +6,37 @@ public class MollieClientOptions {
     /// <summary>
     /// Your API-key or OAuth token
     /// </summary>
-    public required string ApiKey { get; init; } = string.Empty;
+    public required string ApiKey { get; set; } = string.Empty;
 
     /// <summary>
     /// (Optional) The default user agent is "Mollie.Api.NET {version}". When this property is set, the custom user
     /// agent will be appended to the default user agent.
     /// </summary>
-    public string? CustomUserAgent { get; init; }
+    public string? CustomUserAgent { get; set; }
 
     /// <summary>
     /// (Optional) ClientId used by Connect API
     /// </summary>
-    public string? ClientId { get; init; }
+    public string? ClientId { get; set; }
 
     /// <summary>
     /// (Optional) ClientSecret used by Connect API
     /// </summary>
     /// <returns></returns>
-    public string? ClientSecret { get; init; }
+    public string? ClientSecret { get; set; }
 
     /// <summary>
     /// The base URL for all API requests. Can be overridden for testing purposes.
     /// </summary>
-    public string ApiBaseUrl { get; init; } = BaseMollieClient.DefaultBaseApiEndPoint;
+    public string ApiBaseUrl { get; set; } = BaseMollieClient.DefaultBaseApiEndPoint;
 
     /// <summary>
     /// The authorize endpoint for the Connect client. Can be overridden for testing purposes.
     /// </summary>
-    public string ConnectOAuthAuthorizeEndPoint { get; init; } = ConnectClient.DefaultAuthorizeEndpoint;
+    public string ConnectOAuthAuthorizeEndPoint { get; set; } = ConnectClient.DefaultAuthorizeEndpoint;
 
     /// <summary>
     /// The token endpoint for the Connect client. Can be overridden for testing purposes.
     /// </summary>
-    public string ConnectTokenEndPoint { get; init; } = ConnectClient.DefaultTokenEndpoint;
+    public string ConnectTokenEndPoint { get; set; } = ConnectClient.DefaultTokenEndpoint;
 }


### PR DESCRIPTION
Due to .NET framework compatibility, we shouldn't use { get; init; } properties. This PR changes the `{ get; init; }` properties in the `MollieClientOptions` class to `{ get; set; }`

Fixes issue #429 