### PR TITLE
Add support for the Payouts API

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ This library currently supports the following API's:
 - [Webhooks API](https://github.com/Viincenttt/MollieApi/wiki/19.-Webhook-Api) 
 - [WebhooksEvents API](https://github.com/Viincenttt/MollieApi/wiki/20.-Webhook-Api)
 - [Balance transfer API](https://github.com/Viincenttt/MollieApi/wiki/21.-Balance-transfer-Api) 
+- [Payout API](https://github.com/Viincenttt/MollieApi/wiki/22.-Payout-API)
 
 ---
 

--- a/src/Mollie.Api/Client/Abstract/IPayoutClient.cs
+++ b/src/Mollie.Api/Client/Abstract/IPayoutClient.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Mollie.Api.Models.Payout.Request;
+using Mollie.Api.Models.Payout.Response;
+
+namespace Mollie.Api.Client.Abstract;
+
+public interface IPayoutClient : IBaseMollieClient {
+    /// <summary>
+    /// Request a payout from one of your balances to the balance's configured bank account.
+    /// The payout will be executed on the next scheduled business day. If no amount is specified,
+    /// the full available balance minus any configured balance reserve is paid out.
+    /// </summary>
+    Task<PayoutResponse> CreatePayoutAsync(PayoutRequest request, CancellationToken cancellationToken = default);
+}
+
+

--- a/src/Mollie.Api/Client/Abstract/IPayoutClient.cs
+++ b/src/Mollie.Api/Client/Abstract/IPayoutClient.cs
@@ -23,6 +23,11 @@ public interface IPayoutClient : IBaseMollieClient {
     Task<ListResponse<PayoutResponse>> GetPayoutListAsync(
         string? balanceId = null, string? from = null, int? limit = null,
         SortDirection? sort = null, bool testmode = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieve a single payout by its ID.
+    /// </summary>
+    Task<PayoutResponse> GetPayoutAsync(string payoutId, bool testmode = false, CancellationToken cancellationToken = default);
 }
 
 

--- a/src/Mollie.Api/Client/Abstract/IPayoutClient.cs
+++ b/src/Mollie.Api/Client/Abstract/IPayoutClient.cs
@@ -28,6 +28,12 @@ public interface IPayoutClient : IBaseMollieClient {
     /// Retrieve a single payout by its ID.
     /// </summary>
     Task<PayoutResponse> GetPayoutAsync(string payoutId, bool testmode = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Cancel a payout. A payout can only be canceled while it has the status requested.
+    /// Once the payout moves to initiated, it is too late to cancel.
+    /// </summary>
+    Task<PayoutResponse> CancelPayoutAsync(string payoutId, bool testmode = false, CancellationToken cancellationToken = default);
 }
 
 

--- a/src/Mollie.Api/Client/Abstract/IPayoutClient.cs
+++ b/src/Mollie.Api/Client/Abstract/IPayoutClient.cs
@@ -1,5 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Mollie.Api.Models;
+using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Payout.Request;
 using Mollie.Api.Models.Payout.Response;
 
@@ -12,6 +14,15 @@ public interface IPayoutClient : IBaseMollieClient {
     /// the full available balance minus any configured balance reserve is paid out.
     /// </summary>
     Task<PayoutResponse> CreatePayoutAsync(PayoutRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieve a list of all payouts for your organization, including payouts initiated automatically
+    /// by the balance's payout schedule and payouts requested via the API or dashboard.
+    /// Only payouts created on or after April 1st, 2026 are returned.
+    /// </summary>
+    Task<ListResponse<PayoutResponse>> GetPayoutListAsync(
+        string? balanceId = null, string? from = null, int? limit = null,
+        SortDirection? sort = null, bool testmode = false, CancellationToken cancellationToken = default);
 }
 
 

--- a/src/Mollie.Api/Client/BaseMollieClient.cs
+++ b/src/Mollie.Api/Client/BaseMollieClient.cs
@@ -127,6 +127,11 @@ namespace Mollie.Api.Client {
                 .ConfigureAwait(false);
         }
 
+        protected async Task<T> DeleteAsync<T>(string relativeUri, object? data = null, CancellationToken cancellationToken = default) {
+            return await SendHttpRequest<T>(HttpMethod.Delete, relativeUri, data, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         private async Task<T> ProcessHttpResponseMessage<T>(HttpResponseMessage response) {
             var resultContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/src/Mollie.Api/Client/PayoutClient.cs
+++ b/src/Mollie.Api/Client/PayoutClient.cs
@@ -40,4 +40,13 @@ public class PayoutClient : BaseMollieClient, IPayoutClient {
                 "payouts", from, limit, queryParameters, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
     }
+
+    public async Task<PayoutResponse> GetPayoutAsync(
+        string payoutId, bool testmode = false, CancellationToken cancellationToken = default) {
+        ValidateRequiredUrlParameter(nameof(payoutId), payoutId);
+        var queryParameters = BuildQueryParameters(testmode: testmode);
+        return await GetAsync<PayoutResponse>(
+                $"payouts/{payoutId}{queryParameters.ToQueryString()}", cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
 }

--- a/src/Mollie.Api/Client/PayoutClient.cs
+++ b/src/Mollie.Api/Client/PayoutClient.cs
@@ -3,7 +3,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Mollie.Api.Client.Abstract;
+using Mollie.Api.Extensions;
 using Mollie.Api.Framework.Authentication.Abstract;
+using Mollie.Api.Models;
+using Mollie.Api.Models.List.Response;
 using Mollie.Api.Models.Payout.Request;
 using Mollie.Api.Models.Payout.Response;
 using Mollie.Api.Options;
@@ -27,5 +30,14 @@ public class PayoutClient : BaseMollieClient, IPayoutClient {
         return await PostAsync<PayoutResponse>("payouts", request, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
     }
-}
 
+    public async Task<ListResponse<PayoutResponse>> GetPayoutListAsync(
+        string? balanceId = null, string? from = null, int? limit = null,
+        SortDirection? sort = null, bool testmode = false, CancellationToken cancellationToken = default) {
+        var queryParameters = BuildQueryParameters(testmode: testmode, sort: sort);
+        queryParameters.AddValueIfNotNullOrEmpty(nameof(balanceId), balanceId);
+        return await GetListAsync<ListResponse<PayoutResponse>>(
+                "payouts", from, limit, queryParameters, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Mollie.Api/Client/PayoutClient.cs
+++ b/src/Mollie.Api/Client/PayoutClient.cs
@@ -1,0 +1,31 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Mollie.Api.Client.Abstract;
+using Mollie.Api.Framework.Authentication.Abstract;
+using Mollie.Api.Models.Payout.Request;
+using Mollie.Api.Models.Payout.Response;
+using Mollie.Api.Options;
+
+namespace Mollie.Api.Client;
+
+public class PayoutClient : BaseMollieClient, IPayoutClient {
+    public PayoutClient(string apiKey, HttpClient? httpClient = null)
+        : base(apiKey, httpClient)
+    {
+    }
+
+    [ActivatorUtilitiesConstructor]
+    public PayoutClient(MollieClientOptions options, IMollieSecretManager mollieSecretManager, HttpClient? httpClient = null)
+        : base(options, mollieSecretManager, httpClient)
+    {
+    }
+
+    public async Task<PayoutResponse> CreatePayoutAsync(
+        PayoutRequest request, CancellationToken cancellationToken = default) {
+        return await PostAsync<PayoutResponse>("payouts", request, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+}
+

--- a/src/Mollie.Api/Client/PayoutClient.cs
+++ b/src/Mollie.Api/Client/PayoutClient.cs
@@ -49,4 +49,12 @@ public class PayoutClient : BaseMollieClient, IPayoutClient {
                 $"payouts/{payoutId}{queryParameters.ToQueryString()}", cancellationToken: cancellationToken)
             .ConfigureAwait(false);
     }
+
+    public async Task<PayoutResponse> CancelPayoutAsync(
+        string payoutId, bool testmode = false, CancellationToken cancellationToken = default) {
+        ValidateRequiredUrlParameter(nameof(payoutId), payoutId);
+        var data = CreateTestmodeModel(testmode);
+        return await DeleteAsync<PayoutResponse>($"payouts/{payoutId}", data, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
 }

--- a/src/Mollie.Api/DependencyInjection.cs
+++ b/src/Mollie.Api/DependencyInjection.cs
@@ -69,6 +69,7 @@ namespace Mollie.Api {
             RegisterMollieApiClient<IWebhookClient, WebhookClient>(services, mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IWebhookEventClient, WebhookEventClient>(services, mollieOptions.RetryPolicy);
             RegisterMollieApiClient<IBalanceTransferClient, BalanceTransferClient>(services, mollieOptions.RetryPolicy);
+            RegisterMollieApiClient<IPayoutClient, PayoutClient>(services, mollieOptions.RetryPolicy);
 
             return services;
         }

--- a/src/Mollie.Api/Models/Payout/Request/PayoutRequest.cs
+++ b/src/Mollie.Api/Models/Payout/Request/PayoutRequest.cs
@@ -1,0 +1,25 @@
+namespace Mollie.Api.Models.Payout.Request;
+
+public record PayoutRequest : ITestModeRequest {
+    /// <summary>
+    /// The identifier of the balance that will be paid out.
+    /// Example: bal_gVMhHKqSSRYJyPsuoPNFH.
+    /// </summary>
+    public required string BalanceId { get; set; }
+
+    /// <summary>
+    /// The amount to pay out. When omitted, the full available balance minus any configured balance reserve is paid out.
+    /// </summary>
+    public Amount? Amount { get; set; }
+
+    /// <summary>
+    /// The description that will appear on the bank statement for this payout.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Whether to create the entity in test mode or live mode.
+    /// </summary>
+    public bool? Testmode { get; set; }
+}
+

--- a/src/Mollie.Api/Models/Payout/Response/PayoutResponse.cs
+++ b/src/Mollie.Api/Models/Payout/Response/PayoutResponse.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Mollie.Api.Models.Payout.Response;
+
+public record PayoutResponse {
+    /// <summary>
+    /// Indicates the response contains a payout object. Will always contain the string payout for this endpoint.
+    /// </summary>
+    public required string Resource { get; set; }
+
+    /// <summary>
+    /// The identifier uniquely referring to this payout.
+    /// Example: payout_j8NvRAM2WNZtsykpLEX8J.
+    /// </summary>
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The identifier of the balance that will be paid out.
+    /// Example: bal_gVMhHKqSSRYJyPsuoPNFH.
+    /// </summary>
+    public required string BalanceId { get; set; }
+
+    /// <summary>
+    /// The amount to pay out. The value reflects the amount paid out, excluding any applicable fees.
+    /// </summary>
+    public Amount? Amount { get; set; }
+
+    /// <summary>
+    /// The description that will appear on the bank statement for this payout.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The status of the payout.
+    /// Refer to the <see cref="PayoutStatus"/> class for a full list of known values.
+    /// </summary>
+    public required string Status { get; set; }
+
+    /// <summary>
+    /// The reason for the payout's current status.
+    /// </summary>
+    public required StatusReason StatusReason { get; set; }
+
+    /// <summary>
+    /// The entity's date and time of creation, in ISO 8601 format.
+    /// </summary>
+    public required DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// The date and time the payout was initiated, in ISO 8601 format.
+    /// null if the payout has not been initiated yet.
+    /// </summary>
+    public DateTime? InitiatedAt { get; set; }
+
+    /// <summary>
+    /// The date and time the payout was sent to the destination bank account, in ISO 8601 format.
+    /// null if the payout has not completed yet.
+    /// </summary>
+    public DateTime? CompletedAt { get; set; }
+
+    /// <summary>
+    /// The date and time the payout was canceled, in ISO 8601 format.
+    /// null if the payout was not canceled.
+    /// </summary>
+    public DateTime? CanceledAt { get; set; }
+
+    /// <summary>
+    /// Whether this entity was created in live mode or in test mode.
+    /// </summary>
+    public required Mode Mode { get; set; }
+
+    /// <summary>
+    /// An object with several relevant URLs.
+    /// </summary>
+    [JsonPropertyName("_links")]
+    public required PayoutResponseLinks Links { get; set; }
+}
+
+
+

--- a/src/Mollie.Api/Models/Payout/Response/PayoutResponseLinks.cs
+++ b/src/Mollie.Api/Models/Payout/Response/PayoutResponseLinks.cs
@@ -1,0 +1,16 @@
+using Mollie.Api.Models.Url;
+
+namespace Mollie.Api.Models.Payout.Response;
+
+public record PayoutResponseLinks {
+    /// <summary>
+    /// The URL to the current resource.
+    /// </summary>
+    public required UrlObjectLink<PayoutResponse> Self { get; set; }
+
+    /// <summary>
+    /// The URL to the documentation of the current resource.
+    /// </summary>
+    public required UrlLink Documentation { get; set; }
+}
+

--- a/src/Mollie.Api/Models/Payout/Response/PayoutStatus.cs
+++ b/src/Mollie.Api/Models/Payout/Response/PayoutStatus.cs
@@ -1,0 +1,11 @@
+namespace Mollie.Api.Models.Payout.Response;
+
+public static class PayoutStatus {
+    public const string Requested = "requested";
+    public const string Initiated = "initiated";
+    public const string ProcessingAtBank = "processing-at-bank";
+    public const string Completed = "completed";
+    public const string Failed = "failed";
+    public const string Canceled = "canceled";
+}
+

--- a/tests/Mollie.Tests.Integration/Api/PayoutTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/PayoutTests.cs
@@ -101,6 +101,28 @@ public class PayoutTests : BaseMollieApiTestClass, IDisposable {
         }
     }
 
+    [Fact]
+    public async Task GetPayoutAsync_WithValidPayoutId_IsParsedCorrectly() {
+        // Given: We create a payout first to get a valid ID
+        var primaryBalance = await _balanceClient.GetPrimaryBalanceAsync();
+        var created = await _payoutClient.CreatePayoutAsync(new PayoutRequest { BalanceId = primaryBalance.Id });
+
+        // When: We retrieve the payout by ID
+        var result = await _payoutClient.GetPayoutAsync(created.Id);
+
+        // Then
+        result.ShouldNotBeNull();
+        result.Resource.ShouldBe("payout");
+        result.Id.ShouldBe(created.Id);
+        result.BalanceId.ShouldBe(primaryBalance.Id);
+        result.Status.ShouldNotBeNullOrEmpty();
+        result.StatusReason.ShouldNotBeNull();
+        result.CreatedAt.ShouldNotBe(default);
+        result.Mode.ShouldBeOneOf(Mode.Live, Mode.Test);
+        result.Links.ShouldNotBeNull();
+        result.Links.Self.Href.ShouldNotBeNullOrEmpty();
+    }
+
     public void Dispose() {
         _payoutClient?.Dispose();
         _balanceClient?.Dispose();

--- a/tests/Mollie.Tests.Integration/Api/PayoutTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/PayoutTests.cs
@@ -73,6 +73,34 @@ public class PayoutTests : BaseMollieApiTestClass, IDisposable {
         result.Amount!.Currency.ShouldBe("EUR");
     }
 
+    [Fact]
+    public async Task GetPayoutListAsync_WithoutParameters_IsParsedCorrectly() {
+        // When: We retrieve the list of payouts
+        var result = await _payoutClient.GetPayoutListAsync();
+
+        // Then
+        result.ShouldNotBeNull();
+        result.Items.ShouldNotBeNull();
+        result.Links.ShouldNotBeNull();
+        result.Links.Self.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task GetPayoutListAsync_FilteredByBalanceId_IsParsedCorrectly() {
+        // Given: We retrieve the primary balance
+        var primaryBalance = await _balanceClient.GetPrimaryBalanceAsync();
+
+        // When: We retrieve payouts filtered by balance ID
+        var result = await _payoutClient.GetPayoutListAsync(balanceId: primaryBalance.Id);
+
+        // Then
+        result.ShouldNotBeNull();
+        result.Items.ShouldNotBeNull();
+        foreach (var payout in result.Items) {
+            payout.BalanceId.ShouldBe(primaryBalance.Id);
+        }
+    }
+
     public void Dispose() {
         _payoutClient?.Dispose();
         _balanceClient?.Dispose();

--- a/tests/Mollie.Tests.Integration/Api/PayoutTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/PayoutTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading.Tasks;
+using Mollie.Api.Client.Abstract;
+using Mollie.Api.Models;
+using Mollie.Api.Models.Payout.Request;
+using Mollie.Tests.Integration.Framework;
+using Shouldly;
+using Xunit;
+
+namespace Mollie.Tests.Integration.Api;
+
+[Trait("TestCategory", "LocalIntegrationTests")]
+public class PayoutTests : BaseMollieApiTestClass, IDisposable {
+    private readonly IPayoutClient _payoutClient;
+    private readonly IBalanceClient _balanceClient;
+
+    public PayoutTests(IPayoutClient payoutClient, IBalanceClient balanceClient) {
+        _payoutClient = payoutClient;
+        _balanceClient = balanceClient;
+    }
+
+    [Fact]
+    public async Task CreatePayoutAsync_WithFullBalance_IsParsedCorrectly() {
+        // Given: We retrieve the primary balance to get a valid balance ID
+        var primaryBalance = await _balanceClient.GetPrimaryBalanceAsync();
+
+        var request = new PayoutRequest {
+            BalanceId = primaryBalance.Id
+        };
+
+        // When: We create a payout
+        var result = await _payoutClient.CreatePayoutAsync(request);
+
+        // Then: Make sure we can parse the result
+        result.ShouldNotBeNull();
+        result.Resource.ShouldBe("payout");
+        result.Id.ShouldNotBeNullOrEmpty();
+        result.BalanceId.ShouldBe(primaryBalance.Id);
+        result.Status.ShouldNotBeNullOrEmpty();
+        result.StatusReason.ShouldNotBeNull();
+        result.StatusReason.Code.ShouldNotBeNullOrEmpty();
+        result.StatusReason.Message.ShouldNotBeNullOrEmpty();
+        result.CreatedAt.ShouldNotBe(default);
+        result.Mode.ShouldBeOneOf(Mode.Live, Mode.Test);
+        result.Links.ShouldNotBeNull();
+        result.Links.Self.ShouldNotBeNull();
+        result.Links.Self.Href.ShouldNotBeNullOrEmpty();
+        result.Links.Documentation.ShouldNotBeNull();
+        result.Links.Documentation.Href.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task CreatePayoutAsync_WithSpecificAmountAndDescription_IsParsedCorrectly() {
+        // Given: We retrieve the primary balance
+        var primaryBalance = await _balanceClient.GetPrimaryBalanceAsync();
+
+        var request = new PayoutRequest {
+            BalanceId = primaryBalance.Id,
+            Amount = new Amount(Currency.EUR, "10.00"),
+            Description = "Integration test payout"
+        };
+
+        // When: We create a payout with an amount and description
+        var result = await _payoutClient.CreatePayoutAsync(request);
+
+        // Then
+        result.ShouldNotBeNull();
+        result.Resource.ShouldBe("payout");
+        result.Id.ShouldNotBeNullOrEmpty();
+        result.BalanceId.ShouldBe(primaryBalance.Id);
+        result.Description.ShouldBe("Integration test payout");
+        result.Amount.ShouldNotBeNull();
+        result.Amount!.Currency.ShouldBe("EUR");
+    }
+
+    public void Dispose() {
+        _payoutClient?.Dispose();
+        _balanceClient?.Dispose();
+    }
+}
+

--- a/tests/Mollie.Tests.Integration/Api/PayoutTests.cs
+++ b/tests/Mollie.Tests.Integration/Api/PayoutTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Mollie.Api.Client.Abstract;
 using Mollie.Api.Models;
 using Mollie.Api.Models.Payout.Request;
+using Mollie.Api.Models.Payout.Response;
 using Mollie.Tests.Integration.Framework;
 using Shouldly;
 using Xunit;
@@ -121,6 +122,23 @@ public class PayoutTests : BaseMollieApiTestClass, IDisposable {
         result.Mode.ShouldBeOneOf(Mode.Live, Mode.Test);
         result.Links.ShouldNotBeNull();
         result.Links.Self.Href.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task CancelPayoutAsync_WithRequestedPayout_ReturnsCanceledPayout() {
+        // Given: We create a payout first
+        var primaryBalance = await _balanceClient.GetPrimaryBalanceAsync();
+        var created = await _payoutClient.CreatePayoutAsync(new PayoutRequest { BalanceId = primaryBalance.Id });
+
+        // When: We cancel the payout while it is still in 'requested' status
+        var result = await _payoutClient.CancelPayoutAsync(created.Id);
+
+        // Then
+        result.ShouldNotBeNull();
+        result.Resource.ShouldBe("payout");
+        result.Id.ShouldBe(created.Id);
+        result.Status.ShouldBe(PayoutStatus.Canceled);
+        result.CanceledAt.ShouldNotBeNull();
     }
 
     public void Dispose() {

--- a/tests/Mollie.Tests.Unit/Client/PayoutClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/PayoutClientTests.cs
@@ -192,6 +192,95 @@ public class PayoutClientTests : BaseClientTests {
         exception.Message.ShouldContain("payoutId");
     }
 
+    [Fact]
+    public async Task CancelPayoutAsync_WithValidPayoutId_ResponseIsDeserializedInExpectedFormat() {
+        // Given
+        const string payoutId = "payout_j8NvRAM2WNZtsykpLEX8J";
+        const string balanceId = "bal_gVMhHKqSSRYJyPsuoPNFH";
+        string jsonToReturnInMockResponse = CreateCanceledPayoutJsonResponse(payoutId, balanceId);
+        var mockHttp = CreateMockHttpMessageHandler(
+            HttpMethod.Delete,
+            $"{BaseMollieClient.DefaultBaseApiEndPoint}payouts/{payoutId}",
+            jsonToReturnInMockResponse);
+        HttpClient httpClient = mockHttp.ToHttpClient();
+        var client = new PayoutClient("abcde", httpClient);
+
+        // When
+        PayoutResponse response = await client.CancelPayoutAsync(payoutId);
+
+        // Then
+        mockHttp.VerifyNoOutstandingExpectation();
+        response.ShouldNotBeNull();
+        response.Id.ShouldBe(payoutId);
+        response.BalanceId.ShouldBe(balanceId);
+        response.Status.ShouldBe(PayoutStatus.Canceled);
+        response.CanceledAt.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task CancelPayoutAsync_WithTestmodeTrue_SendsTestmodeInRequestBody() {
+        // Given
+        const string payoutId = "payout_j8NvRAM2WNZtsykpLEX8J";
+        const string balanceId = "bal_gVMhHKqSSRYJyPsuoPNFH";
+        string jsonToReturnInMockResponse = CreateCanceledPayoutJsonResponse(payoutId, balanceId);
+        var mockHttp = CreateMockHttpMessageHandler(
+            HttpMethod.Delete,
+            $"{BaseMollieClient.DefaultBaseApiEndPoint}payouts/{payoutId}",
+            jsonToReturnInMockResponse,
+            expectedPartialContent: "\"testmode\":true");
+        HttpClient httpClient = mockHttp.ToHttpClient();
+        var client = new PayoutClient("abcde", httpClient);
+
+        // When
+        PayoutResponse response = await client.CancelPayoutAsync(payoutId, testmode: true);
+
+        // Then
+        mockHttp.VerifyNoOutstandingExpectation();
+        response.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task CancelPayoutAsync_WithEmptyPayoutId_ThrowsException() {
+        // Given
+        var client = new PayoutClient("abcde", new HttpClient());
+
+        // When / Then
+        var exception = await Should.ThrowAsync<ArgumentException>(async () => {
+            await client.CancelPayoutAsync("");
+        });
+        exception.Message.ShouldContain("payoutId");
+    }
+
+    private string CreateCanceledPayoutJsonResponse(string payoutId, string balanceId) {
+        return $@"{{
+  ""resource"": ""payout"",
+  ""id"": ""{payoutId}"",
+  ""balanceId"": ""{balanceId}"",
+  ""amount"": {{""currency"": ""EUR"", ""value"": ""10.00""}},
+  ""description"": ""My payout description"",
+  ""status"": ""canceled"",
+  ""statusReason"": {{
+    ""code"": ""canceled"",
+    ""message"": ""The payout has been canceled.""
+  }},
+  ""createdAt"": ""2024-03-20T09:13:37+00:00"",
+  ""initiatedAt"": null,
+  ""completedAt"": null,
+  ""canceledAt"": ""2024-03-20T09:15:00+00:00"",
+  ""mode"": ""live"",
+  ""_links"": {{
+    ""self"": {{
+      ""href"": ""https://api.mollie.com/v2/payouts/{payoutId}"",
+      ""type"": ""application/hal+json""
+    }},
+    ""documentation"": {{
+      ""href"": ""https://docs.mollie.com/reference/get-payout"",
+      ""type"": ""text/html""
+    }}
+  }}
+}}";
+    }
+
     private string CreatePayoutListJsonResponse() {
         return $@"{{
   ""count"": 1,

--- a/tests/Mollie.Tests.Unit/Client/PayoutClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/PayoutClientTests.cs
@@ -8,6 +8,7 @@ using Mollie.Api.Models.Payout.Response;
 using RichardSzalay.MockHttp;
 using Shouldly;
 using Xunit;
+using SortDirection = Mollie.Api.Models.SortDirection;
 
 namespace Mollie.Tests.Unit.Client;
 
@@ -81,6 +82,32 @@ public class PayoutClientTests : BaseClientTests {
         response.Description.ShouldBe("My payout description");
     }
 
+    [Theory]
+    [InlineData(null, null, null, false, null, "")]
+    [InlineData(null, "from", null, false, null, "?from=from")]
+    [InlineData(null, "from", 50, false, null, "?from=from&limit=50")]
+    [InlineData(null, null, null, true, null, "?testmode=true")]
+    [InlineData(null, null, null, true, SortDirection.Desc, "?testmode=true&sort=desc")]
+    [InlineData(null, null, null, true, SortDirection.Asc, "?testmode=true&sort=asc")]
+    [InlineData("bal_gVMhHKqSSRYJyPsuoPNFH", null, null, false, null, "?balanceId=bal_gVMhHKqSSRYJyPsuoPNFH")]
+    [InlineData("bal_gVMhHKqSSRYJyPsuoPNFH", null, null, true, SortDirection.Desc, "?testmode=true&sort=desc&balanceId=bal_gVMhHKqSSRYJyPsuoPNFH")]
+    public async Task GetPayoutListAsync_QueryStringParameters_AreFormattedCorrectly(
+        string? balanceId, string? from, int? limit, bool testmode, SortDirection? sort, string expectedQueryString) {
+        // Given
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When($"{BaseMollieClient.DefaultBaseApiEndPoint}payouts{expectedQueryString}")
+            .Respond("application/json", CreatePayoutListJsonResponse());
+        HttpClient httpClient = mockHttp.ToHttpClient();
+        var client = new PayoutClient("abcde", httpClient);
+
+        // When
+        var result = await client.GetPayoutListAsync(balanceId, from, limit, sort, testmode);
+
+        // Then
+        mockHttp.VerifyNoOutstandingExpectation();
+        result.ShouldNotBeNull();
+    }
+
     [Fact]
     public async Task CreatePayoutAsync_WithTestmode_SendsTestmodeInRequest() {
         // Given
@@ -105,6 +132,27 @@ public class PayoutClientTests : BaseClientTests {
         // Then
         mockHttp.VerifyNoOutstandingExpectation();
         response.ShouldNotBeNull();
+    }
+
+    private string CreatePayoutListJsonResponse() {
+        return $@"{{
+  ""count"": 1,
+  ""_embedded"": {{
+    ""payouts"": [
+      {CreatePayoutJsonResponse("payout_j8NvRAM2WNZtsykpLEX8J", "bal_gVMhHKqSSRYJyPsuoPNFH", null)}
+    ]
+  }},
+  ""_links"": {{
+    ""self"": {{
+      ""href"": ""https://api.mollie.com/v2/payouts"",
+      ""type"": ""application/hal+json""
+    }},
+    ""documentation"": {{
+      ""href"": ""https://docs.mollie.com/reference/list-payouts"",
+      ""type"": ""text/html""
+    }}
+  }}
+}}";
     }
 
     private string CreatePayoutJsonResponse(

--- a/tests/Mollie.Tests.Unit/Client/PayoutClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/PayoutClientTests.cs
@@ -134,6 +134,64 @@ public class PayoutClientTests : BaseClientTests {
         response.ShouldNotBeNull();
     }
 
+    [Fact]
+    public async Task GetPayoutAsync_WithValidPayoutId_ResponseIsDeserializedInExpectedFormat() {
+        // Given
+        const string payoutId = "payout_j8NvRAM2WNZtsykpLEX8J";
+        const string balanceId = "bal_gVMhHKqSSRYJyPsuoPNFH";
+        string jsonToReturnInMockResponse = CreatePayoutJsonResponse(payoutId, balanceId, null);
+        var mockHttp = CreateMockHttpMessageHandler(
+            HttpMethod.Get,
+            $"{BaseMollieClient.DefaultBaseApiEndPoint}payouts/{payoutId}",
+            jsonToReturnInMockResponse);
+        HttpClient httpClient = mockHttp.ToHttpClient();
+        var client = new PayoutClient("abcde", httpClient);
+
+        // When
+        PayoutResponse response = await client.GetPayoutAsync(payoutId);
+
+        // Then
+        mockHttp.VerifyNoOutstandingExpectation();
+        response.ShouldNotBeNull();
+        response.Id.ShouldBe(payoutId);
+        response.BalanceId.ShouldBe(balanceId);
+        response.Status.ShouldBe(PayoutStatus.Requested);
+    }
+
+    [Fact]
+    public async Task GetPayoutAsync_WithTestmodeTrue_QueryStringContainsTestmodeParameter() {
+        // Given
+        const string payoutId = "payout_j8NvRAM2WNZtsykpLEX8J";
+        const string balanceId = "bal_gVMhHKqSSRYJyPsuoPNFH";
+        string jsonToReturnInMockResponse = CreatePayoutJsonResponse(payoutId, balanceId, null);
+        var mockHttp = CreateMockHttpMessageHandler(
+            HttpMethod.Get,
+            $"{BaseMollieClient.DefaultBaseApiEndPoint}payouts/{payoutId}?testmode=true",
+            jsonToReturnInMockResponse);
+        HttpClient httpClient = mockHttp.ToHttpClient();
+        var client = new PayoutClient("abcde", httpClient);
+
+        // When
+        PayoutResponse response = await client.GetPayoutAsync(payoutId, testmode: true);
+
+        // Then
+        mockHttp.VerifyNoOutstandingExpectation();
+        response.ShouldNotBeNull();
+        response.Id.ShouldBe(payoutId);
+    }
+
+    [Fact]
+    public async Task GetPayoutAsync_WithEmptyPayoutId_ThrowsException() {
+        // Given
+        var client = new PayoutClient("abcde", new HttpClient());
+
+        // When / Then
+        var exception = await Should.ThrowAsync<ArgumentException>(async () => {
+            await client.GetPayoutAsync("");
+        });
+        exception.Message.ShouldContain("payoutId");
+    }
+
     private string CreatePayoutListJsonResponse() {
         return $@"{{
   ""count"": 1,

--- a/tests/Mollie.Tests.Unit/Client/PayoutClientTests.cs
+++ b/tests/Mollie.Tests.Unit/Client/PayoutClientTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Mollie.Api.Client;
+using Mollie.Api.Models;
+using Mollie.Api.Models.Payout.Request;
+using Mollie.Api.Models.Payout.Response;
+using RichardSzalay.MockHttp;
+using Shouldly;
+using Xunit;
+
+namespace Mollie.Tests.Unit.Client;
+
+public class PayoutClientTests : BaseClientTests {
+    [Fact]
+    public async Task CreatePayoutAsync_WithRequiredParameters_ResponseIsDeserializedInExpectedFormat() {
+        // Given: we create a payout request with required parameters
+        const string payoutId = "payout_j8NvRAM2WNZtsykpLEX8J";
+        const string balanceId = "bal_gVMhHKqSSRYJyPsuoPNFH";
+        PayoutRequest request = new() {
+            BalanceId = balanceId
+        };
+        string jsonToReturnInMockResponse = CreatePayoutJsonResponse(payoutId, balanceId, null);
+        var mockHttp = CreateMockHttpMessageHandler(
+            HttpMethod.Post,
+            $"{BaseMollieClient.DefaultBaseApiEndPoint}payouts",
+            jsonToReturnInMockResponse);
+        HttpClient httpClient = mockHttp.ToHttpClient();
+        var client = new PayoutClient("abcde", httpClient);
+
+        // When: We send the request
+        PayoutResponse response = await client.CreatePayoutAsync(request);
+
+        // Then
+        mockHttp.VerifyNoOutstandingExpectation();
+        response.ShouldNotBeNull();
+        response.Resource.ShouldBe("payout");
+        response.Id.ShouldBe(payoutId);
+        response.BalanceId.ShouldBe(balanceId);
+        response.Status.ShouldBe(PayoutStatus.Requested);
+        response.StatusReason.Code.ShouldBe("requested");
+        response.StatusReason.Message.ShouldBe("The payout has been requested.");
+        response.CreatedAt.ToUniversalTime().ShouldBe(new DateTime(2024, 3, 20, 9, 13, 37, DateTimeKind.Utc));
+        response.InitiatedAt.ShouldBeNull();
+        response.CompletedAt.ShouldBeNull();
+        response.CanceledAt.ShouldBeNull();
+        response.Mode.ShouldBe(Mode.Live);
+        response.Links.ShouldNotBeNull();
+        response.Links.Self.Href.ShouldBe($"https://api.mollie.com/v2/payouts/{payoutId}");
+        response.Links.Documentation.Href.ShouldBe("https://docs.mollie.com/reference/get-payout");
+    }
+
+    [Fact]
+    public async Task CreatePayoutAsync_WithAmountAndDescription_ResponseIsDeserializedInExpectedFormat() {
+        // Given: we create a payout request with amount and description
+        const string payoutId = "payout_j8NvRAM2WNZtsykpLEX8J";
+        const string balanceId = "bal_gVMhHKqSSRYJyPsuoPNFH";
+        var amount = new Amount(Currency.EUR, "10.00");
+        PayoutRequest request = new() {
+            BalanceId = balanceId,
+            Amount = amount,
+            Description = "My payout description"
+        };
+        string jsonToReturnInMockResponse = CreatePayoutJsonResponse(payoutId, balanceId, amount, request.Description);
+        var mockHttp = CreateMockHttpMessageHandler(
+            HttpMethod.Post,
+            $"{BaseMollieClient.DefaultBaseApiEndPoint}payouts",
+            jsonToReturnInMockResponse);
+        HttpClient httpClient = mockHttp.ToHttpClient();
+        var client = new PayoutClient("abcde", httpClient);
+
+        // When: We send the request
+        PayoutResponse response = await client.CreatePayoutAsync(request);
+
+        // Then
+        mockHttp.VerifyNoOutstandingExpectation();
+        response.ShouldNotBeNull();
+        response.Amount.ShouldNotBeNull();
+        response.Amount!.Currency.ShouldBe("EUR");
+        response.Amount.Value.ShouldBe("10.00");
+        response.Description.ShouldBe("My payout description");
+    }
+
+    [Fact]
+    public async Task CreatePayoutAsync_WithTestmode_SendsTestmodeInRequest() {
+        // Given
+        const string payoutId = "payout_j8NvRAM2WNZtsykpLEX8J";
+        const string balanceId = "bal_gVMhHKqSSRYJyPsuoPNFH";
+        PayoutRequest request = new() {
+            BalanceId = balanceId,
+            Testmode = true
+        };
+        string jsonToReturnInMockResponse = CreatePayoutJsonResponse(payoutId, balanceId, null);
+        var mockHttp = CreateMockHttpMessageHandler(
+            HttpMethod.Post,
+            $"{BaseMollieClient.DefaultBaseApiEndPoint}payouts",
+            jsonToReturnInMockResponse,
+            expectedPartialContent: "\"testmode\":true");
+        HttpClient httpClient = mockHttp.ToHttpClient();
+        var client = new PayoutClient("abcde", httpClient);
+
+        // When
+        PayoutResponse response = await client.CreatePayoutAsync(request);
+
+        // Then
+        mockHttp.VerifyNoOutstandingExpectation();
+        response.ShouldNotBeNull();
+    }
+
+    private string CreatePayoutJsonResponse(
+        string payoutId,
+        string balanceId,
+        Amount? amount,
+        string? description = null) {
+        string amountJson = amount != null
+            ? $@"{{""currency"": ""{amount.Currency}"", ""value"": ""{amount.Value}""}}"
+            : @"{""currency"": ""EUR"", ""value"": ""10.00""}";
+        string descriptionJson = description != null ? $@"""{description}""" : @"""My payout description""";
+
+        return $@"{{
+  ""resource"": ""payout"",
+  ""id"": ""{payoutId}"",
+  ""balanceId"": ""{balanceId}"",
+  ""amount"": {amountJson},
+  ""description"": {descriptionJson},
+  ""status"": ""requested"",
+  ""statusReason"": {{
+    ""code"": ""requested"",
+    ""message"": ""The payout has been requested.""
+  }},
+  ""createdAt"": ""2024-03-20T09:13:37+00:00"",
+  ""initiatedAt"": null,
+  ""completedAt"": null,
+  ""canceledAt"": null,
+  ""mode"": ""live"",
+  ""_links"": {{
+    ""self"": {{
+      ""href"": ""https://api.mollie.com/v2/payouts/{payoutId}"",
+      ""type"": ""application/hal+json""
+    }},
+    ""documentation"": {{
+      ""href"": ""https://docs.mollie.com/reference/get-payout"",
+      ""type"": ""text/html""
+    }}
+  }}
+}}";
+    }
+}
+


### PR DESCRIPTION
Docs: https://docs.mollie.com/reference/payouts-api

With the Payouts API you can initiate payouts from your Mollie balance to your organization’s bank account. You can find all details about underlying transactions through the [Settlements API](https://docs.mollie.com/reference/settlements-api).

You can request a payout for all funds in your balance or for a custom amount. For custom amount payouts we don’t create a Settlement, which means there is no settlement report. Instead, a custom amount payout is included as a transaction in the report created the next time your full balance amount is paid out. Alternatively, you can also retrieve these payouts via the List payouts endpoint.