### PR TITLE
Move TerminalId from PaymentRequest to PointOfSalePaymentRequest

### DIFF
--- a/src/Mollie.Api/Models/Payment/Request/PaymentRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentRequest.cs
@@ -150,12 +150,6 @@ namespace Mollie.Api.Models.Payment.Request {
 		/// </summary>
 		public bool? Testmode { get; set; }
 
-        /// <summary>
-        /// Id of the physical POS terminal that will be used for the payment.
-        /// Only required when method = POS
-        /// </summary>
-        public string? TerminalId { get; set; }
-
 		/// <summary>
 		///	Oauth only - Optional – Adding an Application Fee allows you to charge the merchant a small sum for the payment and transfer
 		/// this to your own account.

--- a/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/PointOfSalePaymentRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentSpecificParameters/PointOfSalePaymentRequest.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Mollie.Api.Models.Payment.Request.PaymentSpecificParameters;
+
+public record PointOfSalePaymentRequest : PaymentRequest {
+    public PointOfSalePaymentRequest() {
+        Method = PaymentMethod.PointOfSale;
+    }
+
+    [SetsRequiredMembers]
+    public PointOfSalePaymentRequest(PaymentRequest paymentRequest, string terminalId) : base(paymentRequest) {
+        Method = PaymentMethod.PointOfSale;
+        TerminalId = terminalId;
+    }
+
+    /// <summary>
+    /// The ID of the terminal device where you want to initiate the payment on
+    /// </summary>
+    public required string TerminalId { get; set; }
+}

--- a/tests/Mollie.Tests.Integration/Api/PaymentTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/PaymentTests.cs
@@ -498,7 +498,7 @@ public class PaymentTests : BaseMollieApiTestClass, IDisposable {
         TerminalResponse? terminal = terminals.Items.FirstOrDefault();
         if (terminal != null) {
             string terminalId = terminals.Items.First().Id;
-            PaymentRequest paymentRequest = new PaymentRequest() {
+            PointOfSalePaymentRequest paymentRequest = new() {
                 Amount = new Amount(Currency.EUR, 10m),
                 Description = "Description",
                 Method = PaymentMethod.PointOfSale,


### PR DESCRIPTION
The TerminalId parameter is specific for POS payments. This PR adds a `PointOfSalePaymentRequest` class that contains a required `TerminalId` parameter and removes it from the generic `PaymentRequest` class.