### PR TITLE
Fix issue where the mode enum was serialized incorrectly

### DIFF
--- a/src/Mollie.Api/Framework/JsonConverterService.cs
+++ b/src/Mollie.Api/Framework/JsonConverterService.cs
@@ -27,8 +27,10 @@ internal class JsonConverterService
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             WriteIndented = false,
-            AllowTrailingCommas = true
+            AllowTrailingCommas = true,
         };
+
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
 
         return JsonSerializer.Serialize(objectToSerialize, options);
     }

--- a/tests/Mollie.Tests.Unit/Client/ProfileClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/ProfileClientTests.cs
@@ -30,10 +30,12 @@ public class ProfileClientTests : BaseClientTests
             CountriesOfActivity = ["NL"],
             BusinessCategory = "OTHER_MERCHANDISE"
         };
-        var mockHttp = new MockHttpMessageHandler();
-        mockHttp.Expect(HttpMethod.Post, $"{BaseMollieClient.DefaultBaseApiEndPoint}profiles")
-            .With(request => request.Headers.Contains("Idempotency-Key"))
-            .Respond("application/json", defaultProfileJsonResponse);
+        var mockHttp = CreateMockHttpMessageHandler(
+            HttpMethod.Post,
+            $"{BaseMollieClient.DefaultBaseApiEndPoint}profiles",
+            defaultProfileJsonResponse,
+            "\"mode\": \"test\"");
+
         HttpClient httpClient = mockHttp.ToHttpClient();
         using var profileClient = new ProfileClient("abcde", httpClient);
 


### PR DESCRIPTION
Fix for #469 

```C#
ProfileRequest profileRequest = new() {
            Name = "My website name",
            Email = "info@mywebsite.com",
            Mode = Mode.Test,
            Phone = "+31208202070",
            Website = "https://www.mywebsite.com",
            Description = "Description",
            CountriesOfActivity = ["NL"],
            BusinessCategory = "OTHER_MERCHANDISE"
        };
```

Was serialized as
```json
{
  ...
  "mode" : 1
}
```

While expected was
```json
{
  ...
  "mode" : "test"
}
```

It turns out the `JsonStringEnumConverter` was not registrered for serialization, only for deserialization. 
