### PR TITLE
Fix Capabilities property to use List instead of CapabilityResponse

### DIFF
--- a/src/Mollie.Api/Models/Client/Response/ClientEmbeddedResponse.cs
+++ b/src/Mollie.Api/Models/Client/Response/ClientEmbeddedResponse.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Mollie.Api.Models.Capability.Response;
 using Mollie.Api.Models.Onboarding.Response;
 using Mollie.Api.Models.Organization;
@@ -9,6 +10,6 @@ namespace Mollie.Api.Models.Client.Response {
 
         public OnboardingStatusResponse? Onboarding { get; set; }
 
-        public CapabilityResponse? Capabilities { get; set; }
+        public List<CapabilityResponse>? Capabilities { get; set; }
     }
 }


### PR DESCRIPTION
Response is different than what the API documentation suggests:

<img width="744" height="1053" alt="image" src="https://github.com/user-attachments/assets/3df90cdb-6422-4b62-822a-59035f0af32f" />
