### PR TITLE
feat(nuget): Add missing package properties

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,15 +1,31 @@
 <Project>
   <PropertyGroup>
-	<Version>4.18.0.0</Version>
-	<Authors>Vincent Kok</Authors>
-    <Company>Vincent Kok</Company>
-    <Product>Mollie Payment API</Product>
-    <PackageProjectUrl>https://github.com/Viincenttt/MollieApi</PackageProjectUrl>
-    <PackageTags>Mollie;Payment;Payments;Webhook</PackageTags>
+    <!-- Package identity -->
+    <Version>4.18.0.0</Version>
     <AssemblyVersion>4.18.0.0</AssemblyVersion>
     <FileVersion>4.18.0.0</FileVersion>
     <PackageVersion>4.18.0.0</PackageVersion>
+    <Authors>Vincent Kok</Authors>
+    <Company>Vincent Kok</Company>
+    <Product>Mollie Payment API</Product>
+    <PackageTags>Mollie;Payment;Payments;Webhook</PackageTags>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Package metadata & license -->
+    <PackageProjectUrl>https://github.com/Viincenttt/MollieApi</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Viincenttt/MollieApi.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Build & symbols -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!-- Suppress warnings for missing XML documentation comments on public members -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/Mollie.Api/Mollie.Api.csproj
+++ b/src/Mollie.Api/Mollie.Api.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="2.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.19" />
     <PackageReference Include="PolySharp" Version="1.15.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Enhances the NuGet package metadata in Directory.Build.props to produce higher-quality packages on NuGet.org.

Changes
Repository linking — Added RepositoryUrl and RepositoryType so NuGet.org displays a source repository link and IDE tooling can navigate to source.
Symbol packages — Added IncludeSymbols and SymbolPackageFormat (snupkg) to publish symbol packages alongside the main package, enabling consumers to step into source during debugging.
Source embedding — Added EmbedUntrackedSources to ensure all source files are embedded for deterministic builds.
Suppress CS1591 — Added NoWarn for CS1591 to suppress warnings for missing XML documentation comments on public members.
Property grouping — Reorganized properties into logical groups (identity, metadata/license, build/symbols) with comments for readability.

<img width="600" height="619" alt="image" src="https://github.com/user-attachments/assets/6a7ce72a-4a23-4267-b159-4a2e5f79b581" />

Closes #474 