### PR TITLE
chore: Clear build warnings

### DIFF
--- a/src/Mollie.Api/Client/Abstract/IPaymentClient.cs
+++ b/src/Mollie.Api/Client/Abstract/IPaymentClient.cs
@@ -35,6 +35,7 @@ namespace Mollie.Api.Client.Abstract {
         /// </param>
         /// <param name="embedRefunds">Include all refunds created for the payment.</param>
         /// <param name="embedChargebacks"> Include all chargebacks issued for the payment.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the request.</param>
         /// <returns></returns>
         Task<PaymentResponse> GetPaymentAsync(
             string paymentId,
@@ -52,6 +53,7 @@ namespace Mollie.Api.Client.Abstract {
         /// </summary>
         /// <param name="paymentId"></param>
         /// <param name="testmode">Oauth - Optional – Set this to true to cancel a test mode payment.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the request.</param>
         /// <returns></returns>
         Task CancelPaymentAsync(
             string paymentId,
@@ -85,6 +87,7 @@ namespace Mollie.Api.Client.Abstract {
         /// <param name="embedChargebacks">Include any chargebacks issued for the payments.</param>
         /// <param name="sort">Used for setting the direction of the results based on the from parameter. Can be set
         /// to desc or asc. Default is desc.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the request.</param>
         /// <returns></returns>
 		Task<ListResponse<PaymentResponse>> GetPaymentListAsync(
             string? from = null,
@@ -101,6 +104,7 @@ namespace Mollie.Api.Client.Abstract {
         /// Retrieve a list of payments by URL
         /// </summary>
         /// <param name="url">The URL from which to retrieve the payments</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the request.</param>
         /// <returns>A list of paginated payments</returns>
         Task<ListResponse<PaymentResponse>> GetPaymentListAsync(
             UrlObjectLink<ListResponse<PaymentResponse>> url,
@@ -110,6 +114,7 @@ namespace Mollie.Api.Client.Abstract {
         /// Retrieve a single payment by URL
         /// </summary>
         /// <param name="url">The URL from which to retrieve the payment</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the request.</param>
         /// <returns>The found payment</returns>
         Task<PaymentResponse> GetPaymentAsync(
             UrlObjectLink<PaymentResponse> url,
@@ -120,6 +125,7 @@ namespace Mollie.Api.Client.Abstract {
         /// </summary>
         /// <param name="paymentId">The payment id to update</param>
         /// <param name="paymentUpdateRequest">The payment parameters to update</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the request.</param>
         /// <returns>The changed payment</returns>
         /// <remarks>Updating the payment details will not result in a webhook call</remarks>
         Task<PaymentResponse> UpdatePaymentAsync(

--- a/src/Mollie.Api/Client/Abstract/IPaymentLinkClient.cs
+++ b/src/Mollie.Api/Client/Abstract/IPaymentLinkClient.cs
@@ -24,9 +24,6 @@ namespace Mollie.Api.Client.Abstract {
         /// </summary>
         /// <param name="paymentLinkId">Provide the ID of the item you want to perform this operation on.</param>
         /// <param name="paymentLinkUpdateRequest">The request body</param>
-        /// <param name="testmode">Most API credentials are specifically created for either live mode or test mode.
-        /// In those cases the testmode query parameter can be omitted. For organization-level credentials such as
-        /// OAuth access tokens, you can enable test mode by setting the testmode query parameter to true.</param>
         /// <param name="cancellationToken">Token to cancel the operation</param>
         /// <returns>The updated payment link response</returns>
         Task<PaymentLinkResponse> UpdatePaymentLinkAsync(

--- a/src/Mollie.Api/Client/BaseMollieClient.cs
+++ b/src/Mollie.Api/Client/BaseMollieClient.cs
@@ -192,7 +192,7 @@ namespace Mollie.Api.Client {
 
         private string GetUserAgent() {
             const string packageName = "Mollie.Api.NET";
-            string versionNumber = typeof(BaseMollieClient).GetTypeInfo().Assembly.GetName().Version.ToString();
+            string versionNumber = typeof(BaseMollieClient).GetTypeInfo().Assembly.GetName().Version?.ToString() ?? "unknown";
             string userAgent = $"{packageName}/{versionNumber}";
 
             if (!string.IsNullOrEmpty(_options.CustomUserAgent)) {

--- a/src/Mollie.Api/DependencyInjection.cs
+++ b/src/Mollie.Api/DependencyInjection.cs
@@ -46,7 +46,9 @@ namespace Mollie.Api {
             RegisterMollieApiClient<IInvoiceClient, InvoiceClient>(services, mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IMandateClient, MandateClient>(services, mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IOnboardingClient, OnboardingClient>(services, mollieOptions.RetryPolicy);
+#pragma warning disable CS0618
             RegisterMollieApiClient<IOrderClient, OrderClient>(services, mollieOptions.RetryPolicy);
+#pragma warning restore CS0618
             RegisterMollieApiClient<IOrganizationClient, OrganizationClient>(services, mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IPaymentClient, PaymentClient>(services, mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IPaymentLinkClient, PaymentLinkClient>(services, mollieOptions.RetryPolicy);

--- a/src/Mollie.Api/JsonConverters/Iso8601DateTimeConverter.cs
+++ b/src/Mollie.Api/JsonConverters/Iso8601DateTimeConverter.cs
@@ -7,7 +7,7 @@ namespace Mollie.Api.JsonConverters {
     {
         public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return DateTime.Parse(reader.GetString());
+            return DateTime.Parse(reader.GetString()!);
         }
 
         public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)

--- a/src/Mollie.Api/JsonConverters/PolymorphicConverter.cs
+++ b/src/Mollie.Api/JsonConverters/PolymorphicConverter.cs
@@ -40,14 +40,14 @@ internal class PolymorphicConverter<T> : JsonConverter<T> {
         JsonSerializerOptions newOptions = new(options);
         newOptions.Converters.Remove(this);
 
-        var result = (T)JsonSerializer.Deserialize(json, response.GetType(), newOptions)!;
+        var result = (T)JsonSerializer.Deserialize(json, response!.GetType(), newOptions)!;
 
         return result;
     }
 
     public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
     {
-        JsonSerializer.Serialize(writer, value, value.GetType(), options);
+        JsonSerializer.Serialize(writer, value, value!.GetType(), options);
     }
 }
 

--- a/src/Mollie.Api/JsonConverters/RawJsonConverter.cs
+++ b/src/Mollie.Api/JsonConverters/RawJsonConverter.cs
@@ -29,9 +29,9 @@ internal class RawJsonConverter : JsonConverter<string>
             return;
         }
 
-        if (IsValidJson(value))
+        if (IsValidJson(value!))
         {
-            writer.WriteRawValue(value);
+            writer.WriteRawValue(value!);
         }
         else
         {

--- a/src/Mollie.Api/JsonConverters/SettlementPeriodConverter.cs
+++ b/src/Mollie.Api/JsonConverters/SettlementPeriodConverter.cs
@@ -22,7 +22,7 @@ internal class SettlementPeriodConverter : JsonConverter<Dictionary<int, Diction
 
             foreach (var period in property.Value.EnumerateObject()) {
                 int day = int.Parse(period.Name);
-                var settlementPeriod = JsonSerializer.Deserialize<SettlementPeriod>(period.Value.GetRawText(), options);
+                var settlementPeriod = JsonSerializer.Deserialize<SettlementPeriod>(period.Value.GetRawText(), options)!;
                 monthPeriods[day] = settlementPeriod;
             }
 

--- a/src/Mollie.Api/Models/Balance/Response/BalanceReport/BalanceReportResponse.cs
+++ b/src/Mollie.Api/Models/Balance/Response/BalanceReport/BalanceReportResponse.cs
@@ -34,12 +34,10 @@ namespace Mollie.Api.Models.Balance.Response.BalanceReport {
         /// You can retrieve reports in two different formats. With the status-balances format, transactions are grouped by status
         /// (e.g. pending, available), then by direction of movement (e.g. moved from pending to available), then by transaction type,
         /// and then by other sub-groupings where available (e.g. payment method).
-
-        /// With the transaction-categories format, transactions are grouped by transaction type, then by direction of movement, and
-        /// then again by other sub-groupings where available.
-
-        /// Both reporting formats will always contain opening and closing amounts that correspond to the start and end dates of the report.
-        /// Possible values: status-balances transaction-categories
+        /// <para>With the transaction-categories format, transactions are grouped by transaction type, then by direction of movement, and
+        /// then again by other sub-groupings where available.</para>
+        /// <para>Both reporting formats will always contain opening and closing amounts that correspond to the start and end dates of the report.
+        /// Possible values: status-balances transaction-categories</para>
         /// </summary>
         public required string Grouping { get; set; }
 

--- a/src/Mollie.Api/Models/Payment/Request/PaymentRequest.cs
+++ b/src/Mollie.Api/Models/Payment/Request/PaymentRequest.cs
@@ -30,11 +30,10 @@ namespace Mollie.Api.Models.Payment.Request {
 
         /// <summary>
         /// The URL your consumer will be redirected to when the consumer explicitly cancels the payment. If this URL is not
-        /// provided, the consumer will be redirected to the redirectUrl instead — see above.
-
-        /// Mollie will always give you status updates via webhooks, including for the canceled status. This parameter is
+        /// provided, the consumer will be redirected to the redirectUrl instead &#x2014; see above.
+        /// <para>Mollie will always give you status updates via webhooks, including for the canceled status. This parameter is
         /// therefore entirely optional, but can be useful when implementing a dedicated consumer-facing flow to handle payment
-        /// cancellations.
+        /// cancellations.</para>
         /// </summary>
         public string? CancelUrl { get; set; }
 

--- a/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/PointOfSalePaymentResponse.cs
+++ b/src/Mollie.Api/Models/Payment/Response/PaymentSpecificParameters/PointOfSalePaymentResponse.cs
@@ -19,7 +19,7 @@ public record PointOfSalePaymentResponseDetails {
     public string? CardNumber { get; set; }
 
     /// <summary>
-    /// The first 6 digits & last 4 digits of the customer's masked card number.
+    /// The first 6 digits &amp; last 4 digits of the customer's masked card number.
     /// </summary>
     public string? MaskedNumber { get; set; }
 

--- a/src/Mollie.Api/Models/Session/Request/SessionRequest.cs
+++ b/src/Mollie.Api/Models/Session/Request/SessionRequest.cs
@@ -26,11 +26,10 @@ namespace Mollie.Api.Models.Session.Request {
 
         /// <summary>
         /// The URL your consumer will be redirected to when the consumer explicitly cancels the payment. If this URL is not
-        /// provided, the consumer will be redirected to the redirectUrl instead — see above.
-
-        /// Mollie will always give you status updates via webhooks, including for the canceled status. This parameter is
+        /// provided, the consumer will be redirected to the redirectUrl instead &#x2014; see above.
+        /// <para>Mollie will always give you status updates via webhooks, including for the canceled status. This parameter is
         /// therefore entirely optional, but can be useful when implementing a dedicated consumer-facing flow to handle payment
-        /// cancellations.
+        /// cancellations.</para>
         /// </summary>
         public string? CancelUrl { get; set; }
 

--- a/tests/Mollie.Tests.Integration/Api/OrderTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/OrderTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+#pragma warning disable CS0618
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/tests/Mollie.Tests.Unit/Client/OrderClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/OrderClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+#pragma warning disable CS0618
 using Mollie.Api.Client;
 using Mollie.Api.Models;
 using Mollie.Api.Models.Order;


### PR DESCRIPTION
**CS1570 — Malformed XML:**
- SessionRequest.cs & PaymentRequest.cs: replaced em dash `—` with `&#x2014;`, wrapped second paragraph in `<para>` tags
- BalanceReportResponse.cs: wrapped paragraphs in `<para>` tags to remove blank `///` lines
- PointOfSalePaymentResponse.cs: escaped `&` → `&amp;`

**CS1572/CS1573 — XML param mismatches:**
- IPaymentClient.cs: added `<param name="cancellationToken">` to 6 methods missing it
- IPaymentLinkClient.cs: removed stale `<param name="testmode">` tag

**CS8601/8602/8604 — Nullable refs:**
- PolymorphicConverter.cs: added `!` to `response!.GetType()` and `value!.GetType()`
- RawJsonConverter.cs: added `!` on `IsValidJson(value!)` and `WriteRawValue(value!)`
- SettlementPeriodConverter.cs: added `!` on `settlementPeriod!` assignment
- Iso8601DateTimeConverter.cs: added `!` on `reader.GetString()!`
- BaseMollieClient.cs: used `?.ToString() ?? "unknown"` on `Version`

**CS0618 — Obsolete OrderClient:**
- DependencyInjection.cs: `#pragma warning disable/restore CS0618` around DI registration
- OrderClientTests.cs & OrderTests.cs: `#pragma warning disable CS0618` at file top

**Remaining (2 warnings, not in original list):** CS0618 in the Blazor sample's `.razor` files (Create.razor, Overview.razor) — `@inject IOrderClient` cannot be suppressed with `#pragma` on Razor directives.

Made changes.