### PR TITLE
Added default constructor to Amount.cs

### DIFF
--- a/src/Mollie.Api/Models/Amount.cs
+++ b/src/Mollie.Api/Models/Amount.cs
@@ -22,6 +22,9 @@ namespace Mollie.Api.Models {
         /// </summary>
         public required string Value { get; set; }
 
+        public Amount() {
+        }
+        
         [JsonConstructor]
         [SetsRequiredMembers]
         public Amount(string currency, string value) {


### PR DESCRIPTION
Currently getting errors because json converter of Newtonsoft can not find a default constructor.