### PR TITLE
Add documentation file to nuget package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,14 +1,14 @@
 <Project>
   <PropertyGroup>
-	<Version>4.17.0.0</Version>
+	<Version>4.17.1.0</Version>
 	<Authors>Vincent Kok</Authors>
     <Company>Vincent Kok</Company>
     <Product>Mollie Payment API</Product>
     <PackageProjectUrl>https://github.com/Viincenttt/MollieApi</PackageProjectUrl>
     <PackageTags>Mollie;Payment;Payments;Webhook</PackageTags>
-    <AssemblyVersion>4.17.0.0</AssemblyVersion>
-    <FileVersion>4.17.0.0</FileVersion>
-    <PackageVersion>4.17.0.0</PackageVersion>	
+    <AssemblyVersion>4.17.1.0</AssemblyVersion>
+    <FileVersion>4.17.1.0</FileVersion>
+    <PackageVersion>4.17.1.0</PackageVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/Mollie.Api.AspNet/Mollie.Api.AspNet.csproj
+++ b/src/Mollie.Api.AspNet/Mollie.Api.AspNet.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>11</LangVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>
       ASP.NET Core extensions for the Mollie.Api client.
       Provides ready-to-use model binders, filters, and middleware to securely process Mollie webhooks and integrate payments into your ASP.NET Core MVC or Minimal API applications.

--- a/src/Mollie.Api/Client/Abstract/IPaymentClient.cs
+++ b/src/Mollie.Api/Client/Abstract/IPaymentClient.cs
@@ -8,6 +8,14 @@ using Mollie.Api.Models.Url;
 
 namespace Mollie.Api.Client.Abstract {
     public interface IPaymentClient : IBaseMollieClient {
+
+        /// <summary>
+        /// Create a payment object.
+        /// </summary>
+        /// <param name="paymentRequest">The payment request object containing the payment details</param>
+        /// <param name="includeQrCode">Include a QR code object for the payment. Only available for iDEAL, Bancontact and bank transfer payments.</param>
+        /// <param name="cancellationToken">Token to cancel the request</param>
+        /// <returns>The payment object created by Mollie. Once the payment is created, redirect the user to Links.Checkout.Redirect</returns>
         Task<PaymentResponse> CreatePaymentAsync(
             PaymentRequest paymentRequest,
             bool includeQrCode = false,
@@ -93,7 +101,7 @@ namespace Mollie.Api.Client.Abstract {
         /// Retrieve a list of payments by URL
         /// </summary>
         /// <param name="url">The URL from which to retrieve the payments</param>
-        /// <returns></returns>
+        /// <returns>A list of paginated payments</returns>
         Task<ListResponse<PaymentResponse>> GetPaymentListAsync(
             UrlObjectLink<ListResponse<PaymentResponse>> url,
             CancellationToken cancellationToken = default);
@@ -102,7 +110,7 @@ namespace Mollie.Api.Client.Abstract {
         /// Retrieve a single payment by URL
         /// </summary>
         /// <param name="url">The URL from which to retrieve the payment</param>
-        /// <returns></returns>
+        /// <returns>The found payment</returns>
         Task<PaymentResponse> GetPaymentAsync(
             UrlObjectLink<PaymentResponse> url,
             CancellationToken cancellationToken = default);
@@ -112,7 +120,8 @@ namespace Mollie.Api.Client.Abstract {
         /// </summary>
         /// <param name="paymentId">The payment id to update</param>
         /// <param name="paymentUpdateRequest">The payment parameters to update</param>
-        /// <returns></returns>
+        /// <returns>The changed payment</returns>
+        /// <remarks>Updating the payment details will not result in a webhook call</remarks>
         Task<PaymentResponse> UpdatePaymentAsync(
             string paymentId,
             PaymentUpdateRequest paymentUpdateRequest,

--- a/src/Mollie.Api/Client/Abstract/ISubscriptionClient.cs
+++ b/src/Mollie.Api/Client/Abstract/ISubscriptionClient.cs
@@ -8,14 +8,78 @@ using Mollie.Api.Models.Url;
 
 namespace Mollie.Api.Client.Abstract {
     public interface ISubscriptionClient : IBaseMollieClient {
+        /// <summary>
+        /// Cancel an existing subscription. Canceling a subscription has no effect on the mandates of the customer.
+        /// </summary>
+        /// <param name="customerId">The customer ID of the customer to which the subscription belongs</param>
+        /// <param name="subscriptionId">The subscription ID of the subscription to cancel</param>
+        /// <param name="testmode">Indicates whether the subscription is in test mode or not</param>
+        /// <param name="cancellationToken">Token to cancel the request. Cancelling the token might not cancel the subscription</param>
         Task CancelSubscriptionAsync(string customerId, string subscriptionId, bool testmode = false, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Create a new subscription for a customer.
+        /// </summary>
+        /// <param name="customerId">The customer ID of the customer to which the subscription belongs</param>
+        /// <param name="request">The subscription request object containing the subscription details</param>
+        /// <param name="cancellationToken">Token to cancel the request</param>
+        /// <returns>The subscription object created by Mollie</returns>
         Task<SubscriptionResponse> CreateSubscriptionAsync(string customerId, SubscriptionRequest request, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve a single subscription by its ID and the ID of its parent customer.
+        /// </summary>
+        /// <param name="customerId">The customer ID of the customer to which the subscription belongs</param>
+        /// <param name="subscriptionId">The subscription ID of the subscription to retrieve</param>
+        /// <param name="testmode">Indicates whether the subscription is in test mode or not</param>
+        /// <param name="cancellationToken">Token to cancel the request</param>
+        /// <returns>The subscription object retrieved by Mollie</returns>
         Task<SubscriptionResponse> GetSubscriptionAsync(string customerId, string subscriptionId, bool testmode = false, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve all subscriptions of a customer.
+        /// </summary>
+        /// <param name="customerId">The customer ID of the customer to which the subscription belongs</param>
+        /// <param name="from">The cursor to start pagination from</param>
+        /// <param name="limit">The maximum number of subscriptions to return</param>
+        /// <param name="profileId">The profile ID to filter subscriptions by</param>
+        /// <param name="testmode">Indicates whether the subscription is in test mode or not</param>
+        /// <param name="cancellationToken">Token to cancel the request</param>
+        /// <returns>A list of paginated subscriptions</returns>
         Task<ListResponse<SubscriptionResponse>> GetSubscriptionListAsync(string customerId, string? from = null, int? limit = null, string? profileId = null, bool testmode = false, CancellationToken cancellationToken = default);
         Task<ListResponse<SubscriptionResponse>> GetSubscriptionListAsync(UrlObjectLink<ListResponse<SubscriptionResponse>> url, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Get all subscriptions
+        /// </summary>
+        /// <param name="from">The cursor to start pagination from</param>
+        /// <param name="limit">The maximum number of subscriptions to return</param>
+        /// <param name="profileId">The profile ID to filter subscriptions by</param>
+        /// <param name="testmode">Indicates whether the subscription is in test mode or not</param>
+        /// <param name="cancellationToken">Token to cancel the request</param>
+        /// <returns>A list of paginated subscriptions</returns>
         Task<ListResponse<SubscriptionResponse>> GetAllSubscriptionList(string? from = null, int? limit = null, string? profileId = null, bool testmode = false, CancellationToken cancellationToken = default);
         Task<SubscriptionResponse> GetSubscriptionAsync(UrlObjectLink<SubscriptionResponse> url, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update an existing subscription.
+        /// </summary>
+        /// <param name="customerId">The customer ID of the customer to which the subscription belongs</param>
+        /// <param name="subscriptionId">The subscription ID of the subscription to update</param>
+        /// <param name="request">The subscription update request</param>
+        /// <param name="cancellationToken">Token to cancel the request</param>
+        /// <returns>The updated subscription object</returns>
+        /// <remarks>Canceled subscriptions cannot be updated</remarks>
         Task<SubscriptionResponse> UpdateSubscriptionAsync(string customerId, string subscriptionId, SubscriptionUpdateRequest request, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieve all payments of a specific subscription.
+        /// </summary>
+        /// <param name="customerId">The customer ID of the customer to which the subscription belongs</param>
+        /// <param name="subscriptionId">The subscription ID of the subscription to retrieve payments for</param>
+        /// <param name="from">The cursor to start pagination from</param>
+        /// <param name="limit">The maximum number of payments to return</param>
+        /// <param name="testmode">Indicates whether the subscription is in test mode or not</param>
+        /// <param name="cancellationToken">Token to cancel the request</param>
+        /// <returns>A list of paginated payments</returns>
         Task<ListResponse<PaymentResponse>> GetSubscriptionPaymentListAsync(string customerId, string subscriptionId, string? from = null, int? limit = null, bool testmode = false, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Mollie.Api/Models/Amount.cs
+++ b/src/Mollie.Api/Models/Amount.cs
@@ -5,6 +5,9 @@ using System.Globalization;
 using System.Text.Json.Serialization;
 
 namespace Mollie.Api.Models {
+    /// <summary>
+    /// The amount of a payment, refund, or chargeback.
+    /// </summary>
     public record Amount {
         private static readonly IDictionary<string, string> CurrenciesWithAlternativeDecimalPrecision =
             new Dictionary<string, string>() {
@@ -22,6 +25,11 @@ namespace Mollie.Api.Models {
         /// </summary>
         public required string Value { get; set; }
 
+        /// <summary>
+        /// Constructor for constructing based on a string value
+        /// </summary>
+        /// <param name="currency">An ISO 4217 currency code. The currencies supported depend on the payment methods that are enabled on your account.</param>
+        /// <param name="value">A string containing an exact monetary amount in the given currency.</param>
         [JsonConstructor]
         [SetsRequiredMembers]
         public Amount(string currency, string value) {
@@ -32,8 +40,8 @@ namespace Mollie.Api.Models {
         /// <summary>
         /// Constructor for constructing based on a decimal value
         /// </summary>
-        /// <param name="currency"></param>
-        /// <param name="value"></param>
+        /// <param name="currency">An ISO 4217 currency code. The currencies supported depend on the payment methods that are enabled on your account.</param>
+        /// <param name="value">The amount in the specified currency.</param>
         [SetsRequiredMembers]
         public Amount(string currency, decimal value) {
             Currency = currency;

--- a/src/Mollie.Api/Mollie.Api.csproj
+++ b/src/Mollie.Api/Mollie.Api.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>This is a wrapper for the Mollie REST webservice. All payment methods and webservice calls are supported.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
- Updated project to include the documentation files into the nuget package
- Added XML comments for a couple of the clients and models

After using the library for a couple of weeks I thought the models and clients never had documentation then I looked at the github and found that there are but they were never turned on.